### PR TITLE
Hide the form input when we choose a Mega Evolution in the evolution …

### DIFF
--- a/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
@@ -47,7 +47,7 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
   });
 
   const inputValidityEnsured = () => {
-    if (state.evolveTo === '__undef__' && evolutionIndex !== 0 && !state.isMega) return false;
+    if (state.evolveTo === '__undef__' && !state.isMega && evolutionIndex !== 0) return false;
     if (areConditionValid()) return true;
     Object.values(inputRefs.current).forEach((input) => input && (!input.validity.valid || input.validity.valueMissing) && input.focus());
     return false;
@@ -106,7 +106,7 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
                 />
               )}
             </InputWithTopLabelContainer>
-            {state.evolveTo !== '__undef__' && creatures[state.evolveTo]?.forms.length > 1 && (
+            {state.evolveTo !== '__undef__' && !state.isMega && creatures[state.evolveTo]?.forms.length > 1 && (
               <InputWithTopLabelContainer>
                 <Label>{t('form')}</Label>
                 <SelectPokemonForm


### PR DESCRIPTION
### Steps to reproduce
- Choosing a pokémon
- Adding an evolution with a pokemon with a form
- Add a form
- If we give it mega-evolution, the form input disappears