### PR TITLE
Remove the pokeiconshiny from the new project archive

### DIFF
--- a/new-project.zip
+++ b/new-project.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e3432933546555e2dfaf19014e7e2168e747d6c5ef26ab75cdf0b47569c08f6
-size 59262511
+oid sha256:448df4de7fcbbd9a781a2da9a6cb703ed40fab3770132d51d210ca0ce3ca040c
+size 59262373

--- a/new-project.zip
+++ b/new-project.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:448df4de7fcbbd9a781a2da9a6cb703ed40fab3770132d51d210ca0ce3ca040c
-size 59262373
+oid sha256:27769c32c8bd46bd061a47bece8ee534fea283e79f0af1c853475b6e1bfd54bc
+size 59344629


### PR DESCRIPTION
## Description
This MR removes the graphics/pokedex/pokeiconshiny from the new-project.zip archive so that users won't add icons in this folder. **PSDK is not able to find the icons in this folder.**
Closes #135 

## Tests to perform
- [x] Create a new project
- [x] Check that the project is loaded without any error (you can check the logs in `AppData\Roaming\Pokémon Studio\logs`)
- [x] Check that the graphics/pokedex/pokeiconshiny is not created anymore
- [x] Check that the Pokédex texts are properly displayed on the Pokédex database UI
