### PR TITLE
Fix MacOS distribution

### DIFF
--- a/.github/workflows/production_ci.yml
+++ b/.github/workflows/production_ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest-xlarge]
 
     steps:
       - uses: actions/checkout@v3

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,8 +11,9 @@ import { rendererConfig } from './config/webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     icon: './assets/icon',
-    executableName: process.platform === 'win32' ? undefined : 'pokemon-studio',
+    executableName: process.platform !== 'linux' ? undefined : 'pokemon-studio',
     extraResource: ['new-project.zip', 'psdk-binaries', 'app-update.yml'],
+    name: process.platform === 'darwin' ? "Pokemon Studio" : undefined
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
Apparently having an accent in the app name causes issues when the app gets extracted (zip or dmg). 
Removing them fixes the issue so on MacOS Pokémon Studio will be "Pokemon Studio.app" and show as "Pokemon Studio" in the Dock.