### PR TITLE
Fix the copyTiledFiles service

### DIFF
--- a/assets/i18n/fr/database_types.json
+++ b/assets/i18n/fr/database_types.json
@@ -23,7 +23,7 @@
   "show_all_pokemon": "Afficher la liste des Pokémon",
   "show_all_moves": "Afficher la liste des attaques",
   "pokemon_with_type": "Pokémon dotés du type {{type}}",
-  "move_with_type": "Attaques dotés du type {{type}}",
+  "move_with_type": "Attaques dotées du type {{type}}",
   "none": "Aucun",
   "deletion": "Suppression",
   "delete_this_type": "Supprimer ce type",

--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -71,7 +71,7 @@ const updateTmxFile = (tiledMap: MapToImport, mapsFolderPath: string, originalTi
   const tilesetSources = resources.tilesetSources;
   tilesetSources.forEach((tileset) => {
     const basename = path.basename(tileset);
-    data = data.replaceAll(tileset, `../Tilesets/${basename}`);
+    data = data.replaceAll(`"${tileset}"`, `"../Tilesets/${basename}"`);
   });
   fs.writeFileSync(tmxFilePath, data);
 };
@@ -91,7 +91,7 @@ const updateTsxFile = (tiledMap: MapToImport, mapsFolderPath: string, tilesetsFo
     let data = fs.readFileSync(tsxFilePath).toString();
     assetSources.forEach((asset) => {
       const basename = path.basename(asset.inTileset);
-      data = data.replaceAll(asset.inTileset, `../Assets/${basename}`);
+      data = data.replaceAll(`"${asset.inTileset}"`, `"../Assets/${basename}"`);
     });
     fs.writeFileSync(tsxFilePath, data);
   });
@@ -132,6 +132,8 @@ const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
 
   await tiledMaps.reduce(async (lastPromise, tiledMap, currentIndex) => {
     await lastPromise;
+
+    log.info('copy-tiled-files/process', tiledMap.path);
     copyTmxFile(tiledMap, mapsFolderPath, payload.tiledSrcPath);
     copyTsxFile(tiledMap, tilesetsFolderPath, payload.tiledSrcPath);
     copyAssetFile(tiledMap, assetsFolderPath, payload.tiledSrcPath);


### PR DESCRIPTION
## Description

When we edit a tmx file to update the tileset paths, we look for occurrences. For example, if there are `interieur.tsx` and `new_interieur.tsx` in the tmx file, `interieur.tsx` is replaced by the correct path and a piece of `new_interieur.tsx` becomes `new_/path` and it's not the behavior expected.
This PR fixes this issue by improving the occurrence search.

## Note before testing

Create a new project in Tiled mode and use this archive:
https://discord.com/channels/143824995867557888/1195452737706532915/1195492549926850741

## Tests to perform

- [x] Check that MapImport works
