### PR TITLE
Remove index files to fix conflit on Windows and duplicate index files on Linux

### DIFF
--- a/src/views/components/Link/Index.ts
+++ b/src/views/components/Link/Index.ts
@@ -1,1 +1,0 @@
-export * from './Link';

--- a/src/views/components/database/navigation/NavigationDatabase/Index.ts
+++ b/src/views/components/database/navigation/NavigationDatabase/Index.ts
@@ -1,1 +1,0 @@
-export * from './NavigationDatabase';

--- a/src/views/components/database/navigation/NavigationDatabaseItem/Index.ts
+++ b/src/views/components/database/navigation/NavigationDatabaseItem/Index.ts
@@ -1,1 +1,0 @@
-export * from './NavigationDatabaseItem';

--- a/src/views/components/icons/BaseIcon/Index.ts
+++ b/src/views/components/icons/BaseIcon/Index.ts
@@ -1,1 +1,0 @@
-export * from './BaseIcon';

--- a/src/views/components/navigation/NavigationBarItem/Index.ts
+++ b/src/views/components/navigation/NavigationBarItem/Index.ts
@@ -1,1 +1,0 @@
-export * from './NavigationBarItem';

--- a/src/views/pages/editors/HomePageNewEditor.tsx
+++ b/src/views/pages/editors/HomePageNewEditor.tsx
@@ -35,6 +35,7 @@ export const HomePageNewEditor: FunctionComponent = () => {
     multiLanguage: false,
     studioVersion: '1.0.0',
     iconPath: 'project_icon.png',
+    isTiledMode: null,
   });
   const refreshUI = useRefreshUI();
   const languageOptions = useMemo(() => languageEntries(t), [t]);


### PR DESCRIPTION
## Description

This PR removes the useless index files which create a bug on Linux build and conflict on Windows.
The filed removed are:
- `src/views/components/Link/Index.ts`
- `src/views/components/database/navigation/NavigationDatabase/Index.ts`
- `src/views/components/database/navigation/NavigationDatabaseItem/Index.ts`
- `src/views/components/icons/BaseIcon/Index.ts`
- `src/views/components/navigation/NavigationBarItem/Index.ts`

Linux does the difference between `Index.ts` and `index.ts`, but for Windows it's the same thing.

The PR also fixes too a missing attribut in the HomePageNewEditor component.

## Note before testing

The ignorecase config of your git should be set to false.
Command: `git config core.ignorecase false`

## Tests to perform

- [ ] Check only `index.ts` files exists on Windows
- [x] Check only `index.ts` files exists on Linux
- [ ] Check only `index.ts` files exists on MacOS
