### PR TITLE
Remove electron simple updater

### DIFF
--- a/app-update.yml
+++ b/app-update.yml
@@ -1,0 +1,4 @@
+owner: PokemonWorkshop
+repo: PokemonStudio
+provider: github
+updaterCacheDirName: pokemon-studio-updater

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,7 +12,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     icon: './assets/icon',
     executableName: 'pokemon-studio',
-    extraResource: ['new-project.zip', 'psdk-binaries'],
+    extraResource: ['new-project.zip', 'psdk-binaries', 'app-update.yml'],
   },
   rebuildConfig: {},
   makers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "csv-stringify": "^6.3.0",
         "electron-is-dev": "^2.0.0",
         "electron-log": "^5.0.0-beta.24",
-        "electron-simple-updater": "^2.0.11",
         "electron-updater": "^5.3.0",
         "extract-zip": "^2.0.1",
         "i18next": "^22.4.13",
@@ -5117,14 +5116,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -7424,18 +7415,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/electron-simple-updater": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/electron-simple-updater/-/electron-simple-updater-2.0.11.tgz",
-      "integrity": "sha512-V6SsmquUZJDfggW2KzmSruEIQyWvQBSs89hwS/CTmfH2Y8liZnofoyjkX5hOI7SoluYCERtQJJwTJbj0lte2bA==",
-      "dependencies": {
-        "axios": "^0.24.0",
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -8643,6 +8622,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
       "target": [
         "nsis"
       ],
+      "publish": {
+        "provider": "github",
+        "owner": "PokemonWorkshop",
+        "repo": "PokemonStudio"
+      },
       "icon": "assets/icon.ico"
     },
     "nsis": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "csv-stringify": "^6.3.0",
     "electron-is-dev": "^2.0.0",
     "electron-log": "^5.0.0-beta.24",
-    "electron-simple-updater": "^2.0.11",
     "electron-updater": "^5.3.0",
     "extract-zip": "^2.0.1",
     "i18next": "^22.4.13",

--- a/package.json
+++ b/package.json
@@ -112,17 +112,13 @@
     ],
     "extraFiles": [
       "psdk-binaries",
-      "new-project.zip"
+      "new-project.zip",
+      "app-update.yml"
     ],
     "win": {
       "target": [
         "nsis"
       ],
-      "publish": {
-        "provider": "github",
-        "owner": "PokemonWorkshop",
-        "repo": "PokemonStudio"
-      },
       "icon": "assets/icon.ico"
     },
     "nsis": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -191,7 +191,7 @@ ipcMain.on('window-is-maximized', (event) => {
 ipcMain.handle('get-psdk-binaries-path', () => getPSDKBinariesPath());
 ipcMain.handle('get-psdk-version', () => getPSDKVersion());
 ipcMain.handle('get-app-version', () => app.getVersion());
-ipcMain.once('studio-check-update', () => app.isPackaged && autoUpdater.checkForUpdatesAndNotify());
+ipcMain.once('studio-check-update', () => app.isPackaged && autoUpdater.checkForUpdates());
 ipcMain.on('get-last-psdk-version', getLastPSDKVersion);
 ipcMain.on('update-psdk', updatePSDK);
 ipcMain.on('start-psdk', (_, projectPath: string) => startPSDK(projectPath));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import log, { FileTransport, PathVariables } from 'electron-log';
 import MenuBuilder from './menu';
-import updater from 'electron-simple-updater';
+import { autoUpdater } from 'electron-updater';
 import { getPSDKBinariesPath, getPSDKVersion } from '../services/getPSDKVersion';
 import { getLastPSDKVersion } from '../services/getLastPSDKVersion';
 import { updatePSDK } from '../services/updatePSDK';
@@ -129,16 +129,11 @@ const createWindow = async () => {
 
   // Updater
   if (app.isPackaged) {
-    updater.init({
-      autoDownload: true,
-      checkUpdateOnStart: false,
-      url: 'https://raw.githubusercontent.com/PokemonWorkshop/PokemonStudio/main/updates.json',
-      logger: log,
-    });
-    updater.on('update-available', () => {
+    autoUpdater.logger = log;
+    autoUpdater.on('update-available', () => {
       mainWindow?.webContents.send('request-update-available');
     });
-    updater.on('update-downloaded', () => {
+    autoUpdater.on('update-downloaded', () => {
       mainWindow?.webContents.send('request-update-downloaded');
     });
   }
@@ -196,7 +191,7 @@ ipcMain.on('window-is-maximized', (event) => {
 ipcMain.handle('get-psdk-binaries-path', () => getPSDKBinariesPath());
 ipcMain.handle('get-psdk-version', () => getPSDKVersion());
 ipcMain.handle('get-app-version', () => app.getVersion());
-ipcMain.once('studio-check-update', () => app.isPackaged && updater.checkForUpdates());
+ipcMain.once('studio-check-update', () => app.isPackaged && autoUpdater.checkForUpdatesAndNotify());
 ipcMain.on('get-last-psdk-version', getLastPSDKVersion);
 ipcMain.on('update-psdk', updatePSDK);
 ipcMain.on('start-psdk', (_, projectPath: string) => startPSDK(projectPath));

--- a/src/views/pages/editors/HomePageNewEditor.tsx
+++ b/src/views/pages/editors/HomePageNewEditor.tsx
@@ -15,7 +15,7 @@ import { basename, dirname } from '@utils/path';
 const iconFileExtensions = ['png'];
 
 const DefaultLanguage = ['en', 'fr', 'es'] as const;
-export type DefaultLanguageType = typeof DefaultLanguage[number];
+export type DefaultLanguageType = (typeof DefaultLanguage)[number];
 export type ProjectCreationData = StudioProject & {
   icon?: string;
   defaultLanguage: DefaultLanguageType;


### PR DESCRIPTION
## Description

This PR removes the useless electron-simple-updater package. It fixes too an issue with a missing file. The file `app-update.yml` should be generate when we build the app but it doesn't work. This is a problem with electron forge.

Waiting for a solution, the file has been created manually and it is copied when we build the application.

## Note before testing

For test the auto update, change this in the `app-update.yml` file: 
```
owner: Palbolsky
repo: LouesSoientLesOris
```
After use the following commands:
```
npm i
npm run make
```

Go in the `out/make` folder and install the application. (if you have the 1.4.3, I recommand that uninstall it before).

## Tests to perform

- [ ] Check that the auto update works
