### PR TITLE
Fix step average so it's added as inactive by default

### DIFF
--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -17,6 +17,7 @@
   "environment": "Environment",
   "variation": "Variation",
   "steps_average": "Average number of steps",
+  "no_steps": "Defined by the map",
   "switch": "Switch",
   "example_name": "Pallet Town - Grass 1",
   "pokemon_group": "Pokémon of the group",

--- a/assets/i18n/fr/database_groups.json
+++ b/assets/i18n/fr/database_groups.json
@@ -18,6 +18,7 @@
   "environment": "Environnement",
   "variation": "Variation",
   "steps_average": "Pas moyens requis",
+  "no_steps": "Défini par la carte",
   "example_name": "Bourg Palette - Herbes 1",
   "pokemon_group": "Pokémon du groupe",
   "fields_asterisk_required": "Les champs avec un astérisque sont requis.",

--- a/src/migrations/addStepsAverageToGroup.ts
+++ b/src/migrations/addStepsAverageToGroup.ts
@@ -12,7 +12,7 @@ type StudioGroupDataBeforeMigration = z.infer<typeof PRE_MIGRATION_GROUP_VALIDAT
 const addStepsAverage = (group: StudioGroupDataBeforeMigration): StudioGroup => {
   return {
     ...group,
-    stepsAverage: 30,
+    stepsAverage: 0,
   };
 };
 

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -60,7 +60,7 @@ export const GROUP_VALIDATOR = z.object({
   isHordeBattle: z.boolean().default(false),
   customConditions: z.array(CUSTOM_GROUP_CONDITION_VALIDATOR),
   encounters: z.array(ENCOUNTER_VALIDATOR),
-  stepsAverage: POSITIVE_INT,
+  stepsAverage: POSITIVE_OR_ZERO_INT,
 });
 export type StudioGroup = z.infer<typeof GROUP_VALIDATOR>;
 

--- a/src/views/components/database/group/GroupFrame.tsx
+++ b/src/views/components/database/group/GroupFrame.tsx
@@ -67,7 +67,7 @@ export const GroupFrame = ({ group, dialogsRef }: GroupFrameProps) => {
             </DataFieldsetFieldWithChild>
             <DataFieldsetField
               label={t('steps_average')}
-              data={group.stepsAverage ? group.stepsAverage : '---'}
+              data={group.stepsAverage ? group.stepsAverage : t('no_steps')}
               disabled={group.stepsAverage === 0}
             />
           </GroupSubInfoContainer>

--- a/src/views/components/database/group/GroupFrame.tsx
+++ b/src/views/components/database/group/GroupFrame.tsx
@@ -65,7 +65,11 @@ export const GroupFrame = ({ group, dialogsRef }: GroupFrameProps) => {
                 <span>{`(${variationText ? t(variationText) : '???'})`}</span>
               </EnvironmentContainer>
             </DataFieldsetFieldWithChild>
-            <DataFieldsetField label={t('steps_average')} data={group.stepsAverage} />
+            <DataFieldsetField
+              label={t('steps_average')}
+              data={group.stepsAverage ? group.stepsAverage : '---'}
+              disabled={group.stepsAverage === 0}
+            />
           </GroupSubInfoContainer>
         </GroupInfoContainer>
       </DataGrid>

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -166,7 +166,7 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
         </InputWithTopLabelContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="steps-average">{t('steps_average')}</Label>
-          <Input name="steps-average" type="number" min={1} max={999} step={1} defaultValue={group.stepsAverage} ref={stepsAverageRef} />
+          <Input name="steps-average" type="number" min={0} max={999} step={1} defaultValue={group.stepsAverage} ref={stepsAverageRef} />
         </InputWithLeftLabelContainer>
       </InputContainer>
       <GroupTranslationOverlay group={group} onClose={onTranslationOverlayClose} ref={dialogsRef} />

--- a/src/views/components/database/group/editors/GroupNewEditor.tsx
+++ b/src/views/components/database/group/editors/GroupNewEditor.tsx
@@ -87,7 +87,7 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
 
   const canNew = () => {
     if (!name) return false;
-    if (isNaN(stepsAverage) || stepsAverage < 1 || stepsAverage > 999) return false;
+    if (isNaN(stepsAverage) || stepsAverage < 0 || stepsAverage > 999) return false;
     if (isNaN(switchId) || switchId < 1 || switchId > 99999) return false;
 
     return true;
@@ -173,7 +173,7 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
           <Input
             name="steps-average"
             type="number"
-            min={1}
+            min={0}
             max={999}
             step={1}
             value={isNaN(stepsAverage) ? '' : stepsAverage}


### PR DESCRIPTION
1. Makes the default value 0 when it did not exist (remain compliant with previous way of doing things)
2. Allow user to not specify step average in groups by allowing 0 value