### PR TITLE
Improve the effect & status chance UX on the Moves UI

### DIFF
--- a/assets/i18n/en/database_moves.json
+++ b/assets/i18n/en/database_moves.json
@@ -153,5 +153,8 @@
   "move_deleted": "Move deleted",
   "no_characteristic": "No characteristic",
   "common_event": "Common event",
-  "always": "Always"
+  "always": "Always",
+  "error_status": "You cannot have the same status multiple times!",
+  "error_chances": "The chances of applying an effect must be a positive integer greater than 0!",
+  "error_overflow": "The sum of your chances must not exceed 100%!"
 }

--- a/assets/i18n/en/database_moves.json
+++ b/assets/i18n/en/database_moves.json
@@ -154,7 +154,7 @@
   "no_characteristic": "No characteristic",
   "common_event": "Common event",
   "always": "Always",
-  "error_status": "You cannot have the same status multiple times!",
-  "error_chances": "The chances of applying an effect must be a positive integer greater than 0!",
-  "error_overflow": "The sum of your chances must not exceed 100%!"
+  "error_status": "You cannot have the same status multiple times.",
+  "error_chances": "The chances of inflicting a status must be between 1 and 99.",
+  "error_overflow": "The sum of your chances to inflict a status must not exceed 100%."
 }

--- a/assets/i18n/en/database_moves.json
+++ b/assets/i18n/en/database_moves.json
@@ -155,6 +155,6 @@
   "common_event": "Common event",
   "always": "Always",
   "error_status": "You cannot have the same status multiple times.",
-  "error_chances": "The chances of inflicting a status must be between 1 and 99.",
+  "error_chances": "The chances of inflicting a status must be between 1 and 100.",
   "error_overflow": "The sum of your chances to inflict a status must not exceed 100%."
 }

--- a/assets/i18n/fr/database_moves.json
+++ b/assets/i18n/fr/database_moves.json
@@ -153,5 +153,8 @@
   "move_deleted": "Attaque supprimée",
   "no_characteristic": "Aucune caractéristique",
   "common_event": "Événement commun",
-  "always": "Toujours"
+  "always": "Toujours",
+  "error_status": "Vous ne pouvez pas avoir plusieurs fois le même statut !",
+  "error_chances": "Les chances d'appliquer un effet doivent être un nombre entier positif supérieur à 0 !",
+  "error_overflow": "La somme de vos chances ne doivent pas excéder 100% !"
 }

--- a/assets/i18n/fr/database_moves.json
+++ b/assets/i18n/fr/database_moves.json
@@ -154,7 +154,7 @@
   "no_characteristic": "Aucune caractéristique",
   "common_event": "Événement commun",
   "always": "Toujours",
-  "error_status": "Vous ne pouvez pas avoir plusieurs fois le même statut !",
-  "error_chances": "Les chances d'appliquer un effet doivent être un nombre entier positif supérieur à 0 !",
-  "error_overflow": "La somme de vos chances ne doivent pas excéder 100% !"
+  "error_status": "Vous ne pouvez pas avoir plusieurs fois le même statut.",
+  "error_chances": "Les chances d'infliger un statut doit être compris entre 1 et 99.",
+  "error_overflow": "La somme de vos chances d'infliger un statut ne doit pas excéder 100%."
 }

--- a/assets/i18n/fr/database_moves.json
+++ b/assets/i18n/fr/database_moves.json
@@ -155,6 +155,6 @@
   "common_event": "Événement commun",
   "always": "Toujours",
   "error_status": "Vous ne pouvez pas avoir plusieurs fois le même statut.",
-  "error_chances": "Les chances d'infliger un statut doit être compris entre 1 et 99.",
+  "error_chances": "Les chances d'infliger un statut doivent être comprises entre 1 et 100.",
   "error_overflow": "La somme de vos chances d'infliger un statut ne doit pas excéder 100%."
 }

--- a/src/views/components/database/dataBlocks/index.tsx
+++ b/src/views/components/database/dataBlocks/index.tsx
@@ -2,7 +2,7 @@ export { DataBlockContainer } from './DataBlockContainer';
 export { DataBlockWrapper } from './DataBlockWrapper';
 export { DataBlockWithTitle, DataBlockWithTitleNoActive, DataBlockWithTitleCollapse, DataBlockWithTitlePagination } from './DataBlockWithTitle';
 export { DataBlockWithAction, DataBlockWithActionTooltip } from './DataBoxWithAction';
-export { DataFieldsetField } from './DataFieldsetField';
+export { DataFieldsetField, DataFieldsetFieldWithChild, DataFieldsetFieldCenteredWithChild, DataFieldsetFieldCode } from './DataFieldsetField';
 export { DataFieldgroup } from './DataFieldgroup';
 export { DataFieldgroupField } from './DataFieldgroupField';
 export { DataSpriteContainer } from './DataSpriteContainer';

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -54,11 +54,11 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
     <DataBlockWithTitle size="half" title={t('statuses')} onClick={() => dialogsRef?.current?.openDialog('status')}>
       <DataGrid columns="1fr 1fr 1fr" rows="1fr">
         {move.moveStatus.length === 0 ? (
-          <DataFieldsetField label={t(STATUS_KEY[0])} data={getStatus(move.moveStatus, 0)} disabled={isDisabledStatus(move.moveStatus, 0)} />
+          <DataFieldsetField label={t('status')} data={getStatus(move.moveStatus, 0)} disabled={isDisabledStatus(move.moveStatus, 0)} />
         ) : (
           move.moveStatus.map((_, index) => (
             <React.Fragment key={index}>
-              <DataFieldsetFieldWithChild label={t(STATUS_KEY[index])}>
+              <DataFieldsetFieldWithChild label={t(move.moveStatus.length > 1 ? STATUS_KEY[index] : 'status')}>
                 <StatusContainer>
                   <span>{getStatus(move.moveStatus, 0)}</span>
                   {shouldDisplayLuckRate(move.moveStatus) && <span>{`(${getLuckRate(move.moveStatus, index)})`}</span>}

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -17,6 +17,8 @@ type MoveStatusProps = {
   dialogsRef: MoveDialogsRef;
 };
 
+type StatusKey = 'status_1' | 'status_2' | 'status_3';
+
 export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
   const { t } = useTranslation('database_moves');
 
@@ -40,7 +42,7 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
         {move.moveStatus.map((_, index) => (
           <React.Fragment key={index}>
             <DataFieldsetField
-              label={t(`status_${index + 1}`)}
+              label={t(`status_${index + 1}` as StatusKey)}
               data={getStatus(move.moveStatus, index)}
               disabled={isDisabledStatus(move.moveStatus, index)}
             />

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -30,15 +30,29 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
     return `${status[index].luckRate} %`;
   };
 
+  const shouldDisplayLuckRate = (status: StudioMoveStatus[] | null) => {
+    return status !== null && status.length > 1;
+  };
+
   return (
     <DataBlockWithTitle size="half" title={t('statuses')} onClick={() => dialogsRef?.current?.openDialog('status')}>
       <DataGrid columns="1fr 1fr 1fr" rows="1fr 1fr">
-        <DataFieldsetField label={t('status_1')} data={getStatus(move.moveStatus, 0)} disabled={isDisabledStatus(move.moveStatus, 0)} />
-        <DataFieldsetField label={t('chance')} data={getLuckRate(move.moveStatus, 0)} disabled={isDisabledLuckRate(move.moveStatus, 0)} />
-        <DataFieldsetField label={t('status_2')} data={getStatus(move.moveStatus, 1)} disabled={isDisabledStatus(move.moveStatus, 1)} />
-        <DataFieldsetField label={t('chance')} data={getLuckRate(move.moveStatus, 1)} disabled={isDisabledLuckRate(move.moveStatus, 1)} />
-        <DataFieldsetField label={t('status_3')} data={getStatus(move.moveStatus, 2)} disabled={isDisabledStatus(move.moveStatus, 2)} />
-        <DataFieldsetField label={t('chance')} data={getLuckRate(move.moveStatus, 2)} disabled={isDisabledLuckRate(move.moveStatus, 2)} />
+        {move.moveStatus.map((status, index) => (
+          <React.Fragment key={index}>
+            <DataFieldsetField
+              label={t(`status_${index + 1}`)}
+              data={getStatus(move.moveStatus, index)}
+              disabled={isDisabledStatus(move.moveStatus, index)}
+            />
+            {shouldDisplayLuckRate(move.moveStatus) && (
+              <DataFieldsetField
+                label={t('chance')}
+                data={getLuckRate(move.moveStatus, index)}
+                disabled={isDisabledLuckRate(move.moveStatus, index)}
+              />
+            )}
+          </React.Fragment>
+        ))}
       </DataGrid>
     </DataBlockWithTitle>
   );

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -1,20 +1,34 @@
 import React from 'react';
-import { StudioMove, StudioMoveStatus, StudioMoveStatusList } from '@modelEntities/move';
+import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import { DataBlockWithTitle, DataFieldsetField, DataGrid } from '../dataBlocks';
+import { StudioMove, StudioMoveStatus, StudioMoveStatusList } from '@modelEntities/move';
+import { DataBlockWithTitle, DataFieldsetField, DataFieldsetFieldWithChild, DataGrid } from '../dataBlocks';
 import { MoveDialogsRef } from './editors/MoveEditorOverlay';
 
-const isDisabledStatus = (status: StudioMoveStatus[] | null, index: number) => {
-  return status === null || status.length <= index || status[index].status === null ? true : undefined;
-};
+const StatusContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  color: ${({ theme }) => theme.colors.text100};
+  ${({ theme }) => theme.fonts.normalRegular}
 
-const isDisabledLuckRate = (status: StudioMoveStatus[] | null, index: number) => {
-  return status === null || status.length <= index || status[index].luckRate === 0 ? true : undefined;
-};
+  & span:nth-child(2) {
+    color: ${({ theme }) => theme.colors.text400};
+  }
+
+  @media ${({ theme }) => theme.breakpoints.dataBox422} {
+    flex-direction: column;
+    gap: 0px;
+  }
+`;
 
 type MoveStatusProps = {
   move: StudioMove;
   dialogsRef: MoveDialogsRef;
+};
+
+const isDisabledStatus = (status: StudioMoveStatus[] | null, index: number) => {
+  return status === null || status.length <= index || status[index].status === null ? true : undefined;
 };
 
 const STATUS_KEY = ['status_1', 'status_2', 'status_3'] as const;
@@ -38,23 +52,21 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
 
   return (
     <DataBlockWithTitle size="half" title={t('statuses')} onClick={() => dialogsRef?.current?.openDialog('status')}>
-      <DataGrid columns="1fr 1fr 1fr" rows="1fr 1fr">
-        {move.moveStatus.map((_, index) => (
-          <React.Fragment key={index}>
-            <DataFieldsetField
-              label={t(STATUS_KEY[index] || STATUS_KEY[0])}
-              data={getStatus(move.moveStatus, index)}
-              disabled={isDisabledStatus(move.moveStatus, index)}
-            />
-            {shouldDisplayLuckRate(move.moveStatus) && (
-              <DataFieldsetField
-                label={t('chance')}
-                data={getLuckRate(move.moveStatus, index)}
-                disabled={isDisabledLuckRate(move.moveStatus, index)}
-              />
-            )}
-          </React.Fragment>
-        ))}
+      <DataGrid columns="1fr 1fr 1fr" rows="1fr">
+        {move.moveStatus.length === 0 ? (
+          <DataFieldsetField label={t(STATUS_KEY[0])} data={getStatus(move.moveStatus, 0)} disabled={isDisabledStatus(move.moveStatus, 0)} />
+        ) : (
+          move.moveStatus.map((_, index) => (
+            <React.Fragment key={index}>
+              <DataFieldsetFieldWithChild label={t(STATUS_KEY[index])}>
+                <StatusContainer>
+                  <span>{getStatus(move.moveStatus, 0)}</span>
+                  {shouldDisplayLuckRate(move.moveStatus) && <span>{`(${getLuckRate(move.moveStatus, index)})`}</span>}
+                </StatusContainer>
+              </DataFieldsetFieldWithChild>
+            </React.Fragment>
+          ))
+        )}
       </DataGrid>
     </DataBlockWithTitle>
   );

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -37,7 +37,7 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
   return (
     <DataBlockWithTitle size="half" title={t('statuses')} onClick={() => dialogsRef?.current?.openDialog('status')}>
       <DataGrid columns="1fr 1fr 1fr" rows="1fr 1fr">
-        {move.moveStatus.map((status, index) => (
+        {move.moveStatus.map((_, index) => (
           <React.Fragment key={index}>
             <DataFieldsetField
               label={t(`status_${index + 1}`)}

--- a/src/views/components/database/move/MoveStatus.tsx
+++ b/src/views/components/database/move/MoveStatus.tsx
@@ -17,7 +17,7 @@ type MoveStatusProps = {
   dialogsRef: MoveDialogsRef;
 };
 
-type StatusKey = 'status_1' | 'status_2' | 'status_3';
+const STATUS_KEY = ['status_1', 'status_2', 'status_3'] as const;
 
 export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
   const { t } = useTranslation('database_moves');
@@ -42,7 +42,7 @@ export const MoveStatus = ({ move, dialogsRef }: MoveStatusProps) => {
         {move.moveStatus.map((_, index) => (
           <React.Fragment key={index}>
             <DataFieldsetField
-              label={t(`status_${index + 1}` as StatusKey)}
+              label={t(STATUS_KEY[index] || STATUS_KEY[0])}
               data={getStatus(move.moveStatus, index)}
               disabled={isDisabledStatus(move.moveStatus, index)}
             />

--- a/src/views/components/database/move/editors/MoveStatusEditor.tsx
+++ b/src/views/components/database/move/editors/MoveStatusEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useState } from 'react';
 import { Editor } from '@components/editor';
 import { TFunction, useTranslation } from 'react-i18next';
 import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PercentInput } from '@components/inputs';
@@ -18,25 +18,42 @@ const moveStatusEntries = (t: TFunction<'database_moves'>) => [
   })).sort((a, b) => a.label.localeCompare(b.label)),
 ];
 
-const isValidStatus = (status: StudioMoveStatusListEditor, chance: number) => status !== '__undef__' || (chance > 0 && chance <= 100);
+const isValidStatus = (status: StudioMoveStatusListEditor): status is Exclude<StudioMoveStatusList, null> => status !== '__undef__';
+const isValidChance = (chance: number) => !isNaN(chance) && chance > 0 && chance <= 100;
 
 export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_moves');
   const { move } = useMovePage();
   const updateMove = useUpdateMove(move);
   const statusOptions = useMemo(() => moveStatusEntries(t), [t]);
-  const [status1, setStatus1] = useState<StudioMoveStatusListEditor>(move.moveStatus[0]?.status || '__undef__');
-  const [status2, setStatus2] = useState<StudioMoveStatusListEditor>(move.moveStatus[1]?.status || '__undef__');
-  const [status3, setStatus3] = useState<StudioMoveStatusListEditor>(move.moveStatus[2]?.status || '__undef__');
-  const [chance1, setChance1] = useState<number>(move.moveStatus[0]?.luckRate || 0);
-  const [chance2, setChance2] = useState<number>(move.moveStatus[1]?.luckRate || 0);
-  const chance3Ref = useRef<HTMLInputElement>(null);
+
+  const [status1, setStatus1] = useState<StudioMoveStatusListEditor>(move.moveStatus[0]?.status ?? '__undef__');
+  const [status2, setStatus2] = useState<StudioMoveStatusListEditor>(move.moveStatus[1]?.status ?? '__undef__');
+  const [status3, setStatus3] = useState<StudioMoveStatusListEditor>(move.moveStatus[2]?.status ?? '__undef__');
+  const [chance1, setChance1] = useState<number>(move.moveStatus[0]?.luckRate ?? 0);
+  const [chance2, setChance2] = useState<number>(move.moveStatus[1]?.luckRate ?? 0);
+  const [chance3, setChance3] = useState<number>(move.moveStatus[2]?.luckRate ?? 0);
+  const [error, setError] = useState<string>('');
+
+  const setStatusFunctions = [setStatus1, setStatus2, setStatus3];
+
+  const setChancesFunctions = [setChance1, setChance2, setChance3];
+
+  const isInitialStateStandard =
+    (chance1 === 100 && chance2 === 0 && chance3 === 0) ||
+    (chance1 === 50 && chance2 === 50 && chance3 === 0) ||
+    (chance1 === 33 && chance2 === 33 && chance3 === 33);
 
   const canClose = () => {
-    if (isNaN(chance1) || chance1 < 0 || chance1 > 100) return false;
-    if (isNaN(chance2) || chance2 < 0 || chance2 > 100) return false;
-    if (!chance3Ref.current) return true;
-    if (!chance3Ref.current.validity.valid || isNaN(chance3Ref.current.valueAsNumber)) return false;
+    if (!isValidStatus(status1)) return true;
+
+    if (isValidStatus(status1) && !isValidChance(chance1)) return false;
+    if (isValidStatus(status2) && !isValidChance(chance2)) return false;
+    if (isValidStatus(status3) && !isValidChance(chance3)) return false;
+    if (chance1 + chance2 + chance3 > 100) return false;
+
+    const validStatuses = [status1, status2, status3].filter((status) => isValidStatus(status));
+    if (new Set(validStatuses).size !== validStatuses.length) return false;
 
     return true;
   };
@@ -44,24 +61,72 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const onClose = () => {
     if (!canClose()) return;
 
+    const statuses = [status1, status2, status3];
+    const chances = [chance1, chance2, chance3];
+
     const moveStatus: StudioMoveStatus[] = [];
-    if (status1 !== '__undef__' || chance1 !== 0) {
-      moveStatus.push({ status: status1 !== '__undef__' ? status1 : null, luckRate: chance1 });
-    } else {
-      return updateMove({ moveStatus });
-    }
-    if (status2 !== '__undef__' || chance2 !== 0) {
-      moveStatus.push({ status: status2 !== '__undef__' ? status2 : null, luckRate: chance2 });
-    } else {
-      return updateMove({ moveStatus });
-    }
-    if (status3 !== '__undef__' || (chance3Ref.current && chance3Ref.current.valueAsNumber !== 0)) {
-      moveStatus.push({ status: status3 !== '__undef__' ? status3 : null, luckRate: chance3Ref.current?.valueAsNumber || 0 });
-    } else {
-      return updateMove({ moveStatus });
+    for (let i = 0; i < statuses.length; i++) {
+      const status = statuses[i];
+      if (isValidStatus(status)) {
+        moveStatus.push({ status, luckRate: chances[i] });
+      } else {
+        return updateMove({ moveStatus });
+      }
     }
     updateMove({ moveStatus });
   };
+
+  const resetStatusesFrom = (startIndex: number) => {
+    setStatusFunctions.slice(startIndex).forEach((setStatus) => setStatus('__undef__'));
+  };
+
+  const setChances = (chances: Array<number>) => {
+    setChancesFunctions.forEach((setChance, index) => setChance(chances[index]));
+  };
+
+  const handleStatusChange = (index: number, value: string) => {
+    const newValue = value as StudioMoveStatusListEditor;
+    setStatusFunctions[index](newValue);
+
+    if (!isValidStatus(newValue)) {
+      resetStatusesFrom(index);
+      if (index === 1) setChances([100, 0, 0]);
+      if (index === 2) setChances([50, 50, 0]);
+    } else {
+      switch (index) {
+        case 0:
+          setChances([100, 0, 0]);
+          break;
+        case 1:
+          if (isInitialStateStandard) {
+            setChances([50, 50, 0]);
+          }
+          break;
+        case 2:
+          if (isInitialStateStandard) {
+            setChances([33, 33, 33]);
+          }
+          break;
+      }
+    }
+  };
+
+  const handleChancesChange = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+    const newChance = event.target.value === '' ? Number.NaN : Number(event.target.value);
+    setChancesFunctions[index](newChance);
+  };
+
+  useEffect(() => {
+    const validStatuses = [status1, status2, status3].filter((status) => isValidStatus(status));
+    if (new Set(validStatuses).size !== validStatuses.length) return setError(t('error_status'));
+
+    if (isValidStatus(status1) && !isValidChance(chance1)) return setError(t('error_chances'));
+    if (isValidStatus(status2) && !isValidChance(chance2)) return setError(t('error_chances'));
+    if (isValidStatus(status3) && !isValidChance(chance3)) return setError(t('error_chances'));
+    if (chance1 + chance2 + chance3 > 100) return setError(t('error_overflow'));
+
+    setError('');
+  }, [t, status1, status2, status3, chance1, chance2, chance3]);
 
   useEditorHandlingClose(ref, onClose, canClose);
 
@@ -74,22 +139,25 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             <SelectCustomSimple
               id="select-status-1"
               options={statusOptions}
-              onChange={(value) => setStatus1(value as StudioMoveStatusListEditor)}
+              onChange={(value) => handleStatusChange(0, value)}
               value={status1}
               noTooltip
             />
           </InputWithTopLabelContainer>
-          <InputWithLeftLabelContainer>
-            <Label htmlFor="chance-1">{t('chance')}</Label>
-            <PercentInput
-              type="number"
-              name="chance-1"
-              min="0"
-              max="100"
-              value={isNaN(chance1) ? '' : chance1}
-              onChange={(event) => setChance1(event.target.value === '' ? Number.NaN : Number(event.target.value))}
-            />
-          </InputWithLeftLabelContainer>
+
+          {isValidStatus(status1) && isValidStatus(status2) && (
+            <InputWithLeftLabelContainer>
+              <Label htmlFor="chance-1">{t('chance')}</Label>
+              <PercentInput
+                type="number"
+                name="chance-1"
+                min="0"
+                max="100"
+                value={isNaN(chance1) ? '' : chance1}
+                onChange={(event) => handleChancesChange(0, event)}
+              />
+            </InputWithLeftLabelContainer>
+          )}
         </InputContainer>
         {isValidStatus(status1, chance1) && (
           <InputContainer size="s">
@@ -98,22 +166,25 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               <SelectCustomSimple
                 id="select-status-2"
                 options={statusOptions}
-                onChange={(value) => setStatus2(value as StudioMoveStatusListEditor)}
+                onChange={(value) => handleStatusChange(1, value)}
                 value={status2}
                 noTooltip
               />
             </InputWithTopLabelContainer>
-            <InputWithLeftLabelContainer>
-              <Label htmlFor="chance-2">{t('chance')}</Label>
-              <PercentInput
-                type="number"
-                name="chance-2"
-                min="0"
-                max="100"
-                value={isNaN(chance2) ? '' : chance2}
-                onChange={(event) => setChance2(event.target.value === '' ? Number.NaN : Number(event.target.value))}
-              />
-            </InputWithLeftLabelContainer>
+
+            {isValidStatus(status2) && (
+              <InputWithLeftLabelContainer>
+                <Label htmlFor="chance-2">{t('chance')}</Label>
+                <PercentInput
+                  type="number"
+                  name="chance-2"
+                  min="0"
+                  max="100"
+                  value={isNaN(chance2) ? '' : chance2}
+                  onChange={(event) => handleChancesChange(1, event)}
+                />
+              </InputWithLeftLabelContainer>
+            )}
           </InputContainer>
         )}
         {isValidStatus(status1, chance1) && isValidStatus(status2, chance2) && (
@@ -123,15 +194,31 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               <SelectCustomSimple
                 id="select-status-3"
                 options={statusOptions}
-                onChange={(value) => setStatus3(value as StudioMoveStatusListEditor)}
+                onChange={(value) => handleStatusChange(2, value)}
                 value={status3}
                 noTooltip
               />
             </InputWithTopLabelContainer>
-            <InputWithLeftLabelContainer>
-              <Label htmlFor="chance-3">{t('chance')}</Label>
-              <PercentInput type="number" name="chance-3" min="0" max="100" defaultValue={move.moveStatus[2]?.luckRate || 0} ref={chance3Ref} />
-            </InputWithLeftLabelContainer>
+
+            {isValidStatus(status3) && (
+              <InputWithLeftLabelContainer>
+                <Label htmlFor="chance-3">{t('chance')}</Label>
+                <PercentInput
+                  type="number"
+                  name="chance-3"
+                  min="0"
+                  max="100"
+                  value={isNaN(chance3) ? '' : chance3}
+                  onChange={(event) => handleChancesChange(2, event)}
+                />
+              </InputWithLeftLabelContainer>
+            )}
+
+            {error && (
+              <Label>
+                <span>{error}</span>
+              </Label>
+            )}
           </InputContainer>
         )}
       </InputContainer>

--- a/src/views/components/database/move/editors/MoveStatusEditor.tsx
+++ b/src/views/components/database/move/editors/MoveStatusEditor.tsx
@@ -135,7 +135,7 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       <InputContainer>
         <InputContainer size="s">
           <InputWithTopLabelContainer>
-            <Label htmlFor="status-1">{t('status_1')}</Label>
+            <Label htmlFor="status-1">{t(isValidStatus(status1) ? 'status_1' : 'status')}</Label>
             <SelectCustomSimple
               id="select-status-1"
               options={statusOptions}
@@ -161,7 +161,7 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             </InputWithLeftLabelContainer>
           )}
         </InputContainer>
-        {isValidStatus(status1, chance1) && (
+        {isValidStatus(status1) && (
           <InputContainer size="s">
             <InputWithTopLabelContainer>
               <Label htmlFor="status-2">{t('status_2')}</Label>
@@ -191,7 +191,7 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             )}
           </InputContainer>
         )}
-        {isValidStatus(status1, chance1) && isValidStatus(status2, chance2) && (
+        {isValidStatus(status1) && isValidStatus(status2) && (
           <InputContainer size="s">
             <InputWithTopLabelContainer>
               <Label htmlFor="status-3">{t('status_3')}</Label>

--- a/src/views/components/database/move/editors/MoveStatusEditor.tsx
+++ b/src/views/components/database/move/editors/MoveStatusEditor.tsx
@@ -36,9 +36,7 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const [error, setError] = useState<string>('');
 
   const setStatusFunctions = [setStatus1, setStatus2, setStatus3];
-
   const setChancesFunctions = [setChance1, setChance2, setChance3];
-
   const isInitialStateStandard =
     (chance1 === 100 && chance2 === 0 && chance3 === 0) ||
     (chance1 === 50 && chance2 === 50 && chance3 === 0) ||
@@ -112,8 +110,10 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
 
   const handleChancesChange = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
-    const newChance = event.target.value === '' ? Number.NaN : Number(event.target.value);
-    setChancesFunctions[index](newChance);
+    let value = event.target.value === '' ? NaN : Number(event.target.value);
+    value = isNaN(value) ? NaN : Math.max(0, Math.min(100, value));
+
+    setChancesFunctions[index](value);
   };
 
   useEffect(() => {
@@ -147,7 +147,9 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
           {isValidStatus(status1) && isValidStatus(status2) && (
             <InputWithLeftLabelContainer>
-              <Label htmlFor="chance-1">{t('chance')}</Label>
+              <Label htmlFor="chance-1" required>
+                {t('chance')}
+              </Label>
               <PercentInput
                 type="number"
                 name="chance-1"
@@ -174,7 +176,9 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
             {isValidStatus(status2) && (
               <InputWithLeftLabelContainer>
-                <Label htmlFor="chance-2">{t('chance')}</Label>
+                <Label htmlFor="chance-2" required>
+                  {t('chance')}
+                </Label>
                 <PercentInput
                   type="number"
                   name="chance-2"
@@ -202,7 +206,9 @@ export const MoveStatusEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
             {isValidStatus(status3) && (
               <InputWithLeftLabelContainer>
-                <Label htmlFor="chance-3">{t('chance')}</Label>
+                <Label htmlFor="chance-3" required>
+                  {t('chance')}
+                </Label>
                 <PercentInput
                   type="number"
                   name="chance-3"


### PR DESCRIPTION
## Tests to perform

- [x] Hide the probability if you only have one status
- [x] The probabilities change automatically according to the number of statuses.
- [x] The same status cannot be entered more than once
- [x] Nothing is displayed if you have no status
- [x] Probabilities can only be changed if a status has been set.
- [x] Setting none to one of the statuses will reset the following
- [x] Custom values aren't overwrited when opening the modal
- [x] Displays an error message if the number is not a positive integer greater than 0
- [x] Displays an error message if the sum of the chances exceeds 100
- [x] Displays an error message if the same status is displayed more than once
- [x] If you are using the default values, when you change the status, the values change automatically.
