### PR TITLE
Add a check to prevent a Pokémon in the group from having a maximum level lower than the minimum level

### DIFF
--- a/assets/i18n/en/pokemon_battler_list.json
+++ b/assets/i18n/en/pokemon_battler_list.json
@@ -36,5 +36,6 @@
   "ivs_title": "Individual Values",
   "evs_title": "Effort Values",
   "pokemon_first_position": "Pokémon in first position",
-  "none": "None"
+  "none": "None",
+  "min_max_level_error": "The maximum level must be higher than the minimum level."
 }

--- a/assets/i18n/fr/pokemon_battler_list.json
+++ b/assets/i18n/fr/pokemon_battler_list.json
@@ -36,5 +36,6 @@
   "ivs_title": "Potentiel (IV)",
   "evs_title": "Points d’efforts (EV)",
   "pokemon_first_position": "Pokémon en première position",
-  "none": "Aucune"
+  "none": "Aucune",
+  "min_max_level_error": "Le niveau maximum doit être supérieur au niveau minimum."
 }

--- a/src/views/components/pokemonBattler/editors/InputNumber.tsx
+++ b/src/views/components/pokemonBattler/editors/InputNumber.tsx
@@ -8,9 +8,10 @@ type InputNumberProps = {
   min: string | number;
   max: string | number;
   onChange: (value: number) => void;
+  error?: boolean;
 };
 
-export const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(({ name, defaultValue, min, max, onChange }, ref) => {
+export const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(({ name, defaultValue, min, max, onChange, error }, ref) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const saveDefaultValue = useMemo(() => (isNaN(defaultValue) ? '' : defaultValue), []);
   return (
@@ -21,6 +22,7 @@ export const InputNumber = forwardRef<HTMLInputElement, InputNumberProps>(({ nam
       max={max}
       defaultValue={saveDefaultValue}
       onChange={(event) => onChange(event.target.valueAsNumber)}
+      error={error}
       ref={ref}
     />
   );

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerEditor.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import type { CurrentBattlerType, PokemonBattlerFrom } from './PokemonBattlerEditorOverlay';
 import { useTranslation } from 'react-i18next';
@@ -56,10 +56,6 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
       formAvailable,
       state,
     } = usePokemonBattler({ action, currentBattler, from });
-    const levelFixedRef = useRef<HTMLInputElement>(null);
-    const levelMinRef = useRef<HTMLInputElement>(null);
-    const levelMaxRef = useRef<HTMLInputElement>(null);
-    const encounterChanceRef = useRef<HTMLInputElement>(null);
     const [minMaxLevelError, setMinMaxLevelError] = useState<boolean>(false);
 
     const handleNew = () => {
@@ -127,7 +123,6 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
                       max={state.projectConfig.settings_config.pokemonMaxLevel}
                       defaultValue={encounter.levelSetup.level}
                       onChange={(value) => updateEncounter({ levelSetup: { kind: 'fixed', level: value } })}
-                      ref={levelFixedRef}
                     />
                   </InputWithLeftLabelContainer>
                 )}
@@ -152,7 +147,6 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
                             setMinMaxLevelError(value > level.maximumLevel);
                           }}
                           error={minMaxLevelError}
-                          ref={levelMinRef}
                         />
                         <span className="separator">{t('pokemon_battler_list:level_separator')}</span>
                         <InputNumber
@@ -170,7 +164,6 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
                             });
                             setMinMaxLevelError(value < level.minimumLevel);
                           }}
-                          ref={levelMaxRef}
                           error={minMaxLevelError}
                         />
                       </InputWithSeparatorContainer>
@@ -188,7 +181,6 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
                       unit="%"
                       defaultValue={encounter.randomEncounterChance}
                       onChange={(value) => updateEncounter({ randomEncounterChance: value })}
-                      ref={encounterChanceRef}
                     />
                   </InputWithLeftLabelContainer>
                 )}

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerEditor.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useRef, useState } from 'react';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import type { CurrentBattlerType, PokemonBattlerFrom } from './PokemonBattlerEditorOverlay';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +23,7 @@ import { SelectAbility } from '@components/selects';
 import { SelectNature } from '@components/selects/SelectNature';
 import { PokemonBattlerMoreInfoEditor, PokemonBattlerMoveEditor, PokemonBattlerStatsEditor } from '.';
 import { EmbeddedUnitInputNumber, InputNumber } from './InputNumber';
+import { TextInputError } from '@components/inputs/Input';
 
 const ButtonContainer = styled.div`
   display: flex;
@@ -59,6 +60,7 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
     const levelMinRef = useRef<HTMLInputElement>(null);
     const levelMaxRef = useRef<HTMLInputElement>(null);
     const encounterChanceRef = useRef<HTMLInputElement>(null);
+    const [minMaxLevelError, setMinMaxLevelError] = useState<boolean>(false);
 
     const handleNew = () => {
       if (!canNew) return;
@@ -130,44 +132,51 @@ export const PokemonBattlerEditor = forwardRef<EditorHandlingClose, PokemonBattl
                   </InputWithLeftLabelContainer>
                 )}
                 {from === 'group' && encounter.levelSetup.kind === 'minmax' && (
-                  <InputWithLeftLabelContainer>
-                    <Label htmlFor="minmax-level">{t('pokemon_battler_list:level')}</Label>
-                    <InputWithSeparatorContainer>
-                      <InputNumber
-                        name="min-level"
-                        min="1"
-                        max={state.projectConfig.settings_config.pokemonMaxLevel}
-                        defaultValue={encounter.levelSetup.level.minimumLevel}
-                        onChange={(value) => {
-                          const level = encounter.levelSetup.level as StudioEncounterLevelMinMax;
-                          updateEncounter({
-                            levelSetup: {
-                              kind: 'minmax',
-                              level: { ...level, minimumLevel: value },
-                            },
-                          });
-                        }}
-                        ref={levelMinRef}
-                      />
-                      <span className="separator">{t('pokemon_battler_list:level_separator')}</span>
-                      <InputNumber
-                        name="max-level"
-                        min="1"
-                        max={state.projectConfig.settings_config.pokemonMaxLevel}
-                        defaultValue={encounter.levelSetup.level.maximumLevel}
-                        onChange={(value) => {
-                          const level = encounter.levelSetup.level as StudioEncounterLevelMinMax;
-                          updateEncounter({
-                            levelSetup: {
-                              kind: 'minmax',
-                              level: { ...level, maximumLevel: value },
-                            },
-                          });
-                        }}
-                        ref={levelMaxRef}
-                      />
-                    </InputWithSeparatorContainer>
-                  </InputWithLeftLabelContainer>
+                  <InputWithTopLabelContainer>
+                    <InputWithLeftLabelContainer>
+                      <Label htmlFor="minmax-level">{t('pokemon_battler_list:level')}</Label>
+                      <InputWithSeparatorContainer>
+                        <InputNumber
+                          name="min-level"
+                          min="1"
+                          max={state.projectConfig.settings_config.pokemonMaxLevel}
+                          defaultValue={encounter.levelSetup.level.minimumLevel}
+                          onChange={(value) => {
+                            const level = encounter.levelSetup.level as StudioEncounterLevelMinMax;
+                            updateEncounter({
+                              levelSetup: {
+                                kind: 'minmax',
+                                level: { ...level, minimumLevel: value },
+                              },
+                            });
+                            setMinMaxLevelError(value > level.maximumLevel);
+                          }}
+                          error={minMaxLevelError}
+                          ref={levelMinRef}
+                        />
+                        <span className="separator">{t('pokemon_battler_list:level_separator')}</span>
+                        <InputNumber
+                          name="max-level"
+                          min="1"
+                          max={state.projectConfig.settings_config.pokemonMaxLevel}
+                          defaultValue={encounter.levelSetup.level.maximumLevel}
+                          onChange={(value) => {
+                            const level = encounter.levelSetup.level as StudioEncounterLevelMinMax;
+                            updateEncounter({
+                              levelSetup: {
+                                kind: 'minmax',
+                                level: { ...level, maximumLevel: value },
+                              },
+                            });
+                            setMinMaxLevelError(value < level.minimumLevel);
+                          }}
+                          ref={levelMaxRef}
+                          error={minMaxLevelError}
+                        />
+                      </InputWithSeparatorContainer>
+                    </InputWithLeftLabelContainer>
+                    {minMaxLevelError && <TextInputError>{t('pokemon_battler_list:min_max_level_error')}</TextInputError>}
+                  </InputWithTopLabelContainer>
                 )}
                 {from === 'group' && (
                   <InputWithLeftLabelContainer>

--- a/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
+++ b/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
@@ -223,7 +223,13 @@ export const usePokemonBattler = ({ action, currentBattler, from }: Props) => {
       const minLevel = levelSetup.level.minimumLevel;
       const maxLevel = levelSetup.level.maximumLevel;
       const pokemonMaxLevel = state.projectConfig.settings_config.pokemonMaxLevel;
-      if (isNaN(minLevel) || isNaN(maxLevel) || notBetween(minLevel, 1, pokemonMaxLevel) || notBetween(maxLevel, 1, pokemonMaxLevel)) {
+      if (
+        isNaN(minLevel) ||
+        isNaN(maxLevel) ||
+        notBetween(minLevel, 1, pokemonMaxLevel) ||
+        notBetween(maxLevel, 1, pokemonMaxLevel) ||
+        maxLevel < minLevel
+      ) {
         return false;
       }
     }
@@ -264,7 +270,7 @@ export const usePokemonBattler = ({ action, currentBattler, from }: Props) => {
       const pokemonMaxLevel = state.projectConfig.settings_config.pokemonMaxLevel;
       const minLevel = levelSetup.level.minimumLevel;
       const maxLevel = levelSetup.level.maximumLevel;
-      if (notBetween(minLevel, 1, pokemonMaxLevel) || notBetween(maxLevel, 1, pokemonMaxLevel)) return false;
+      if (notBetween(minLevel, 1, pokemonMaxLevel) || notBetween(maxLevel, 1, pokemonMaxLevel) || maxLevel < minLevel) return false;
     }
 
     const shinySetup = encounter.shinySetup;


### PR DESCRIPTION
### MR description

This MR add a check in the usePokemonBattler hook to prevent the creation or edition if the maximum level is lower than the minimum level.

A feedback has been added for the user in the PokemonBattlerEditor component:

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/578fd7be-bf8f-4589-a83b-0963c76a42e2)

### Test to realize

- [ ] The user can not create or edit a Pokémon in the group if the maximum level is lower than the minimum level.
