### PR TITLE
Add a warning on the Dashboard Studio mode message dialog box

### DIFF
--- a/assets/i18n/en/dashboard.json
+++ b/assets/i18n/en/dashboard.json
@@ -18,6 +18,7 @@
   "credits": "Game Credits",
   "title_studio_mode_message_box": "Choosing the software to create your maps",
   "message_studio_mode_message_box": "When creating your game, do you want to use Tiled or RPG Maker XP to create your maps?",
+  "warning_message": "You can switch to Tiled later. Make a backup of your project before chosing any option.",
   "button_use_rmxp": "Use RPG Maker XP",
   "button_use_tiled": "Use Tiled"
 }

--- a/assets/i18n/fr/dashboard.json
+++ b/assets/i18n/fr/dashboard.json
@@ -18,6 +18,7 @@
   "credits": "Crédits du jeu",
   "title_studio_mode_message_box": "Choix du logiciel de création de vos cartes",
   "message_studio_mode_message_box": "Lors de la création de votre jeu, souhaitez-vous utiliser Tiled ou RPG Maker XP pour la création de vos cartes ?",
+  "warning_message": "Le passage à Tiled est possible plus tard. Pensez à créer un backup de votre projet avant de choisir une option.",
   "button_use_rmxp": "Utiliser RPG Maker XP",
   "button_use_tiled": "Utiliser Tiled"
 }

--- a/src/views/components/dashboard/editors/DashboardStudioModeMessageBox.tsx
+++ b/src/views/components/dashboard/editors/DashboardStudioModeMessageBox.tsx
@@ -68,6 +68,9 @@ export const DashboardStudioModeMessageBox = ({ closeDialog }: DashboardStudioMo
       </MessageBoxTitleIconContainer>
       <MessageBoxTextContainer>
         <p>{t('dashboard:message_studio_mode_message_box')}</p>
+        <p className="red" style={{ marginTop: '1rem' }}>
+          {t('dashboard:warning_message')}
+        </p>
       </MessageBoxTextContainer>
       <MessageBoxActionContainer>
         <SecondaryButton onClick={() => setMode('rmxp')}>{t('dashboard:button_use_rmxp')}</SecondaryButton>


### PR DESCRIPTION
## Description

This PR adds a warning to make sure the user is warned:
- To create a backup of their project.
- That they'll be able to switch to Tiled mode later.

## Tests to perform

- [ ] Load a 1.4.3 project to migrate to 2.0.0 version
- [ ] Check the dialog message to see the red warning