### PR TITLE
Allow Studio to inform PSDK which maps it needs to convert back to RMXP format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-virtualized": "^9.22.5",
         "styled-components": "^5.3.6",
         "ts-marshal": "^0.0.7",
-        "ts-tiled-converter": "^0.0.7",
+        "ts-tiled-converter": "^0.0.8",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -14369,9 +14369,9 @@
       }
     },
     "node_modules/ts-tiled-converter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.7.tgz",
-      "integrity": "sha512-AxxwVXUZEYnWmasn7LoxH0Q0vB7lnsOlV+7Y4KKOUIOMrff3t4NJF7lwZMw1iN3leqCTOZGg19R8n+K5JL4U4g==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.8.tgz",
+      "integrity": "sha512-Ex0pV8kka7LrijYprfKApD5XVKwQ82jP0Jay9R+/Cc6VTDQiMkoj5fPwtxhKxkl3MWJORNriqdmKULZGaIiueA==",
       "dependencies": {
         "fast-xml-parser": "^4.2.4",
         "lodash.groupby": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-virtualized": "^9.22.5",
         "styled-components": "^5.3.6",
         "ts-marshal": "^0.0.7",
-        "ts-tiled-converter": "^0.0.5",
+        "ts-tiled-converter": "^0.0.6",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -14369,9 +14369,9 @@
       }
     },
     "node_modules/ts-tiled-converter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.5.tgz",
-      "integrity": "sha512-7Jtlgp4ixBcT3TXUg/mFbwUDCJ+srNIrleb1epIc7om3elyiJI30lw0tTsw/cwGaNUxPzotnTcQteOHxxzeC7g==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.6.tgz",
+      "integrity": "sha512-GVwUUJ8B9rjCYr5Pkn2BqAEBsCeThS6zYv7BXBiPlecQFbTtggcSE6Ijs+Ur8rKe8G5MOsIvJcHqqWUK6EIoHw==",
       "dependencies": {
         "fast-xml-parser": "^4.2.4",
         "lodash.groupby": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-virtualized": "^9.22.5",
         "styled-components": "^5.3.6",
         "ts-marshal": "^0.0.7",
-        "ts-tiled-converter": "^0.0.8",
+        "ts-tiled-converter": "^0.0.9",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -14369,9 +14369,9 @@
       }
     },
     "node_modules/ts-tiled-converter": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.8.tgz",
-      "integrity": "sha512-Ex0pV8kka7LrijYprfKApD5XVKwQ82jP0Jay9R+/Cc6VTDQiMkoj5fPwtxhKxkl3MWJORNriqdmKULZGaIiueA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.9.tgz",
+      "integrity": "sha512-tPvE9/elACQE+vlZ12W7dTNa9xjgtAHCzd1UwNFdFM0QRUzVniqyOn8QKEbFawiCsxyL3aCXBibkxEYa1muZsQ==",
       "dependencies": {
         "fast-xml-parser": "^4.2.4",
         "lodash.groupby": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-virtualized": "^9.22.5",
         "styled-components": "^5.3.6",
         "ts-marshal": "^0.0.7",
-        "ts-tiled-converter": "^0.0.6",
+        "ts-tiled-converter": "^0.0.7",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -14369,9 +14369,9 @@
       }
     },
     "node_modules/ts-tiled-converter": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.6.tgz",
-      "integrity": "sha512-GVwUUJ8B9rjCYr5Pkn2BqAEBsCeThS6zYv7BXBiPlecQFbTtggcSE6Ijs+Ur8rKe8G5MOsIvJcHqqWUK6EIoHw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ts-tiled-converter/-/ts-tiled-converter-0.0.7.tgz",
+      "integrity": "sha512-AxxwVXUZEYnWmasn7LoxH0Q0vB7lnsOlV+7Y4KKOUIOMrff3t4NJF7lwZMw1iN3leqCTOZGg19R8n+K5JL4U4g==",
       "dependencies": {
         "fast-xml-parser": "^4.2.4",
         "lodash.groupby": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-virtualized": "^9.22.5",
     "styled-components": "^5.3.6",
     "ts-marshal": "^0.0.7",
-    "ts-tiled-converter": "^0.0.6",
+    "ts-tiled-converter": "^0.0.7",
     "zod": "^3.22.4"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-virtualized": "^9.22.5",
     "styled-components": "^5.3.6",
     "ts-marshal": "^0.0.7",
-    "ts-tiled-converter": "^0.0.8",
+    "ts-tiled-converter": "^0.0.9",
     "zod": "^3.22.4"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-virtualized": "^9.22.5",
     "styled-components": "^5.3.6",
     "ts-marshal": "^0.0.7",
-    "ts-tiled-converter": "^0.0.5",
+    "ts-tiled-converter": "^0.0.6",
     "zod": "^3.22.4"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-virtualized": "^9.22.5",
     "styled-components": "^5.3.6",
     "ts-marshal": "^0.0.7",
-    "ts-tiled-converter": "^0.0.7",
+    "ts-tiled-converter": "^0.0.8",
     "zod": "^3.22.4"
   },
   "build": {

--- a/src/backendTasks/readProjectData.ts
+++ b/src/backendTasks/readProjectData.ts
@@ -8,6 +8,7 @@ import { StudioTextInfo } from '@modelEntities/textInfo';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 import { ChannelNames, sendProgress } from '@utils/BackendTask';
 import { StudioMapInfo } from '@modelEntities/mapInfo';
+import { setLoadedMaps } from './studioMapToRMXPConversionFacilitator';
 
 const projectDataKeys = [
   'abilities',
@@ -76,6 +77,8 @@ const readProjectData = async (payload: ReadProjectDataInput, event: IpcMainEven
     return { ...prevData, [curr]: data };
   }, Promise.resolve({ textInfos, mapInfo } as ProjectDataFromBackEnd));
 
+  // Store the loaded maps so the converter will know which maps changed
+  setLoadedMaps(projectData.maps);
   log.info('read-project-data/success');
   return projectData;
 };

--- a/src/backendTasks/saveProjectData.ts
+++ b/src/backendTasks/saveProjectData.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { SavingData } from '@utils/SavingUtils';
 import path from 'path';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import { processSavedMaps } from './studioMapToRMXPConversionFacilitator';
 
 export type SaveProjectDataInput = { path: string; data: SavingData };
 
@@ -13,6 +14,12 @@ const saveProjectData = async (payload: SaveProjectDataInput) => {
   // Ensure PSDK will rebuild the data
   const psdkDatPath = path.join(projectDataPath, 'psdk.dat');
   if (fs.existsSync(psdkDatPath)) fs.unlinkSync(psdkDatPath);
+
+  // Process all the map that changed
+  await processSavedMaps(
+    projectDataPath,
+    payload.data.filter(({ savingPath, savingAction }) => savingPath.startsWith('maps/') && savingAction !== 'DELETE').map(({ data }) => data || '{}')
+  );
 
   return Promise.all(
     payload.data.map(async (sd) => {

--- a/src/backendTasks/saveProjectData.ts
+++ b/src/backendTasks/saveProjectData.ts
@@ -17,7 +17,7 @@ const saveProjectData = async (payload: SaveProjectDataInput) => {
 
   // Process all the map that changed
   await processSavedMaps(
-    projectDataPath,
+    projectDataPath.replaceAll('\\', '/'),
     payload.data.filter(({ savingPath, savingAction }) => savingPath.startsWith('maps/') && savingAction !== 'DELETE').map(({ data }) => data || '{}')
   );
 

--- a/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
+++ b/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
@@ -1,9 +1,11 @@
 import type { StudioMap } from '@modelEntities/map';
 import uniq from 'lodash.uniq';
 import { existsSync } from 'fs';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import { getTilesetImageAndAnimatedTiles } from 'ts-tiled-converter';
+import { BrowserWindow, dialog } from 'electron';
+import log from 'electron-log';
 
 let loadedMaps: string[] = [];
 const MAP_PATH = '../Tiled/Maps';
@@ -24,43 +26,77 @@ const extractTileMetadata = ({ tileMetadata, tiledFilename }: StudioMap) => ({
   tileMetadata: tileMetadata as PartialTiledMapMetadata,
 });
 
-const saveMapsToProcess = async (projectDataPath: string, maps: StudioMap[]) => {
-  const filename = path.join(projectDataPath, 'map_jobs.json');
+const createJobDirIfNotExist = async (tiledFolder: string) => {
+  const jobsDir = path.join(tiledFolder, '.jobs');
+  if (!existsSync(jobsDir)) {
+    await mkdir(jobsDir, { recursive: true });
+  }
+};
+
+const saveMapsToProcess = async (tiledFolder: string, maps: StudioMap[]) => {
+  const filename = path.join(tiledFolder, '.jobs/map_jobs.json');
   const previousMapToConvert = existsSync(filename) ? await readFile(filename) : Buffer.from('[]', 'utf8');
   const newData = uniq(maps.map(({ dbSymbol }) => dbSymbol).concat(JSON.parse(previousMapToConvert.toString('utf8'))));
   return writeFile(filename, JSON.stringify(newData));
 };
 
-export const processSavedMaps = async (projectDataPath: string, savedMaps: string[]) => {
-  if (savedMaps.length === 0) return;
-
-  const newSavedMaps = savedMaps.map((s) => JSON.parse(s) as StudioMap);
-  if (newSavedMaps.some(({ tileMetadata }) => !tileMetadata)) return;
-
-  await saveMapsToProcess(projectDataPath, newSavedMaps);
+const filterOutMaps = (newSavedMaps: StudioMap[]) => {
   const dbSymbolToFilterOut = newSavedMaps.map(({ dbSymbol }) => `dbSymbol: "${dbSymbol}"`);
-  const filteredMaps = loadedMaps.filter((map) => !dbSymbolToFilterOut.some((d) => map.includes(d)));
+  return loadedMaps.filter((map) => !dbSymbolToFilterOut.some((d) => map.includes(d)));
+};
+
+const getAllMapTilesets = (projectDataPath: string, filteredMaps: string[], newSavedMaps: StudioMap[]) => {
   const filteredMapData = filteredMaps.map((s) => JSON.parse(s) as StudioMap).filter(({ tileMetadata }) => !!tileMetadata);
-  const tilesets = uniq(
+  return uniq(
     newSavedMaps
       .concat(filteredMapData)
       .map(extractTileMetadata)
-      .flatMap((m) => m.tileMetadata.tilesets.map(({ source }) => path.join(projectDataPath, MAP_PATH, m.dirname, source)))
+      .flatMap((m) => m.tileMetadata.tilesets.map(({ source }) => path.join(projectDataPath, MAP_PATH, m.dirname, source).replaceAll('\\', '/')))
   );
+};
 
-  const tiledFolder = path.join(projectDataPath, '../Tiled');
-
-  const animatedTiles = tilesets.reduce((tilesByTileset, tilesetFilename) => {
+const buildAnimatedTilesRecord = (tiledFolder: string, tilesets: string[]) =>
+  tilesets.reduce((tilesByTileset, tilesetFilename) => {
     const name = tilesetFilename.replace(tiledFolder, '').slice(1);
     const tiles = getTilesetImageAndAnimatedTiles(tilesetFilename);
 
-    if (!(tiles instanceof Error)) {
-      tilesByTileset[name] = tiles;
+    if (!(tiles instanceof Error) && tiles.animatedTiles.length > 0) {
+      tilesByTileset[name] = {
+        animatedTiles: tiles.animatedTiles,
+        assetSourceInTileset: tiles.assetSource.inTileset,
+      };
     }
     return tilesByTileset;
   }, {} as Record<string, unknown>);
 
-  await writeFile(path.join(projectDataPath, 'animated_tiles.json'), JSON.stringify(animatedTiles));
+export const processSavedMaps = async (projectDataPath: string, savedMaps: string[]) => {
+  try {
+    if (savedMaps.length === 0) return;
 
-  setLoadedMaps(savedMaps.concat(filteredMaps));
+    const newSavedMaps = savedMaps.map((s) => JSON.parse(s) as StudioMap);
+    if (newSavedMaps.some(({ tileMetadata }) => !tileMetadata)) return;
+
+    const filteredMaps = filterOutMaps(newSavedMaps);
+    const tilesets = getAllMapTilesets(projectDataPath, filteredMaps, newSavedMaps);
+    const tiledFolder = path.join(projectDataPath, '../Tiled').replaceAll('\\', '/');
+    const animatedTiles = buildAnimatedTilesRecord(tiledFolder, tilesets);
+
+    await createJobDirIfNotExist(tiledFolder);
+    await saveMapsToProcess(tiledFolder, newSavedMaps);
+    await writeFile(path.join(tiledFolder, '.jobs/animated_tiles.json'), JSON.stringify(animatedTiles));
+
+    setLoadedMaps(savedMaps.concat(filteredMaps));
+  } catch (e) {
+    log.error('Error while saving StudioMap to RMXP conversion jobs', e);
+    const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+    // This message is not awaited because for some reasons its showing again and again when awaited (wtf?)
+    // In any case, under Microsoft Windows, the MessageBox is child of the main Window so until the user presses OK
+    // the main Window is not accepting any user input :)
+    dialog.showMessageBox(BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0], {
+      title: 'Map conversion job error',
+      message: `Failed to save StudioMap to RMXP conversion jobs: \n${errorMessage}`,
+      type: 'error',
+    });
+    // Note: For UX reason I decided not to block saving if the jobs cannot be saved because jobs can still be crafted easily, lost data is harder to craft.
+  }
 };

--- a/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
+++ b/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
@@ -1,0 +1,66 @@
+import type { StudioMap } from '@modelEntities/map';
+import uniq from 'lodash.uniq';
+import { existsSync } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { getTilesetImageAndAnimatedTiles } from 'ts-tiled-converter';
+
+let loadedMaps: string[] = [];
+const MAP_PATH = '../Tiled/Maps';
+
+export const setLoadedMaps = (maps: string[]) => {
+  loadedMaps = maps;
+};
+
+type PartialTiledMapMetadata = {
+  tilesets: {
+    firstGlobalId: number;
+    source: string;
+  }[];
+};
+
+const extractTileMetadata = ({ tileMetadata, tiledFilename }: StudioMap) => ({
+  dirname: path.dirname(tiledFilename),
+  tileMetadata: tileMetadata as PartialTiledMapMetadata,
+});
+
+const saveMapsToProcess = async (projectDataPath: string, maps: StudioMap[]) => {
+  const filename = path.join(projectDataPath, 'map_jobs.json');
+  const previousMapToConvert = existsSync(filename) ? await readFile(filename) : Buffer.from('[]', 'utf8');
+  const newData = uniq(maps.map(({ dbSymbol }) => dbSymbol).concat(JSON.parse(previousMapToConvert.toString('utf8'))));
+  return writeFile(filename, JSON.stringify(newData));
+};
+
+export const processSavedMaps = async (projectDataPath: string, savedMaps: string[]) => {
+  if (savedMaps.length === 0) return;
+
+  const newSavedMaps = savedMaps.map((s) => JSON.parse(s) as StudioMap);
+  if (newSavedMaps.some(({ tileMetadata }) => !tileMetadata)) return;
+
+  await saveMapsToProcess(projectDataPath, newSavedMaps);
+  const dbSymbolToFilterOut = newSavedMaps.map(({ dbSymbol }) => `dbSymbol: "${dbSymbol}"`);
+  const filteredMaps = loadedMaps.filter((map) => !dbSymbolToFilterOut.some((d) => map.includes(d)));
+  const filteredMapData = filteredMaps.map((s) => JSON.parse(s) as StudioMap).filter(({ tileMetadata }) => !!tileMetadata);
+  const tilesets = uniq(
+    newSavedMaps
+      .concat(filteredMapData)
+      .map(extractTileMetadata)
+      .flatMap((m) => m.tileMetadata.tilesets.map(({ source }) => path.join(projectDataPath, MAP_PATH, m.dirname, source)))
+  );
+
+  const tiledFolder = path.join(projectDataPath, '../Tiled');
+
+  const animatedTiles = tilesets.reduce((tilesByTileset, tilesetFilename) => {
+    const name = tilesetFilename.replace(tiledFolder, '').slice(1);
+    const tiles = getTilesetImageAndAnimatedTiles(tilesetFilename);
+
+    if (!(tiles instanceof Error)) {
+      tilesByTileset[name] = tiles;
+    }
+    return tilesByTileset;
+  }, {} as Record<string, unknown>);
+
+  await writeFile(path.join(projectDataPath, 'animated_tiles.json'), JSON.stringify(animatedTiles));
+
+  setLoadedMaps(savedMaps.concat(filteredMaps));
+};

--- a/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
+++ b/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
@@ -64,6 +64,7 @@ const buildAnimatedTilesRecord = (tiledFolder: string, tilesets: string[]) =>
       tilesByTileset[name] = {
         animatedTiles: tiles.animatedTiles,
         assetSourceInTileset: tiles.assetSource.inTileset,
+        transparency: tiles.assetSource.transparency || null,
       };
     }
     return tilesByTileset;

--- a/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
+++ b/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
@@ -60,7 +60,7 @@ const buildAnimatedTilesRecord = (tiledFolder: string, tilesets: string[]) =>
     const name = tilesetFilename.replace(tiledFolder, '').slice(1);
     const tiles = getTilesetImageAndAnimatedTiles(tilesetFilename);
 
-    if (!(tiles instanceof Error) && tiles.animatedTiles.length > 0) {
+    if (!(tiles instanceof Error)) {
       tilesByTileset[name] = {
         animatedTiles: tiles.animatedTiles,
         assetSourceInTileset: tiles.assetSource.inTileset,


### PR DESCRIPTION
Cette PR ajoute un code hooké à ProjectLoad et ProjectSave permettant à Studio d'indiquer quelles maps PSDK doit reconvertir en format RMXP.

## Test à réaliser

### Mode tiled
1. Modifier une map
2. Sauvegarder
3. Constater l'existence de `Data/Tiled/.jobs/animated_tiles.json` et `Data/Tiled/.jobs/map_jobs.json`
  - Si vous n'avez aucun tile animé dans vos tiles, `animated_tiles` doit contenir `{}`
  - Si vous avez des tiles animés dans vos tiles, `animated_tiles` doit contenir un Record de tileset ayant des tiles animés lié à son image et sa liste de tiles animés.
  - Si vous avez sauvegardé une map, `map_jobs` doit contenir les dernières map sauvegardées en premier dans la liste (dbSymbol des map pour être précis).
4. Modifiez une autre map
5. Sauvegardez
6. Constatez que l'autre map a été ajouté au début de la liste de `map_jobs`

### Mode RMXP
1. Modifiez une map
2. Sauvegardez
3. Constatez que rien de spécial ne s'est passé (aucune modification ou création de `Data/Tiled/.jobs` )