### PR TITLE
Fix a reset when we set a map link and back to the first map

### DIFF
--- a/src/utils/ModelUtils.ts
+++ b/src/utils/ModelUtils.ts
@@ -42,3 +42,13 @@ export const findFirstAvailableId = (allData: Record<string, { id: number }>, st
 
   return idSet[holeIndex - 1] + 1;
 };
+
+export const findFirstAndSecondAvailableId = (allData: Record<string, { id: number }>, startId: number) => {
+  const firstId = findFirstAvailableId(allData, startId);
+  const newAllData = {
+    ...allData,
+    [`data_${firstId}`]: { id: firstId },
+  };
+  const secondId = findFirstAvailableId(newAllData, startId);
+  return { firstId, secondId };
+};


### PR DESCRIPTION
### Description

This PR fixes an issue in the maplink. When we set a map link and back to the first map, the link has disappeared.

When we create the first link for a maplink, we create a maplink associated with the map.
When a link is created, the reverse link is also created. If the maplink for the reverse link does not exist, it is also created.
The bug was here. We checked which was the first id available to create the maplink, but if we needed to create two, the second with the same id as the first. So we lost the first maplink (and the first link).

So I made sure we knew the first two available ids to fix the issue.

### Video

https://www.youtube.com/watch?v=FI4rWZtvfFM&t=511s