### PR TITLE
Feature: Make sure we can only delete a map on the map database UI in RMXP mode #121

### DIFF
--- a/src/utils/useMapInfo.ts
+++ b/src/utils/useMapInfo.ts
@@ -52,6 +52,7 @@ export const useMapInfo = () => {
 
   return {
     mapInfo,
+    isRMXPMode: !state.projectStudio.isTiledMode,
     setMapInfo,
     setPartialMapInfo,
     state,

--- a/src/utils/usePage.ts
+++ b/src/utils/usePage.ts
@@ -94,6 +94,7 @@ export const useMapPage = () => {
     hasMap: dbSymbol !== '__undef__',
     hasMapModified: state.mapsModified.length !== 0,
     isRMXPMode: !state.projectStudio.isTiledMode,
+    disabledOpenTiled: !state.projectStudio.isTiledMode || !map.tiledFilename,
     state,
   };
 };

--- a/src/views/components/database/dataBlocks/DataBlockContainer.tsx
+++ b/src/views/components/database/dataBlocks/DataBlockContainer.tsx
@@ -44,7 +44,7 @@ export const DataBlockContainer = styled(ActiveContainer)<DataBlockContainerProp
     }
   }
 
-  &[data-disabled] {
+  &[data-disabled='true'] {
     pointer-events: none;
   }
 `;

--- a/src/views/components/database/dataBlocks/DataBlockContainer.tsx
+++ b/src/views/components/database/dataBlocks/DataBlockContainer.tsx
@@ -43,4 +43,8 @@ export const DataBlockContainer = styled(ActiveContainer)<DataBlockContainerProp
       display: inline-block;
     }
   }
+
+  &[data-disabled] {
+    pointer-events: none;
+  }
 `;

--- a/src/views/components/database/dataBlocks/DataBlockWithTitle.tsx
+++ b/src/views/components/database/dataBlocks/DataBlockWithTitle.tsx
@@ -28,6 +28,10 @@ export const DataBlockWithTitleStyle = styled(DataBlockContainer)`
   #root &[data-disabled='true'] h2 {
     color: ${({ theme }) => theme.colors.dark20};
   }
+
+  &[data-disabled='true'] {
+    pointer-events: none;
+  }
 `;
 
 export const DataBlockWithTitle = ({ title, size, children, disabled, onClick }: DataBlockWithTitleProps) => (

--- a/src/views/components/database/type/editors/TypeNewEditor.tsx
+++ b/src/views/components/database/type/editors/TypeNewEditor.tsx
@@ -118,7 +118,14 @@ export const TypeNewEditor = forwardRef<EditorHandlingClose, TypeNewEditorProps>
           <Label htmlFor="dbSymbol" required>
             {t('database_moves:symbol')}
           </Label>
-          <Input type="text" name="dbSymbol" ref={dbSymbolRef} error={!!dbSymbolErrorType} placeholder={t('database_types:example_db_symbol')} />
+          <Input
+            type="text"
+            name="dbSymbol"
+            ref={dbSymbolRef}
+            onChange={(e) => onChangeDbSymbol(e.currentTarget.value)}
+            error={!!dbSymbolErrorType}
+            placeholder={t('database_types:example_db_symbol')}
+          />
           {dbSymbolErrorType == 'value' && <TextInputError>{t('database_moves:incorrect_format')}</TextInputError>}
           {dbSymbolErrorType == 'duplicate' && <TextInputError>{t('database_moves:db_symbol_already_used')}</TextInputError>}
         </InputWithTopLabelContainer>

--- a/src/views/components/world/map/MapFrame.tsx
+++ b/src/views/components/world/map/MapFrame.tsx
@@ -15,16 +15,17 @@ import { padStr } from '@utils/PadStr';
 type Props = {
   map: StudioMap;
   dialogsRef: MapDialogsRef;
+  disabled: boolean;
 };
 
 /**
  * Frame showing the common information about the map (name & description)
  */
-export const MapFrame = ({ map, dialogsRef }: Props) => {
+export const MapFrame = ({ map, dialogsRef, disabled }: Props) => {
   const getName = useGetEntityNameText();
   const getDescription = useGetEntityDescriptionText();
   return (
-    <DataBlockContainer size="full" onClick={() => dialogsRef.current?.openDialog('frame')}>
+    <DataBlockContainer size="full" data-disabled={disabled} onClick={() => dialogsRef.current?.openDialog('frame')}>
       <DataGrid columns="minmax(min-content, 1024px)">
         <DataInfoContainer>
           <DataInfoContainerHeader>

--- a/src/views/components/world/map/MapMenu.tsx
+++ b/src/views/components/world/map/MapMenu.tsx
@@ -39,7 +39,7 @@ const MapSubMenuContainer = styled.div`
 
 export const MapMenu = () => {
   const dialogsRef = useDialogsRef<MapEditorAndDeletionKeys>();
-  const { mapInfo, setMapInfo } = useMapInfo();
+  const { mapInfo, isRMXPMode, setMapInfo } = useMapInfo();
   const setText = useSetProjectText();
   const { buildOnMouseEnter, onMouseLeave, renderToolTip } = useToolTip();
   const { t } = useTranslation(['world', 'database_maps']);
@@ -57,13 +57,14 @@ export const MapMenu = () => {
       <NavigationDatabaseGroup title={t('world:maps')}>
         <MapSubMenuContainer>
           <div className="buttons">
-            <SecondaryButtonWithPlusIcon className="new" onClick={() => dialogsRef.current?.openDialog('new')}>
+            <SecondaryButtonWithPlusIcon className="new" onClick={() => dialogsRef.current?.openDialog('new')} disabled={isRMXPMode}>
               {t('database_maps:new')}
             </SecondaryButtonWithPlusIcon>
             <NewFolderButtonOnlyIcon
               onClick={handleNewFolder}
               onMouseLeave={onMouseLeave}
               onMouseEnter={buildOnMouseEnter(t('database_maps:new_folder'), 'top-begin')}
+              disabled={isRMXPMode}
             />
           </div>
           <SeparatorGreyLine />

--- a/src/views/components/world/map/MapMenu.tsx
+++ b/src/views/components/world/map/MapMenu.tsx
@@ -20,6 +20,7 @@ const MapMenuContainer = styled(NavigationDatabaseStyle)`
   ${NavigationDatabaseGroupStyle} {
     gap: 8px;
   }
+  height: 100vh;
 `;
 
 const MapSubMenuContainer = styled.div`

--- a/src/views/components/world/map/MapMusics.tsx
+++ b/src/views/components/world/map/MapMusics.tsx
@@ -7,13 +7,14 @@ import { MapDialogsRef } from './editors/MapEditorOverlay';
 type Props = {
   map: StudioMap;
   dialogsRef: MapDialogsRef;
+  disabled: boolean;
 };
 
-export const MapMusics = ({ map, dialogsRef }: Props) => {
+export const MapMusics = ({ map, dialogsRef, disabled }: Props) => {
   const { t } = useTranslation('database_maps');
 
   return (
-    <DataBlockWithTitle size="full" title={t('musics')} onClick={() => dialogsRef.current?.openDialog('musics')}>
+    <DataBlockWithTitle size="full" title={t('musics')} disabled={disabled} onClick={() => dialogsRef.current?.openDialog('musics')}>
       <DataGrid columns="1fr" rows="1fr 1fr">
         <DataFieldsetField label={t('background_music')} data={map.bgm || t('no_background_music')} disabled={!map.bgm} />
         <DataFieldsetField label={t('background_sound')} data={map.bgs || t('no_background_sound')} disabled={!map.bgs} />

--- a/src/views/components/world/map/tree/MapTreeComponent.tsx
+++ b/src/views/components/world/map/tree/MapTreeComponent.tsx
@@ -46,7 +46,7 @@ type MapTreeComponentProps = {
 };
 
 export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) => {
-  const { mapInfo, setMapInfo, setPartialMapInfo } = useMapInfo();
+  const { mapInfo, isRMXPMode, setMapInfo, setPartialMapInfo } = useMapInfo();
   const { selectedDataIdentifier: currentMap, setSelectedDataIdentifier: setCurrentMap, projectDataValues: maps } = useProjectMaps();
   const setText = useSetProjectText();
   const getMapName = useGetEntityNameText();
@@ -223,7 +223,7 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
               <span className="icon icon-dot" onClick={openMenu}>
                 <DotIcon />
               </span>
-              {!isDeleted && currentDepth <= 3 && (
+              {!isDeleted && !isRMXPMode && currentDepth <= 3 && (
                 <span
                   className="icon icon-plus"
                   onClick={(e) => {
@@ -283,7 +283,7 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
         onCollapse={onCollapse}
         onDragEnd={onDragEnd}
         offsetPerLevel={26}
-        isDragEnabled
+        isDragEnabled={!isRMXPMode}
         isNestingEnabled
       />
       {mapInfoSelected &&

--- a/src/views/components/world/map/tree/MapTreeContextMenu.tsx
+++ b/src/views/components/world/map/tree/MapTreeContextMenu.tsx
@@ -23,7 +23,7 @@ type MapTreeContextMenuProps = {
 
 export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dialogsRef }: MapTreeContextMenuProps) => {
   const { t } = useTranslation('database_maps');
-  const { mapInfo, setMapInfo } = useMapInfo();
+  const { mapInfo, isRMXPMode, setMapInfo } = useMapInfo();
   const { projectDataValues: maps, setProjectDataValues: setMap } = useProjectMaps();
   const setText = useSetProjectText();
   const getName = useGetEntityNameText();
@@ -70,7 +70,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
 
   return (
     <>
-      {!isDeleted && (
+      {!isDeleted && !isRMXPMode && (
         <div onClick={() => enableRename()}>
           <span className="icon">
             <EditIcon />
@@ -78,7 +78,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
           {t('rename')}
         </div>
       )}
-      {!isFolder && !isDeleted && (
+      {!isFolder && !isDeleted && !isRMXPMode && (
         <div onClick={onClickDuplicate}>
           <span className="icon">
             <CopyIcon />
@@ -86,7 +86,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
           {t('duplicate')}
         </div>
       )}
-      {!isFolder && !isDeleted && (
+      {!isFolder && !isDeleted && !isRMXPMode && (
         <div onClick={onClickTiled}>
           <span className="icon">
             <MapPaddedIcon />

--- a/src/views/components/world/map/tree/MapTreeContextMenu.tsx
+++ b/src/views/components/world/map/tree/MapTreeContextMenu.tsx
@@ -29,6 +29,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
   const getName = useGetEntityNameText();
   const getDescription = useGetEntityDescriptionText();
   const openTiled = useOpenTiled();
+  const hideTiledOption = mapInfoValue.data.klass === 'MapInfoMap' ? !maps[mapInfoValue.data.mapDbSymbol]?.tiledFilename : true || isDeleted;
 
   const isFolder = mapInfoValue.data.klass === 'MapInfoFolder';
   const onClickDelete = () => {
@@ -86,7 +87,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
           {t('duplicate')}
         </div>
       )}
-      {!isFolder && !isDeleted && !isRMXPMode && (
+      {!isFolder && !isDeleted && !isRMXPMode && !hideTiledOption && (
         <div onClick={onClickTiled}>
           <span className="icon">
             <MapPaddedIcon />

--- a/src/views/pages/world/Map.page.tsx
+++ b/src/views/pages/world/Map.page.tsx
@@ -27,7 +27,7 @@ const MapPageStyle = styled.div`
 
 export const MapPage = () => {
   const dialogsRef = useDialogsRef<MapEditorAndDeletionKeys>();
-  const { map, hasMap, hasMapModified, isRMXPMode } = useMapPage();
+  const { map, hasMap, hasMapModified, isRMXPMode, disabledOpenTiled } = useMapPage();
   const openTiled = useOpenTiled();
   const { t } = useTranslation('database_maps');
   const { t: tSub } = useTranslation('submenu_database');
@@ -54,9 +54,9 @@ export const MapPage = () => {
             <MapMusics map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <DataBlockWithAction size="full" title={tSub('edition')} disabled={isRMXPMode}>
-              <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)} disabled={isRMXPMode}>
-                <BaseIcon icon="mapPadded" size="s" color={isRMXPMode ? theme.colors.text700 : theme.colors.primaryBase} />
+            <DataBlockWithAction size="full" title={tSub('edition')} disabled={disabledOpenTiled}>
+              <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)} disabled={disabledOpenTiled}>
+                <BaseIcon icon="mapPadded" size="s" color={disabledOpenTiled ? theme.colors.text700 : theme.colors.primaryBase} />
                 <span>{t('open_with_tiled')}</span>
               </SecondaryButton>
             </DataBlockWithAction>

--- a/src/views/pages/world/Map.page.tsx
+++ b/src/views/pages/world/Map.page.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import { PageContainerStyle, PageDataConstrainerStyle } from '@pages/database/PageContainerStyle';
 import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
-import { DatabaseTabsBar } from '@components/database/DatabaseTabsBar';
 
 import { useDialogsRef } from '@utils/useDialogsRef';
 import { useMapPage } from '@utils/usePage';
@@ -39,24 +38,25 @@ export const MapPage = () => {
         <PageDataConstrainerStyle>
           <DataBlockWrapper>
             <MapBreadcrumb />
-            <DatabaseTabsBar
+            {/** The component is commented on because it's currently useless */}
+            {/*<DatabaseTabsBar
               currentTabIndex={0}
               tabs={[
                 { label: t('data'), path: '/world/map' },
                 { label: t('map'), path: '/world/map/view', disabled: true },
               ]}
-            />
+            />*/}
             {hasMapModified && <MapUpdate />}
             {isRMXPMode && <MapRMXP2StudioUpdate />}
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <MapFrame map={map} dialogsRef={dialogsRef} />
-            <MapMusics map={map} dialogsRef={dialogsRef} />
+            <MapFrame map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
+            <MapMusics map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <DataBlockWithAction size="full" title={tSub('edition')}>
-              <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)}>
-                <BaseIcon icon="mapPadded" size="s" color={theme.colors.primaryBase} />
+            <DataBlockWithAction size="full" title={tSub('edition')} disabled={isRMXPMode}>
+              <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)} disabled={isRMXPMode}>
+                <BaseIcon icon="mapPadded" size="s" color={isRMXPMode ? theme.colors.text700 : theme.colors.primaryBase} />
                 <span>{t('open_with_tiled')}</span>
               </SecondaryButton>
             </DataBlockWithAction>


### PR DESCRIPTION
## Description

This PR disables all features useless in the RMXP mode. The user can only delete maps.
This PR also fixes a minor bug in dbSymbol checking in the TypeNewEditor component.

## Note before testing

Pokémon Studio should be in RMXP mode. (edit the `project.studio` file if necessary)

## Tests to perform

- [x] The user can't edit a map (MapFrame, MapAudio)
- [x] The user can't start Tiled
- [x] The user can't create a new map or a new folder (with the (+) button or 'New map' button)
- [x] The user can't drag & drop in the map tree.
- [x] Only the deleting option is present in the context menu.
- [x] In Tiled mode, all features are available
- [x] The dbSymbol checking works correctly in the TypeNewEditor component
