### PR TITLE
Fix: Remove macos-latest-xlarge from production_ci

### DIFF
--- a/.github/workflows/production_ci.yml
+++ b/.github/workflows/production_ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-xlarge]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Remove macos-latest-xlarge from production_ci file.

## Tests to perform

No test, please approuve.
