### PR TITLE
Fix: The translation UI that crash if only one language is in the CSV

### DIFF
--- a/src/utils/usePage.ts
+++ b/src/utils/usePage.ts
@@ -47,10 +47,11 @@ export const useCreaturePage = () => {
 };
 
 export const useTextPage = () => {
-  const { currentTextInfo } = useTextInfosReadonly();
+  const { currentTextInfo, state } = useTextInfosReadonly();
   return {
     textInfo: currentTextInfo,
     cannotDelete: currentTextInfo.fileId >= 8997,
+    disabledTranslation: state.projectConfig.language_config.choosableLanguageCode.length <= 1,
   };
 };
 

--- a/src/utils/useProjectSavingLanguage.ts
+++ b/src/utils/useProjectSavingLanguage.ts
@@ -1,8 +1,29 @@
-import { useGlobalState } from '@src/GlobalStateProvider';
+import { ProjectText, useGlobalState } from '@src/GlobalStateProvider';
 
 export const useProjectSavingLanguage = () => {
   const [state, setState] = useGlobalState();
   const setProjectSavingLanguage = (savingLanguage: string[]) => setState({ ...state, savingLanguage: savingLanguage });
+  const addNewLanguageProjectText = (languageCode: string) => {
+    const projectText: [string, string[][]][] = Object.entries(state.projectText);
+    projectText.forEach(([, projectTextValue]) => {
+      const hasLanguage = projectTextValue[0]?.find((header) => header === languageCode);
+      if (!hasLanguage) {
+        projectTextValue.forEach((line, index) => {
+          if (index === 0) {
+            return line.push(languageCode);
+          }
+          line.push('');
+        });
+      }
+    });
+    setState((state) => ({
+      ...state,
+      projectText: projectText.reduce((prev, [key, value]) => {
+        prev[Number(key)] = value;
+        return prev;
+      }, {} as ProjectText),
+    }));
+  };
 
-  return { savingLanguage: state.savingLanguage, setSavingLanguage: setProjectSavingLanguage };
+  return { savingLanguage: state.savingLanguage, setSavingLanguage: setProjectSavingLanguage, addNewLanguageProjectText };
 };

--- a/src/views/components/dashboard/editors/DashboardLanguageNewEditor.tsx
+++ b/src/views/components/dashboard/editors/DashboardLanguageNewEditor.tsx
@@ -42,7 +42,7 @@ export const DashboardLanguageNewEditor = ({ defaultValue, onClose, onCloseNew }
   const { projectConfigValues: gameOption, setProjectConfigValues: setGameOption } = useConfigGameOptions();
   const [languageText, setLanguageText] = useState<LanguageDefaultValue>(defaultValue);
   const { t } = useTranslation('dashboard_language');
-  const { savingLanguage, setSavingLanguage } = useProjectSavingLanguage();
+  const { savingLanguage, setSavingLanguage, addNewLanguageProjectText } = useProjectSavingLanguage();
 
   const onClickNew = () => {
     const currentEditedLanguage = cloneEntity(language);
@@ -55,6 +55,7 @@ export const DashboardLanguageNewEditor = ({ defaultValue, onClose, onCloseNew }
     setSavingLanguage([...savingLanguage, languageText.code]);
     setLanguage(currentEditedLanguage);
     setGameOption(currentEditedGameOption);
+    addNewLanguageProjectText(languageText.code);
     onCloseNew();
   };
 

--- a/src/views/components/database/DatabaseTabsBar.tsx
+++ b/src/views/components/database/DatabaseTabsBar.tsx
@@ -92,7 +92,7 @@ export const DatabaseTabsBar = ({ currentTabIndex, tabs }: DatabaseTabBarProps) 
         <React.Fragment key={`database-tab-${index}`}>
           <TabContainer
             className={currentTabIndex === index ? 'current-tab' : undefined}
-            onClick={() => tab.disabled ?? navigate(tab.path)}
+            onClick={() => tab.disabled || navigate(tab.path)}
             disabled={tab.disabled}
           >
             <span>{tab.label}</span>

--- a/src/views/components/textmanagement/TextList.tsx
+++ b/src/views/components/textmanagement/TextList.tsx
@@ -16,9 +16,10 @@ const getHeight = (length: number) => (length > 8 ? 408 : length * 48);
 
 type TextListProps = {
   dialogsRef: TextDialogsRef;
+  disabledTranslation: boolean;
 };
 
-export const TextList = ({ dialogsRef }: TextListProps) => {
+export const TextList = ({ dialogsRef, disabledTranslation }: TextListProps) => {
   const { t } = useTranslation('text_management');
   const [research, setResearch] = useState<string>('');
   const [scrollToEnd, setScrollToEnd] = useState<boolean>(false);
@@ -110,6 +111,7 @@ export const TextList = ({ dialogsRef }: TextListProps) => {
                                 },
                               });
                             }}
+                            disabled={disabledTranslation}
                           >
                             <TranslationIcon />
                           </DarkButton>

--- a/src/views/pages/texts/BaseTexts.page.tsx
+++ b/src/views/pages/texts/BaseTexts.page.tsx
@@ -11,6 +11,7 @@ import { useDialogsRef } from '@utils/useDialogsRef';
 import { TextEditorAndDeletionKeys, TextEditorOverlay } from '@components/textmanagement/editors/TextEditorOverlay';
 import { DatabaseTabsBar } from '@components/database/DatabaseTabsBar';
 import styled from 'styled-components';
+import { useTextPage } from '@utils/usePage';
 
 const TextsPageContainerStyle = styled(PageContainerStyle)`
   @media ${(props) => props.theme.breakpoints.smallScreen} {
@@ -22,6 +23,7 @@ const TextsPageContainerStyle = styled(PageContainerStyle)`
 export const BaseTextsPage = () => {
   const dialogsRef = useDialogsRef<TextEditorAndDeletionKeys>();
   const { t } = useTranslation('text_management');
+  const { disabledTranslation } = useTextPage();
   const location = useLocation();
 
   return (
@@ -34,7 +36,7 @@ export const BaseTextsPage = () => {
               currentTabIndex={location.pathname === '/texts' ? 0 : 1}
               tabs={[
                 { label: t('texts'), path: '/texts' },
-                { label: t('translation'), path: '/texts/translation' },
+                { label: t('translation'), path: '/texts/translation', disabled: disabledTranslation },
               ]}
             />
           </DataBlockWrapper>

--- a/src/views/pages/texts/Texts.page.tsx
+++ b/src/views/pages/texts/Texts.page.tsx
@@ -11,14 +11,13 @@ import { useTextPage } from '@utils/usePage';
 
 export const TextsPage = () => {
   const dialogsRef: TextDialogsRef = useOutletContext();
-
-  const { textInfo, cannotDelete } = useTextPage();
+  const { textInfo, cannotDelete, disabledTranslation } = useTextPage();
   const { t } = useTranslation('text_management');
 
   return (
     <DataBlockWrapper>
       <TextFrame textInfo={textInfo} dialogsRef={dialogsRef} />
-      <TextList dialogsRef={dialogsRef} />
+      <TextList dialogsRef={dialogsRef} disabledTranslation={disabledTranslation} />
       <DataBlockWithAction size="full" title={t('deleting')}>
         <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deletion', true)} disabled={cannotDelete}>
           {t('delete')}


### PR DESCRIPTION
## Description

This PR fixes a crash in the translation UI if only one language is in the CSV.
Now, the translation cannot be use if one language is set in the project. When the user add a language, the language is added in all texts.

## Note before testing

Create a new project with one language. Add a new file text.

## Tests to perform

- [x] Check that the translation is disabled
- [x] Add a new language and test if the translation works
