### PR TITLE
Fix: Make sure the open with tiled feature works on MacOS and Linux

### DIFF
--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -15,6 +15,12 @@ const openTiled = async (payload: OpenTiledPayload) => {
   const mapFilename = path.join(payload.projectPath, 'Data', 'Tiled', 'Maps', payload.tiledMapFilename + '.tmx');
   if (process.platform === 'darwin') {
     await util.promisify(execFile)('open', [payload.tiledPath, mapFilename]);
+  }
+  else if (process.platform === 'linux') {
+    const defaultDir = process.cwd();
+    process.chdir(path.dirname(mapFilename));
+    await util.promisify(execFile)(payload.tiledPath, [path.basename(mapFilename)]);
+    process.chdir(defaultDir);
   } else {
     await util.promisify(execFile)(payload.tiledPath, [mapFilename]);
   }

--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -13,7 +13,11 @@ export type OpenTiledPayload = {
 const openTiled = async (payload: OpenTiledPayload) => {
   log.info('open-tiled', payload);
   const mapFilename = path.join(payload.projectPath, 'Data', 'Tiled', 'Maps', payload.tiledMapFilename + '.tmx');
-  await util.promisify(execFile)(payload.tiledPath, [mapFilename]);
+  if (process.platform === 'darwin') {
+    await util.promisify(execFile)('open', [payload.tiledPath, mapFilename]);
+  } else {
+    await util.promisify(execFile)(payload.tiledPath, [mapFilename]);
+  }
   return {};
 };
 

--- a/src/migrations/baseForMaps.ts
+++ b/src/migrations/baseForMaps.ts
@@ -12,17 +12,24 @@ export const saveCSV = (projectPath: string, fileId: number, languages: string[]
   }
 };
 
+const createFolder = (path: string) => {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path);
+  }
+};
+
 export const baseForMaps = async (_: IpcMainEvent, projectPath: string) => {
   const languages = ['en', 'fr', 'it', 'es'];
-  if (!fs.existsSync(path.join(projectPath, 'Data/Text/Studio'))) {
-    fs.mkdirSync(path.join(projectPath, 'Data/Text/Studio'));
-  }
+  createFolder(path.join(projectPath, 'Data/Text/Studio'));
   saveCSV(projectPath, 200002, languages);
   saveCSV(projectPath, 200003, languages);
   saveCSV(projectPath, 200004, languages, true);
-  if (!fs.existsSync(path.join(projectPath, 'Data/Tiled'))) {
-    fs.mkdirSync(path.join(projectPath, 'Data/Tiled'));
-  }
+
+  createFolder(path.join(projectPath, 'Data/Tiled'));
+  createFolder(path.join(projectPath, 'Data/Tiled/Assets'));
+  createFolder(path.join(projectPath, 'Data/Tiled/Maps'));
+  createFolder(path.join(projectPath, 'Data/Tiled/Tilesets'));
+
   if (fs.existsSync(path.join(projectPath, 'Data/Studio/rmxp_maps.json'))) {
     fs.unlinkSync(path.join(projectPath, 'Data/Studio/rmxp_maps.json'));
   }

--- a/src/views/pages/settings/Settings.maps.page.tsx
+++ b/src/views/pages/settings/Settings.maps.page.tsx
@@ -28,9 +28,10 @@ export const SettingsMapsPage = () => {
   const [tiledPath, setTiledPath] = useState(getSetting('tiledPath'));
   const dialogsRef = useDialogsRef<SettingsEditorAndDeletionKeys>();
   const { t } = useTranslation(['settings', 'settings_maps']);
+  const isWin32 = window.api.platform === 'win32';
 
   const handleFileChoosen = (filePath: string) => {
-    if (basename(filePath).toLowerCase() !== 'tiled.exe') {
+    if (isWin32 && basename(filePath).toLowerCase() !== 'tiled.exe') {
       showNotification('danger', t('settings:map_management'), t('settings_maps:tiled_path_invalid_path_error'));
       return;
     }
@@ -65,8 +66,8 @@ export const SettingsMapsPage = () => {
             {tiledPath ? (
               <FileInput
                 filePath={tiledPath}
-                name={window.api.platform === 'win32' ? t('settings_maps:tiled_exe') : 'Tiled'}
-                extensions={window.api.platform === 'win32' ? ['exe'] : []}
+                name={isWin32 ? t('settings_maps:tiled_exe') : 'Tiled'}
+                extensions={isWin32 ? ['exe'] : ['*']}
                 onFileChoosen={handleFileChoosen}
                 onFileClear={handleFileClear}
                 isAbsolutePath
@@ -74,7 +75,11 @@ export const SettingsMapsPage = () => {
                 noIcon
               />
             ) : (
-              <DropInput name={t('settings_maps:tiled_exe')} extensions={['exe']} onFileChoosen={handleFileChoosen} />
+              <DropInput
+                name={isWin32 ? t('settings_maps:tiled_exe') : 'Tiled'}
+                extensions={isWin32 ? ['exe'] : ['*']}
+                onFileChoosen={handleFileChoosen}
+              />
             )}
             <DownloadMessageContainer>
               {t('settings_maps:download_message')}

--- a/src/views/pages/settings/Settings.maps.page.tsx
+++ b/src/views/pages/settings/Settings.maps.page.tsx
@@ -65,8 +65,8 @@ export const SettingsMapsPage = () => {
             {tiledPath ? (
               <FileInput
                 filePath={tiledPath}
-                name={t('settings_maps:tiled_exe')}
-                extensions={['exe']}
+                name={window.api.platform === 'win32' ? t('settings_maps:tiled_exe') : 'Tiled'}
+                extensions={window.api.platform === 'win32' ? ['exe'] : []}
                 onFileChoosen={handleFileChoosen}
                 onFileClear={handleFileClear}
                 isAbsolutePath


### PR DESCRIPTION
## Description

Fix: The Linux and MacOS users can now select the Tiled path.

## Tests to perform

- [x] Check that the Linux users can select the Tiled Path
- [x] Check that the MacOS users can select the Tiled Path
- [x] Check that the Linux users can open Tiled
- [x] Check that the MacOS users can open Tiled
