### PR TITLE
Fix artifact name and shortcut not found

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,7 +11,7 @@ import { rendererConfig } from './config/webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     icon: './assets/icon',
-    executableName: 'pokemon-studio',
+    executableName: process.platform === 'win32' ? undefined : 'pokemon-studio',
     extraResource: ['new-project.zip', 'psdk-binaries'],
   },
   rebuildConfig: {},

--- a/package.json
+++ b/package.json
@@ -122,7 +122,9 @@
       "icon": "assets/icon.ico"
     },
     "nsis": {
-      "oneClick": false
+      "oneClick": false,
+      "shortcutName": "Pokémon Studio",
+      "artifactName": "Pokemon-Studio-Setup-${version}.${ext}"
     }
   },
   "volta": {


### PR DESCRIPTION
## Description

Fix the artifact name (Pokemon-Studio-Setup-2.0.0.exe) and the shortcut not found when installing the application.
Tested on Windows and Linux, and it works.


