### PR TITLE
Fix wrong data refresh in the DexPokemonListTable component

### DIFF
--- a/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
+++ b/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
@@ -29,7 +29,7 @@ type DexPokemonListImportEditorProps = {
 };
 
 export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPokemonListImportEditorProps>(({ closeDialog }, ref) => {
-  const { projectDataValues: allDex, setProjectDataValues: setDex } = useProjectDex();
+  const { projectDataValues: allDex, setProjectDataValues: setDex, selectedDataIdentifier: currentDex } = useProjectDex();
   const { t } = useTranslation('database_dex');
   const { dex } = useDexPage();
   const firstDbSymbol = Object.entries(allDex)
@@ -53,7 +53,12 @@ export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPok
           <DexImportInfo>{t('import_info')}</DexImportInfo>
           <InputWithTopLabelContainer>
             <Label>{t('import_list_dex')}</Label>
-            <SelectDex dbSymbol={selectedDexImport} onChange={(selected) => setSelectedDexImport(selected)} noLabel />
+            <SelectDex
+              dbSymbol={selectedDexImport}
+              onChange={(selected) => setSelectedDexImport(selected)}
+              filter={(dbSymbol) => dbSymbol !== currentDex}
+              noLabel
+            />
           </InputWithTopLabelContainer>
         </InputContainer>
         <ButtonContainer>

--- a/src/views/components/database/dex/table/DexPokemonListTable.tsx
+++ b/src/views/components/database/dex/table/DexPokemonListTable.tsx
@@ -37,7 +37,8 @@ export const DexPokemonListTable = ({ dex, dialogsRef, setCreatureIndex }: DexPo
   const { t } = useTranslation(['database_dex', 'database_pokemon', 'database_types']);
   const [dragOn, setDragOn] = useState(false);
   const [scrollToRow, setScrollToRow] = useState<number | undefined>(undefined);
-  const currentEditedDex = useMemo(() => cloneEntity(dex), [dex]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const currentEditedDex = useMemo(() => cloneEntity(dex), [dex, dex.creatures]);
 
   useMemo(() => {
     setScrollToRow(0);

--- a/src/views/components/database/dex/table/RenderPokemon.tsx
+++ b/src/views/components/database/dex/table/RenderPokemon.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import theme from '@src/AppTheme';
 import { useTranslation } from 'react-i18next';
@@ -157,7 +157,7 @@ type RenderPokemonProps = {
   setCreatureIndex: (index: number) => void;
 };
 
-export const RenderPokemon = React.forwardRef<HTMLInputElement, RenderPokemonProps>(
+export const RenderPokemon = forwardRef<HTMLInputElement, RenderPokemonProps>(
   ({ style, pokemon, provided, isDragging, dragOn, index, dex, dialogsRef, setScrollToRow, setCreatureIndex }, ref) => {
     const { projectDataValues: types } = useProjectTypes();
     const { projectDataValues: allPokemon } = useProjectPokemon();

--- a/src/views/components/selects/SelectDex.tsx
+++ b/src/views/components/selects/SelectDex.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectOptions } from '@utils/useSelectOptions';
-import { StudioDropDown } from '@components/StudioDropDown';
+import { StudioDropDown, StudioDropDownFilter } from '@components/StudioDropDown';
 import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 
 type SelectDexProps = {
@@ -10,9 +10,10 @@ type SelectDexProps = {
   undefValueOption?: string;
   noLabel?: boolean;
   noneValue?: boolean;
+  filter?: StudioDropDownFilter;
 };
 
-export const SelectDex = ({ dbSymbol, onChange, noLabel, noneValue, undefValueOption }: SelectDexProps) => {
+export const SelectDex = ({ dbSymbol, onChange, noLabel, noneValue, undefValueOption, filter }: SelectDexProps) => {
   const { t } = useTranslation(['database_dex', 'select']);
   const dexOptions = useSelectOptions('dex');
   const options = useMemo(() => {
@@ -20,8 +21,8 @@ export const SelectDex = ({ dbSymbol, onChange, noLabel, noneValue, undefValueOp
     if (noneValue) return [{ value: '__undef__', label: t('select:none') }, ...dexOptions];
     return dexOptions;
   }, [dexOptions, undefValueOption, noneValue]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const optionals = useMemo(() => ({ deletedOption: t('database_dex:dex_deleted') }), []);
+
+  const optionals = { deletedOption: t('database_dex:dex_deleted'), filter };
 
   if (noLabel) return <StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />;
 


### PR DESCRIPTION
## Description

Issue: When the user import a dex and delete a Pokémon, all the Pokémon are deleted. https://github.com/PokemonWorkshop/PokemonStudio/issues/162
This bug is due to an incorrect data refresh in the DexPokemonListTable component. It's fixed.

Another change is that it is now impossible for a Pokédex to import itself.

## Tests to perform

- [x] Import a list of the Pokémon and delete a Pokémon.
- [x] Import a list of the Pokémon and test the other actions.
