### PR TITLE
Fix: Block MapTree context menu from opening in RMXP mode

### DIFF
--- a/src/views/components/world/map/tree/MapTreeComponent.tsx
+++ b/src/views/components/world/map/tree/MapTreeComponent.tsx
@@ -174,6 +174,8 @@ export const MapTreeComponent = ({ treeScrollbarRef }: MapTreeComponentProps) =>
     const openMenu = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
       event.preventDefault();
       event.stopPropagation();
+      if (isRMXPMode) return;
+
       setMapInfoSelected(mapInfo[item.id]);
       // timeout to wait that the mapinfo selected has been taken into account
       setTimeout(() => buildOnClick(event, true));


### PR DESCRIPTION
## Description

This PR blocks MapTree context menu from opening in RMXP mode

## Note before testing

The project must be in rxmp mode.

## Tests to perform

- [ ] The user can not open the context menu with the right click in the map tree
