### PR TITLE
Disable macos runner + add Game.rb into psdk-binaries

### DIFF
--- a/.github/workflows/pr_macos.yml.disabled
+++ b/.github/workflows/pr_macos.yml.disabled
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-latest-xlarge]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/production_ci.yml
+++ b/.github/workflows/production_ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,6 @@ out/
 
 psdk-binaries/lib
 psdk-binaries/ruby_builtin_dlls
-psdk-binaries/Game.rb
 psdk-binaries/*.dll
 psdk-binaries/*.exe
 psdk-binaries/psdk.bat

--- a/psdk-binaries/Game.rb
+++ b/psdk-binaries/Game.rb
@@ -1,0 +1,12 @@
+if ARGV.first == 'gem'
+  require './lib/__gem.rb'
+elsif ARGV.first == 'bundle'
+  require './lib/__bundle.rb'
+else
+  psdk_path =
+    (Dir.exist?('pokemonsdk') && File.expand_path('pokemonsdk')) ||
+    (ENV['PSDK_BINARY_PATH'] && File.join(ENV['PSDK_BINARY_PATH'].tr('\\', '/'), 'pokemonsdk')) ||
+    ((ENV['APPDATA'] || ENV['HOME']).dup.force_encoding('UTF-8') + '/.pokemonsdk')
+  require "#{psdk_path}/scripts/ScriptLoad.rb"
+  ScriptLoader.load_tool('GameLoader/Z_load_uncompiled')
+end


### PR DESCRIPTION
This PR disables MacOS runner as we need to release on Apple Silicon instead of Intel. (There's no reason why we would support out-dated material).

It also adds Game.rb into the PSDK Binaries as it is missing in the binary archive and Studio needs it to start a project. (It's no longer needed to have a Game.rb for each OS as setup.sh is handling the difficult cases like cleaning up the $LOAD_PATH).

I would suggest to disable the Windows Build for PRs because it doesn't make sense to build for Windows on each PR (esp if the build is not actually usable).