### PR TITLE
Fix missing "key" error message in breadcrumb component

### DIFF
--- a/src/views/components/world/map/MapBreadcrumb.tsx
+++ b/src/views/components/world/map/MapBreadcrumb.tsx
@@ -86,12 +86,12 @@ export const MapBreadcrumb = () => {
   return (
     <MapBreadcrumbStyle>
       {breadcrumb.map((selected, i) => (
-        <>
-          <span key={i} className={breadcrumbStyling(breadcrumb, selected, i)} onClick={() => handleClick(selected)}>
+        <React.Fragment key={i}>
+          <span className={breadcrumbStyling(breadcrumb, selected, i)} onClick={() => handleClick(selected)}>
             {selected.name}
           </span>
           {i < breadcrumb.length - 1 ? <span className="breadcrumb-divider"> / </span> : null}
-        </>
+        </React.Fragment>
       ))}
     </MapBreadcrumbStyle>
   );


### PR DESCRIPTION
Fix this error message:
https://github.com/PokemonWorkshop/PokemonStudio/issues/19
![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/57238216/de23cdce-644e-4fa8-8772-2891e9f6b226)

Result:
![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/57238216/1e7fa72b-94d5-4ab1-9732-60f23fda7ee6)
