### PR TITLE
Improve the RMXP to Studio maps synchronization service

### DIFF
--- a/src/backendTasks/readRMXPMapInfo.ts
+++ b/src/backendTasks/readRMXPMapInfo.ts
@@ -6,7 +6,7 @@ import { isMarshalHash, isMarshalStandardObject, Marshal } from 'ts-marshal';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 
 export type ReadRMXPMapInfoInput = { projectPath: string };
-export type ReadRMXPMapInfoOutput = { rmxpMapInfo: { id: number; name: string }[] };
+export type ReadRMXPMapInfoOutput = { rmxpMapInfo: { id: number; name: string; parentId: number }[] };
 
 type MapInfoData = {
   '@scroll_x': number;
@@ -41,9 +41,11 @@ export const readRMXPMapInfo = async (mapInfoFilePath: string) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { __class, __extendedModules, __default, ...mapInfos } = marshalData;
   const mapInfoRecords = Object.entries(mapInfos)
-    .map(([id, data]) => (isMapInfoObject(data) ? { id: Number(id), order: data['@order'], name: data['@name'] } : undefined))
+    .map(([id, data]) =>
+      isMapInfoObject(data) ? { id: Number(id), order: data['@order'], name: data['@name'], parentId: data['@parent_id'] } : undefined
+    )
     .filter(<T>(data: T): data is Exclude<T, undefined> => !!data);
-  const rmxpMapData = mapInfoRecords.sort((a, b) => a.order - b.order).map(({ id, name }) => ({ id, name }));
+  const rmxpMapData = mapInfoRecords.sort((a, b) => a.order - b.order).map(({ id, name, parentId }) => ({ id, name, parentId }));
   return rmxpMapData;
 };
 

--- a/src/migrations/baseForMaps.ts
+++ b/src/migrations/baseForMaps.ts
@@ -2,7 +2,7 @@ import { IpcMainEvent } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { stringify } from 'csv-stringify/sync';
-import { StudioMapInfo } from '@modelEntities/mapInfo';
+import { DEFAULT_MAP_INFO } from '@modelEntities/mapInfo';
 
 export const saveCSV = (projectPath: string, fileId: number, languages: string[], noData?: true) => {
   const csvPath = path.join(projectPath, 'Data/Text/Studio', `${fileId}.csv`);
@@ -34,17 +34,6 @@ export const baseForMaps = async (_: IpcMainEvent, projectPath: string) => {
     fs.unlinkSync(path.join(projectPath, 'Data/Studio/rmxp_maps.json'));
   }
   if (!fs.existsSync(path.join(projectPath, 'Data/Studio/map_info.json'))) {
-    const defaultMapInfo: StudioMapInfo = {
-      ['0']: {
-        id: 0,
-        children: [],
-        hasChildren: false,
-        isExpanded: true,
-        data: {
-          klass: 'MapInfoRoot',
-        },
-      },
-    };
-    fs.writeFileSync(path.join(projectPath, 'Data/Studio/map_info.json'), JSON.stringify(defaultMapInfo, null, 2));
+    fs.writeFileSync(path.join(projectPath, 'Data/Studio/map_info.json'), JSON.stringify(DEFAULT_MAP_INFO, null, 2));
   }
 };

--- a/src/models/entities/mapInfo.ts
+++ b/src/models/entities/mapInfo.ts
@@ -39,3 +39,15 @@ export const MAP_INFO_VALIDATOR = z.record(z.string(), MAP_INFO_VALUE_VALIDATOR)
 export type StudioMapInfo = z.infer<typeof MAP_INFO_VALIDATOR>;
 
 export const MAP_INFO_FOLDER_NAME_TEXT_ID = 200004;
+
+export const DEFAULT_MAP_INFO: StudioMapInfo = {
+  ['0']: {
+    id: 0,
+    children: [],
+    hasChildren: false,
+    isExpanded: true,
+    data: {
+      klass: 'MapInfoRoot',
+    },
+  },
+};

--- a/src/utils/useRMXP2StudioMapsUpdate/helpers.ts
+++ b/src/utils/useRMXP2StudioMapsUpdate/helpers.ts
@@ -1,5 +1,7 @@
 import { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { RMXP2StudioMapsUpdateFunctionBinding, RMXP2StudioMapsUpdateStateObject } from './types';
+import { ProjectData } from '@src/GlobalStateProvider';
+import { DbSymbol } from '@modelEntities/dbSymbol';
 
 export const fail = (binding: MutableRefObject<RMXP2StudioMapsUpdateFunctionBinding>, error: unknown) => {
   window.api.log.error('Failed to synchronise maps:', error);
@@ -18,4 +20,10 @@ export const toAsyncProcess = (func: () => void) => {
     func();
   })();
   return () => {};
+};
+
+export const getSelectedMap = (newMaps: ProjectData['maps'], currentSelectedMap: DbSymbol) => {
+  if (newMaps[currentSelectedMap]) return currentSelectedMap;
+
+  return Object.keys(newMaps)[0] || '__undef__';
 };

--- a/src/views/components/world/map/tree/MapTreeComponent.tsx
+++ b/src/views/components/world/map/tree/MapTreeComponent.tsx
@@ -104,7 +104,7 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
             <span
               className="icon collapse-button"
               onClick={(e) => {
-                e.preventDefault();
+                e.stopPropagation();
                 onCollapse(item.id.toString());
               }}
             >
@@ -114,7 +114,7 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
             <span
               className="icon collapse-button collapse-button-collapsed"
               onClick={(e) => {
-                e.preventDefault();
+                e.stopPropagation();
                 onExpand(item.id.toString());
               }}
             >

--- a/src/views/components/world/map/tree/MapTreeComponent.tsx
+++ b/src/views/components/world/map/tree/MapTreeComponent.tsx
@@ -220,9 +220,11 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
           {isFolder && !!countChildren && <span className="count-children">{countChildren}</span>}
           {!canRename && (
             <div className="actions">
-              <span className="icon icon-dot" onClick={openMenu}>
-                <DotIcon />
-              </span>
+              {!isRMXPMode && (
+                <span className="icon icon-dot" onClick={openMenu}>
+                  <DotIcon />
+                </span>
+              )}
               {!isDeleted && !isRMXPMode && currentDepth <= 3 && (
                 <span
                   className="icon icon-plus"

--- a/src/views/components/world/map/tree/MapTreeContextMenu.tsx
+++ b/src/views/components/world/map/tree/MapTreeContextMenu.tsx
@@ -23,7 +23,7 @@ type MapTreeContextMenuProps = {
 
 export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dialogsRef }: MapTreeContextMenuProps) => {
   const { t } = useTranslation('database_maps');
-  const { mapInfo, isRMXPMode, setMapInfo } = useMapInfo();
+  const { mapInfo, setMapInfo } = useMapInfo();
   const { projectDataValues: maps, setProjectDataValues: setMap } = useProjectMaps();
   const setText = useSetProjectText();
   const getName = useGetEntityNameText();
@@ -71,7 +71,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
 
   return (
     <>
-      {!isDeleted && !isRMXPMode && (
+      {!isDeleted && (
         <div onClick={() => enableRename()}>
           <span className="icon">
             <EditIcon />
@@ -79,7 +79,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
           {t('rename')}
         </div>
       )}
-      {!isFolder && !isDeleted && !isRMXPMode && (
+      {!isFolder && !isDeleted && (
         <div onClick={onClickDuplicate}>
           <span className="icon">
             <CopyIcon />
@@ -87,7 +87,7 @@ export const MapTreeContextMenu = ({ mapInfoValue, isDeleted, enableRename, dial
           {t('duplicate')}
         </div>
       )}
-      {!isFolder && !isDeleted && !isRMXPMode && !hideTiledOption && (
+      {!isFolder && !isDeleted && !hideTiledOption && (
         <div onClick={onClickTiled}>
           <span className="icon">
             <MapPaddedIcon />

--- a/src/views/pages/world/Map.page.tsx
+++ b/src/views/pages/world/Map.page.tsx
@@ -62,8 +62,10 @@ export const MapPage = () => {
             </DataBlockWithAction>
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <DataBlockWithAction size="full" title={t('deleting')}>
-              <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deletion', true)}>{t('delete')}</DeleteButtonWithIcon>
+            <DataBlockWithAction size="full" title={t('deleting')} disabled={isRMXPMode}>
+              <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deletion', true)} disabled={isRMXPMode}>
+                {t('delete')}
+              </DeleteButtonWithIcon>
             </DataBlockWithAction>
           </DataBlockWrapper>
           <MapEditorOverlay ref={dialogsRef} />


### PR DESCRIPTION
## Description

This PR improve the RMXP to Studio maps synchronisation service.
The useless maps of Studio are now deleted and the structure of the tree is preserved.
Users can no longer manually delete a map.

## Note before testing

Studio must be in RMXP mode.

## Tests to perform

- [x] Check that the synchronisation works

## Screenshot

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/8d3b14f7-73b2-4b65-9aa9-ed7646ebc92b)