### PR TITLE
Fix: Error while loading project if the user has some custom CSV named 200005.csv or more in the Text/Dialogs folder

### DIFF
--- a/src/backendTasks/readProjectTexts.ts
+++ b/src/backendTasks/readProjectTexts.ts
@@ -2,7 +2,7 @@ import type { IpcMainEvent } from 'electron';
 import log from 'electron-log';
 import path from 'path';
 import { ProjectText } from '@src/GlobalStateProvider';
-import { getTextFileList, loadCSV } from '@utils/textManagement';
+import { checkTextFileReserved, getTextFileList, getTextPath, loadCSV } from '@utils/textManagement';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 import { ChannelNames, sendProgress } from '@utils/BackendTask';
 
@@ -12,10 +12,15 @@ const readProjectTexts = async (payload: ReadProjectTextInput, event: IpcMainEve
   log.info('read-project-texts');
 
   const textFileList = getTextFileList(payload.path, true);
+  const reservedFileUsed = await checkTextFileReserved(textFileList, payload.path);
+  if (reservedFileUsed) {
+    throw 'A reserved text file has been found in Data/Text/Dialogs. The range 200.000 to 299.999 is reserved for the application and must not be used.';
+  }
+
   const projectTexts = await textFileList.reduce(async (prev, curr, index) => {
     const previousResult = await prev;
     sendProgress(event, channels, { step: index + 1, total: textFileList.length, stepText: `${curr}.csv` });
-    const currentText = await loadCSV(path.join(payload.path, curr >= 200000 ? `Data/Text/Studio/${curr}` : `Data/Text/Dialogs/${curr}`));
+    const currentText = await loadCSV(path.join(payload.path, getTextPath(curr), `${curr}.csv`));
     return { ...previousResult, [curr]: currentText };
   }, Promise.resolve({} as ProjectText));
 

--- a/src/backendTasks/saveProjectTexts.ts
+++ b/src/backendTasks/saveProjectTexts.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { stringify } from 'csv-stringify/sync';
 import { SavingText } from '@utils/SavingUtils';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import { getTextPath } from '@utils/textManagement';
 
 export type SaveProjectTextsInput = { path: string; texts: SavingText };
 
@@ -12,7 +13,7 @@ const saveProjectTexts = async (payload: SaveProjectTextsInput) => {
   return Promise.all(
     payload.texts.map(async (sd) => {
       const file = Number(sd.savingFilename);
-      const filePath = path.join(payload.path, file >= 200000 ? 'Data/Text/Studio' : 'Data/Text/Dialogs', file.toString() + '.csv');
+      const filePath = path.join(payload.path, getTextPath(file), file.toString() + '.csv');
       if (sd.savingAction === 'DELETE' && fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
       } else if (sd.data !== undefined) {

--- a/src/backendTasks/updateTextInfos.ts
+++ b/src/backendTasks/updateTextInfos.ts
@@ -96,8 +96,8 @@ export const updateTextInfos = async (payload: UpdateTextInfosInput) => {
       textId >= descriptions.length ? descriptions.push(newDescriptions) : (descriptions[textId] = newDescriptions);
       return newTextInfo.textInfo;
     });
-    saveCSV(payload.projectPath, 200000, names);
-    saveCSV(payload.projectPath, 200001, descriptions);
+    saveCSV(payload.projectPath, TEXT_INFO_NAME_TEXT_ID, names);
+    saveCSV(payload.projectPath, TEXT_INFO_DESCRIPTION_TEXT_ID, descriptions);
     fs.writeFileSync(path.join(payload.projectPath, TEXT_INFOS_PATH), JSON.stringify(textInfosUpdated, null, 2));
     log.info('update-text-infos/success', 'updated file');
     return {};
@@ -114,8 +114,8 @@ export const updateTextInfos = async (payload: UpdateTextInfosInput) => {
       return { fileId: textInfo.textInfo.fileId, textId: textInfo.textInfo.textId, klass: textInfo.textInfo.klass };
     });
     fs.writeFileSync(path.join(payload.projectPath, TEXT_INFOS_PATH), JSON.stringify(textInfos, null, 2));
-    saveCSV(payload.projectPath, 200000, names, languages);
-    saveCSV(payload.projectPath, 200001, descriptions, languages);
+    saveCSV(payload.projectPath, TEXT_INFO_NAME_TEXT_ID, names, languages);
+    saveCSV(payload.projectPath, TEXT_INFO_DESCRIPTION_TEXT_ID, descriptions, languages);
     log.info('update-text-infos/success', 'file created');
     return {};
   }

--- a/src/utils/textManagement.ts
+++ b/src/utils/textManagement.ts
@@ -49,3 +49,22 @@ export const addLineCSV = (newLine: string[], lineIndex: number, startId: number
     csvData[lineIndex] = newLine;
   }
 };
+
+const isInRangeStudioText = (id: number) => id >= 200_000 && id < 300_000;
+
+export const getTextPath = (id: number) => (isInRangeStudioText(id) ? 'Data/Text/Studio' : 'Data/Text/Dialogs');
+
+/**
+ * Check if 2xxxxx.csv files exist in Data/Text/Dialogs
+ * @param textFileList The list of id of the text files
+ * @param projectPath The path of the project
+ * @returns True if 2xxxxx.csv files exist in Data/Text/Dialogs
+ */
+export const checkTextFileReserved = (textFileList: number[], projectPath: string) => {
+  const textFileListFiltered = textFileList.filter(isInRangeStudioText);
+  const dialogsPath = path.join(projectPath, 'Data/Text/Dialogs');
+  return textFileListFiltered.reduce(async (prev, curr) => {
+    const prevResult = await prev;
+    return prevResult || fs.existsSync(path.join(dialogsPath, `${curr}.csv`));
+  }, Promise.resolve(false));
+};


### PR DESCRIPTION
## Description

This PR fixes an issue in the loading projet if the user has some custom CSV named 200005 csv or more in the Text/Dialogs folder. (issue: https://github.com/PokemonWorkshop/PokemonStudio/issues/156) 

Now, if a csv between 200000 and 299999 is found in the Text/Dialogs folder, an error message is show in the project loading.
The files +300000 can be used.

Note: The error message can't be translated because it comes from backend.

## Tests to perform

- [ ] Check that the texts load
- [ ] Check that the texts save
- [ ] Add a file 200005.csv in the Text/Dialogs folder: the error message must be appear
- [ ] Add a file 300000.csv in the Text/Dialogs folder: the project must open correctly

## Screenshots

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/7cad203d-885e-4c52-8a78-25d5397183a5)