### PR TITLE
Fix a softlock and the add evolution button in the evolution edition modal

### DIFF
--- a/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
@@ -47,7 +47,7 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
   });
 
   const inputValidityEnsured = () => {
-    if (state.evolveTo === '__undef__' && evolutionIndex !== 0) return false;
+    if (state.evolveTo === '__undef__' && evolutionIndex !== 0 && !state.isMega) return false;
     if (areConditionValid()) return true;
     Object.values(inputRefs.current).forEach((input) => input && (!input.validity.valid || input.validity.valueMissing) && input.focus());
     return false;
@@ -136,7 +136,7 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
           </SubEditorTopButtonContainer>
           <SubEditorSeparator parentEditorHasScrollBar />
           <Editor type="creation" title={t('additionalEvolution')}>
-            <SecondaryButtonWithPlusIcon onClick={onAddEvolution} disabled={state.evolveTo === '__undef__'}>
+            <SecondaryButtonWithPlusIcon onClick={onAddEvolution} disabled={state.evolveTo === '__undef__' && !state.isMega}>
               {t('addNewEvolution')}
             </SecondaryButtonWithPlusIcon>
           </Editor>


### PR DESCRIPTION
[See the Discord topic](https://discord.com/channels/143824995867557888/1195789493068894359)
### Steps to reproduce
- Open the Pokémon UI
- Search for Absol
- Click on the Evolution block to open the edition modal
- Check the `Add an evolution` button (it's possible to add now)

## 2 - Soft lock during the evolution edition
### Context
When the user try to edit the second evolution of a Pokémon with two Mega Evolutions, there is a soft lock on the evolution edition modal.

[See the Discord topic](https://discord.com/channels/143824995867557888/1195770702612148254)
### Steps to reproduce
- Create a new projet
- Open the Pokémon UI
- Search for Charizard
- Click on the Evolution block to open the edition modal
- Go to the second Mega Evolution
- There is not a soft lock anymore