### PR TITLE
Improved file search to stop the search if the source folder does not contain the expected files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,10 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4",
         "url-loader": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.9.0",
+        "npm": ">=9.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -106,13 +106,7 @@ const updateMetadata = async (tiledMap: MapToImport, mapsFolderPath: string) => 
   tiledMap.sha1 = sha1;
 };
 
-const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
-  log.info('copy-tiled-files');
-  const projectPath = payload.projectPath;
-  const mapsFolderPath = path.join(projectPath, MAPS_FOLDER);
-  const tilesetsFolderPath = path.join(projectPath, TILESETS_FOLDER);
-  const assetsFolderPath = path.join(projectPath, ASSETS_FOLDER);
-
+const createTargetFolders = (mapsFolderPath: string, tilesetsFolderPath: string, assetsFolderPath: string) => {
   if (!fs.existsSync(mapsFolderPath)) {
     fs.mkdirSync(mapsFolderPath);
   }
@@ -122,6 +116,16 @@ const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
   if (!fs.existsSync(assetsFolderPath)) {
     fs.mkdirSync(assetsFolderPath);
   }
+};
+
+const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
+  log.info('copy-tiled-files');
+  const projectPath = payload.projectPath;
+  const mapsFolderPath = path.join(projectPath, MAPS_FOLDER);
+  const tilesetsFolderPath = path.join(projectPath, TILESETS_FOLDER);
+  const assetsFolderPath = path.join(projectPath, ASSETS_FOLDER);
+
+  createTargetFolders(mapsFolderPath, tilesetsFolderPath, assetsFolderPath);
 
   const tiledMaps: MapToImport[] = JSON.parse(payload.tiledMaps);
   const originalTiledMapPaths = tiledMaps.map(({ path }) => path);


### PR DESCRIPTION
## Description

Improved file search to stop the search if the source folder doesn't contain the expected files. This will prevent the creation of unwanted folders in the import. If recursion is enabled, it will be applied if an expected file is found.
Issue: https://github.com/PokemonWorkshop/PokemonStudio/issues/97

## Note before testing

Pokémon Studio should be in Tiled mode. (edit the `project.studio` file if necessary)
Delete the contents of the `Data/Tiled` folder.
If the application crashs in the map page, update your `map_info.json` file:
```json
{
  "0": {
    "id": 0,
    "children": [],
    "hasChildren": false,
    "isExpanded": true,
    "data": {
      "klass": "MapInfoRoot"
    }
  }
}
```

## Tests to perform

Download and extract this [archive](https://github.com/PokemonWorkshop/PokemonStudio/files/13514255/test-import.zip):

In the Tiled import:

- [x] Select the folder `import-test`: if it works normally, no file is found ;
- [x] Select the folder `import-test/Maps`: if it works normally, the files are found ;
- [x] Launch the import and check in the folder `Data/Tiled` that 3 folders exist: `Maps`, `Assets` and `Tilesets`. The folders must contain only files.
