### PR TITLE
Fix rendering of type chart helper text

### DIFF
--- a/src/views/components/categories/RatioCategoryIcon.tsx
+++ b/src/views/components/categories/RatioCategoryIcon.tsx
@@ -137,7 +137,6 @@ export const RatioCategoryIcon = ({
       }
     }
     editType(offType);
-    setTypeHelperSelected({ offensiveType: offType, defensiveType });
   };
 
   const rightClick = () => {
@@ -164,12 +163,11 @@ export const RatioCategoryIcon = ({
       }
     }
     editType(offType);
-    setTypeHelperSelected({ offensiveType: offType, defensiveType });
   };
 
   const onMouseEnter = (offType: StudioType, defType: StudioType) => {
     setHoveredDefensiveType(defType.dbSymbol);
-    setTypeHelperSelected({ offensiveType: offType, defensiveType: defType });
+    setTypeHelperSelected({ offensiveType: offType.dbSymbol, defensiveType: defType.dbSymbol });
   };
 
   return (

--- a/src/views/components/database/type/TypeHelper.tsx
+++ b/src/views/components/database/type/TypeHelper.tsx
@@ -4,10 +4,11 @@ import { TFunction, useTranslation } from 'react-i18next';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { useGetEntityNameTextUsingTextId } from '@utils/ReadingProjectText';
 import { getEfficiency, StudioType } from '@modelEntities/type';
+import { DbSymbol } from '@modelEntities/dbSymbol';
 
 export type HelperSelectedType = {
-  offensiveType: StudioType | undefined;
-  defensiveType: StudioType | undefined;
+  offensiveType: DbSymbol | undefined;
+  defensiveType: DbSymbol | undefined;
 };
 
 const TypeHelperContainer = styled.span`
@@ -18,22 +19,23 @@ const TypeHelperContainer = styled.span`
 `;
 
 const getHelperText = (
-  typeHelperSelected: HelperSelectedType,
+  offensive: DbSymbol,
+  defensive: DbSymbol,
   allTypes: StudioType[],
   t: TFunction<'database_types'>,
   getTypeName: ReturnType<typeof useGetEntityNameTextUsingTextId>
 ) => {
-  if (!typeHelperSelected.offensiveType || !typeHelperSelected.defensiveType) return '';
-
-  const efficiency = getEfficiency(typeHelperSelected.offensiveType, typeHelperSelected.defensiveType, allTypes);
+  const offensiveType = allTypes.find(({ dbSymbol }) => dbSymbol === offensive) || allTypes[0];
+  const defensiveType = allTypes.find(({ dbSymbol }) => dbSymbol === defensive) || allTypes[0];
+  const efficiency = getEfficiency(offensiveType, defensiveType, allTypes);
   switch (efficiency) {
     case 'high_efficience':
     case 'low_efficience':
     case 'neutral':
     case 'zero_efficience':
       return t(`${efficiency}_helper`, {
-        offensiveType: getTypeName(typeHelperSelected.offensiveType),
-        defensiveType: getTypeName(typeHelperSelected.defensiveType),
+        offensiveType: getTypeName(offensiveType),
+        defensiveType: getTypeName(defensiveType),
       });
     default:
       assertUnreachable(efficiency);
@@ -53,6 +55,8 @@ export const TypeHelper = ({ typeHelperSelected, allTypes }: TypeHelperProps) =>
   return !typeHelperSelected.offensiveType || !typeHelperSelected.defensiveType ? (
     <></>
   ) : (
-    <TypeHelperContainer>{getHelperText(typeHelperSelected, allTypes, t, getTypeName)}</TypeHelperContainer>
+    <TypeHelperContainer>
+      {getHelperText(typeHelperSelected.offensiveType, typeHelperSelected.defensiveType, allTypes, t, getTypeName)}
+    </TypeHelperContainer>
   );
 };


### PR DESCRIPTION
## Description

Fix #28 

## Tests to perform

1. Hover any types on Type Chart, it should display proper helper text
2. Hover the header on Type Chart, it should not display helper text
3. Edit a type with different defensive type on Type Chart, it should always display the right helper text
4. Edit a type with same defensive type on Type Chart, it should always display the right helper text