### PR TITLE
Fixing rareness for a trainer's pokemon

### DIFF
--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -68,6 +68,9 @@ const buildExpandPokemonSetup = (set: PokemonSet, from: string) => {
     setupFields.push({ type: 'ivs', value: formatStats(set.ivs, 31) });
     setupFields.push({ type: 'loyalty', value: set.happiness ?? 70 });
     setupFields.push({ type: 'originalTrainerId', value: 0 });
+
+    const rarenessField = setupFields.find((field) => field.type === 'rareness');
+    if (rarenessField) rarenessField.value = 0;
   }
 
   return setupFields.filter((field) => field.value !== undefined);


### PR DESCRIPTION
### Steps to reproduce
- Step One: Make a trainer.
- Step Two: Import a team from Showdown.
- Step Three: Save, close, and re-open Studio.

```
Articuno @ Leftovers  
Ability: Pressure  
EVs: 252 HP / 252 SpA / 4 SpD  
Modest Nature  
IVs: 30 SpA / 30 SpD  
- Ice Beam  
- Hurricane  
- Substitute  
- Roost  

Ludicolo @ Life Orb  
Ability: Swift Swim  
EVs: 4 HP / 252 SpA / 252 Spe  
Modest Nature  
- Surf  
- Giga Drain  
- Ice Beam  
- Rain Dance  

Volbeat (M) @ Damp Rock  
Ability: Prankster  
EVs: 248 HP / 252 Def / 8 SpD  
Bold Nature  
- Tail Glow  
- Baton Pass  
- Encore  
- Rain Dance  

Seismitoad @ Life Orb  
Ability: Swift Swim  
EVs: 252 SpA / 4 SpD / 252 Spe  
Modest Nature  
- Hydro Pump  
- Earth Power  
- Stealth Rock  
- Rain Dance  

Alomomola @ Damp Rock  
Ability: Regenerator  
EVs: 252 HP / 252 Def / 4 SpD  
Bold Nature  
- Wish  
- Protect  
- Toxic  
- Rain Dance  

Armaldo @ Leftovers  
Ability: Swift Swim  
EVs: 128 HP / 252 Atk / 4 Def / 124 Spe  
Adamant Nature  
- X-Scissor  
- Stone Edge  
- Aqua Tail  
- Rapid Spin
```