### PR TITLE
The user is able to test its PSDK game by using a shortcut instead of clicking the Play button

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -75,7 +75,14 @@ export default class MenuBuilder {
             label: 'Save',
             accelerator: 'CmdOrCtrl+S',
             click: () => {
-              this.mainWindow.webContents.send('request-shortcut', 'db_save');
+              this.mainWindow.webContents.send('request-shortcut', 'save');
+            },
+          },
+          {
+            label: 'Play',
+            accelerator: 'CmdOrCtrl+P',
+            click: () => {
+              this.mainWindow.webContents.send('request-shortcut', 'play');
             },
           },
           { type: 'separator' },

--- a/src/utils/useShortcuts.tsx
+++ b/src/utils/useShortcuts.tsx
@@ -4,7 +4,8 @@ const STUDIO_SHORTCUTS = {
   db_previous: ['ArrowLeft', 'Left'],
   db_next: ['ArrowRight', 'Right'],
   db_new: ['KeyN'],
-  db_save: ['KeyS'],
+  save: ['KeyS'],
+  play: ['KeyP'],
 } as const;
 
 export type StudioShortcut = keyof typeof STUDIO_SHORTCUTS;

--- a/src/views/components/buttons/PlayButton.tsx
+++ b/src/views/components/buttons/PlayButton.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { StyledNavLinkActionItem } from '@components/navigation/NavigationBarItem/StyledNavLink';
 import { NavigationBarItemContainer } from '@components/navigation/NavigationBarItem/NavigationBarItemContainer';
 import { ReactComponent as PlayIcon } from '@assets/icons/global/play.svg';
 import { useGlobalState } from '@src/GlobalStateProvider';
 import { useTranslation } from 'react-i18next';
+import { StudioShortcutActions, useShortcut } from '@utils/useShortcuts';
 
 const PlayMenuButtonContainer = styled.div`
   position: fixed;
@@ -94,6 +95,16 @@ export const PlayButton = () => {
     startPSDK(state.projectPath || '');
     setIsOpen(false);
   };
+
+  const shortcutMap = useMemo<StudioShortcutActions>(() => {
+    // No shortcut if an editor is opened
+    const isShortcutEnabled = () => !document.querySelector('#dialogs')?.textContent;
+    return {
+      play: () => isShortcutEnabled() && startPSDKAndCloseMenu(window.api.startPSDKDebug),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useShortcut(shortcutMap);
 
   return (
     <PlayButtonContainer className={isOpen ? 'open' : undefined} data-disabled={(!isEnabled()).toString()} onMouseLeave={() => setIsOpen(false)}>

--- a/src/views/components/buttons/SaveProjectButton.tsx
+++ b/src/views/components/buttons/SaveProjectButton.tsx
@@ -59,7 +59,7 @@ export const SaveProjectButton = () => {
     // No shortcut if an editor is opened and no data to save
     const isShortcutEnabled = () => !document.querySelector('#dialogs')?.textContent && isDataToSave;
     return {
-      db_save: () =>
+      save: () =>
         isShortcutEnabled() &&
         save(
           () => loaderRef.current.close(),


### PR DESCRIPTION
### MR Description

This MR adds a shortcut allowing users to launch Pokémon SDK by pressing CTRL+P. The shortcut is disabled if an editor is opened.