### PR TITLE
Make sure that the MapImport ignores the already existing map ID in RMXP

### DIFF
--- a/src/utils/ModelUtils.ts
+++ b/src/utils/ModelUtils.ts
@@ -24,10 +24,12 @@ export const findFirstAvailableTextId = (allData: ProjectData['abilities'] | Pro
  * Find the first available id
  * @param allData The project data containing the data (items, moves, etc.)
  * @param startId The first id usable
+ * @param excludeIds Exclude ids that are not to be used
  * @returns The first available id
  */
-export const findFirstAvailableId = (allData: Record<string, { id: number }>, startId: number) => {
+export const findFirstAvailableId = (allData: Record<string, { id: number }>, startId: number, excludeIds?: number[]) => {
   const values = Object.values(allData);
+  if (excludeIds) values.push(...excludeIds.map((id) => ({ id })));
   if (values.length === 0) return startId;
 
   const idSet = values
@@ -43,12 +45,12 @@ export const findFirstAvailableId = (allData: Record<string, { id: number }>, st
   return idSet[holeIndex - 1] + 1;
 };
 
-export const findFirstAndSecondAvailableId = (allData: Record<string, { id: number }>, startId: number) => {
-  const firstId = findFirstAvailableId(allData, startId);
+export const findFirstAndSecondAvailableId = (allData: Record<string, { id: number }>, startId: number, excludeIds?: number[]) => {
+  const firstId = findFirstAvailableId(allData, startId, excludeIds);
   const newAllData = {
     ...allData,
     [`data_${firstId}`]: { id: firstId },
   };
-  const secondId = findFirstAvailableId(newAllData, startId);
+  const secondId = findFirstAvailableId(newAllData, startId, excludeIds);
   return { firstId, secondId };
 };

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -477,8 +477,15 @@ export const createTextInfo = (textInfos: StudioTextInfo[]): StudioTextInfo => {
   };
 };
 
-export const createMap = (allMaps: ProjectData['maps'], stepsAverage: number, tiledFilename: string, bgm: string, bgs: string): StudioMap => {
-  const id = findFirstAvailableId(allMaps, 1);
+export const createMap = (
+  allMaps: ProjectData['maps'],
+  stepsAverage: number,
+  tiledFilename: string,
+  bgm: string,
+  bgs: string,
+  excludeIds?: number[]
+): StudioMap => {
+  const id = findFirstAvailableId(allMaps, 1, excludeIds);
   const dbSymbol = `map${padStr(id, 3)}` as DbSymbol;
   return {
     klass: 'Map',

--- a/src/utils/useMapImport/index.ts
+++ b/src/utils/useMapImport/index.ts
@@ -8,11 +8,11 @@ export const useMapImport = () => {
   const setState = useProcess(processors, DEFAULT_PROCESS_STATE);
 
   return (
-    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string },
+    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapIds: number[] },
     onSuccess: MapImportSuccessCallback,
     onFailure: MapImportFailureCallback
   ) => {
     binding.current = { onFailure, onSuccess };
-    setState({ state: 'import', filesToImport: payload.filesToImport, tiledFilesSrcPath: payload.tiledFilesSrcPath });
+    setState({ state: 'import', filesToImport: payload.filesToImport, tiledFilesSrcPath: payload.tiledFilesSrcPath, rmxpMapIds: payload.rmxpMapIds });
   };
 };

--- a/src/utils/useMapImport/types.ts
+++ b/src/utils/useMapImport/types.ts
@@ -10,10 +10,10 @@ export type MapImportFailureCallback = (error: MapImportError[], genericError?: 
 export type MapImportSuccessCallback = (payload: Record<string, never>) => void;
 export type MapImportStateObject =
   | { state: 'done' }
-  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string }
-  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string }
-  | { state: 'getRMXPMapsData'; mapsToImport: MapToImport[] }
-  | { state: 'createNewMaps'; mapsToImportWithRMXPMap: MapToImportWithRMXPMap[] };
+  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapIds: number[] }
+  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string; rmxpMapIds: number[] }
+  | { state: 'getRMXPMapsData'; mapsToImport: MapToImport[]; rmxpMapIds: number[] }
+  | { state: 'createNewMaps'; mapsToImportWithRMXPMap: MapToImportWithRMXPMap[]; rmxpMapIds: number[] };
 export type MapImportFunctionBinding = {
   onSuccess: MapImportSuccessCallback;
   onFailure: MapImportFailureCallback;

--- a/src/utils/usePage.ts
+++ b/src/utils/usePage.ts
@@ -94,7 +94,7 @@ export const useMapPage = () => {
     hasMap: dbSymbol !== '__undef__',
     hasMapModified: state.mapsModified.length !== 0,
     isRMXPMode: !state.projectStudio.isTiledMode,
-    disabledOpenTiled: !state.projectStudio.isTiledMode || !map.tiledFilename,
+    disabledOpenTiled: !state.projectStudio.isTiledMode || !map?.tiledFilename,
     state,
   };
 };

--- a/src/views/components/world/map/editors/MapImport/MapImport.tsx
+++ b/src/views/components/world/map/editors/MapImport/MapImport.tsx
@@ -78,6 +78,7 @@ export const MapImport = ({ closeDialog, closeParentDialog }: MapImportProps) =>
   const [hasError, setHasError] = useState<boolean>(false);
   const [mapInfoOptions, setMapInfoOptions] = useState<DropDownOption[]>([{ value: 'new', label: t('new') }]);
   const [mapIdsUsed, setMapIdsUsed] = useState<number[]>([]);
+  const [rmxpMapIds, setRmxpMapIds] = useState<number[]>([]);
   const amountMapShouldBeImport = useMemo(() => files.filter((file) => file.shouldBeImport).length, [files]);
 
   const getSubTitle = () => {
@@ -133,6 +134,7 @@ export const MapImport = ({ closeDialog, closeParentDialog }: MapImportProps) =>
               mapInfoOptions.push(...options.filter((option) => option.value !== 'new' && !mapIds.includes(Number(option.value))));
               return mapInfoOptions;
             });
+            setRmxpMapIds(rmxpMapInfo.map(({ id }) => id));
             setState('select_files');
           },
           ({ errorMessage }) => {
@@ -143,7 +145,7 @@ export const MapImport = ({ closeDialog, closeParentDialog }: MapImportProps) =>
       case 'import': {
         const filesToImport = files.filter((file) => file.shouldBeImport);
         mapImport(
-          { filesToImport, tiledFilesSrcPath: folderPath! },
+          { filesToImport, tiledFilesSrcPath: folderPath!, rmxpMapIds },
           () => {
             // we wait the end of the close dialog animation to close the loader and show a notification
             setTimeout(() => {
@@ -208,6 +210,7 @@ export const MapImport = ({ closeDialog, closeParentDialog }: MapImportProps) =>
                 setFolderPath(undefined);
                 setFiles([]);
                 setMapInfoOptions([{ value: 'new', label: t('new') }]);
+                setRmxpMapIds([]);
                 setState('select_folder');
                 setHasError(false);
               }}


### PR DESCRIPTION
## Description

This PR allows you to ignore RMXP map ids when using MapImport.

## Note before testing

You must be in Tiled mode.

## Tests to perform

- [x] Check that Studio don't use a map id used by rmxp
