### PR TITLE
UI: Add map page empty state

### DIFF
--- a/assets/i18n/en/database_maps.json
+++ b/assets/i18n/en/database_maps.json
@@ -72,5 +72,8 @@
   "message_config_open_tiled_error": "The Tiled installation path has not been configured.",
   "message_open_tiled_error": "An error has occurred while opening Tiled.",
   "close": "Close",
-  "configure_tiled_path": "Configure installation path"
+  "configure_tiled_path": "Configure installation path",
+  "title_empty_state": "Start creating a map!",
+  "description_empty_state": "You don't have any map yet. You can create a new map or import existing ones.",
+  "helper_empty_state": "If you have an existing Tiled project, you need to import all your maps first."
 }

--- a/assets/i18n/en/database_maps.json
+++ b/assets/i18n/en/database_maps.json
@@ -45,7 +45,7 @@
   "deletion_folder_of": "Deleting the folder",
   "deletion_folder_message": "You are about to permanently delete the folder «\u00a0{{folder}}\u00a0» and all the maps it contains.",
   "import_tiled_maps": "Import Tiled maps",
-  "import": "Import",
+  "import": "Import maps",
   "import_select_folder": "Select the folder containing the maps to import",
   "import_select_maps": "Select the files to import",
   "import_error": "Some maps cannot be imported.",

--- a/assets/i18n/fr/database_maps.json
+++ b/assets/i18n/fr/database_maps.json
@@ -45,7 +45,7 @@
   "deletion_folder_of": "Suppression du dossier",
   "deletion_folder_message": "Vous êtes sur le point de supprimer définitivement le dossier «\u00a0{{folder}}\u00a0» et toutes les cartes qu'il contient.",
   "import_tiled_maps": "Importer des cartes Tiled",
-  "import": "Importer",
+  "import": "Importer des cartes",
   "import_select_folder": "Sélectionnez le dossier contenant les cartes à importer",
   "import_select_maps": "Sélectionnez les fichiers à importer",
   "import_error": "Certaines cartes ne peuvent pas être importées.",

--- a/assets/i18n/fr/database_maps.json
+++ b/assets/i18n/fr/database_maps.json
@@ -72,5 +72,8 @@
   "message_config_open_tiled_error": "Le chemin d'installation de Tiled n'a pas été configuré.",
   "message_open_tiled_error": "Une erreur est survenue lors de l'ouverture de Tiled.",
   "close": "Fermer",
-  "configure_tiled_path": "Configurer le chemin d'installation"
+  "configure_tiled_path": "Configurer le chemin d'installation",
+  "title_empty_state": "Commencez à créer une carte !",
+  "description_empty_state": "Vous n'avez pas encore de carte. Vous pouvez créer une nouvelle carte ou importer des cartes existantes.",
+  "helper_empty_state": "Si vous avez un projet Tiled existant, vous devez d'abord importer toutes vos cartes."
 }

--- a/src/views/components/pages/PageEmptyState.tsx
+++ b/src/views/components/pages/PageEmptyState.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+const PageEmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 360px;
+  gap: 32px;
+  user-select: none;
+
+  .icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 80px;
+    height: 80px;
+    border-radius: 100%;
+    background-color: ${({ theme }) => theme.colors.dark18};
+
+    svg {
+      color: ${({ theme }) => theme.colors.text400};
+      width: 36px;
+      height: 36px;
+    }
+  }
+
+  .title-description {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: ${({ theme }) => theme.colors.text100};
+
+    .title {
+      text-align: center;
+      ${({ theme }) => theme.fonts.titlesHeadline4}
+    }
+
+    .description {
+      text-align: center;
+      color: ${({ theme }) => theme.fonts.normalRegular};
+    }
+  }
+`;
+
+type PageEmptyStateProps = {
+  title: string;
+  icon: ReactNode;
+  description: string;
+  children: ReactNode;
+};
+
+export const PageEmptyState = ({ title, icon, description, children }: PageEmptyStateProps) => {
+  return (
+    <PageEmptyStateContainer>
+      <div className="icon">{icon}</div>
+      <div className="title-description">
+        <span className="title">{title}</span>
+        <span className="description">{description}</span>
+      </div>
+      {children}
+    </PageEmptyStateContainer>
+  );
+};

--- a/src/views/components/pages/index.tsx
+++ b/src/views/components/pages/index.tsx
@@ -4,3 +4,4 @@ export { PageTemplate } from './PageTemplate';
 export { SubPageTitle } from './SubPageTitle';
 export { SubPageTitleWithIcon } from './SubPageTitleWithIcon';
 export { PageEditor } from './PageEditor';
+export { PageEmptyState } from './PageEmptyState';

--- a/src/views/components/world/map/MapEmptyState.tsx
+++ b/src/views/components/world/map/MapEmptyState.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { PageEmptyState } from '@components/pages';
+import { useTranslation } from 'react-i18next';
+import { ReactComponent as MapIcon } from '@assets/icons/navigation/map-icon.svg';
+import { MapDialogsRef } from './editors/MapEditorOverlay';
+import { PrimaryButton, SecondaryButton } from '@components/buttons';
+import { useDialogsRef } from '@utils/useDialogsRef';
+import { MapImportEditorTitle, MapImportOverlay } from './editors/MapImport/MapImportOverlay';
+import styled from 'styled-components';
+
+const MapEmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+
+  .helper {
+    text-align: center;
+    ${({ theme }) => theme.fonts.normalSmall}
+    color: ${({ theme }) => theme.colors.text400};
+  }
+
+  ${PrimaryButton},
+  ${SecondaryButton} {
+    width: 100%;
+  }
+`;
+
+type MapEmptyStateProps = {
+  dialogsRef: MapDialogsRef;
+};
+
+export const MapEmptyState = ({ dialogsRef }: MapEmptyStateProps) => {
+  const { t } = useTranslation('database_maps');
+  const dialogsMapImportRef = useDialogsRef<MapImportEditorTitle>();
+
+  return (
+    <PageEmptyState title={t('title_empty_state')} icon={<MapIcon />} description={t('description_empty_state')}>
+      <MapEmptyStateContainer>
+        <PrimaryButton onClick={() => dialogsRef.current?.openDialog('new')}>{t('new')}</PrimaryButton>
+        <SecondaryButton onClick={() => dialogsMapImportRef.current?.openDialog('import', true)}>{t('import')}</SecondaryButton>
+        <span className="helper">{t('helper_empty_state')}</span>
+      </MapEmptyStateContainer>
+      <MapImportOverlay ref={dialogsMapImportRef} closeParentDialog={() => {}} />
+    </PageEmptyState>
+  );
+};

--- a/src/views/components/world/map/MapEmptyState.tsx
+++ b/src/views/components/world/map/MapEmptyState.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ReactComponent as MapIcon } from '@assets/icons/navigation/map-icon.svg';
 import { MapDialogsRef } from './editors/MapEditorOverlay';
 import { PrimaryButton, SecondaryButton } from '@components/buttons';
-import { useDialogsRef } from '@utils/useDialogsRef';
-import { MapImportEditorTitle, MapImportOverlay } from './editors/MapImport/MapImportOverlay';
+import { MapImportDialogsRef } from './editors/MapImport/MapImportOverlay';
 import styled from 'styled-components';
 
 const MapEmptyStateContainer = styled.div`
@@ -30,11 +29,11 @@ const MapEmptyStateContainer = styled.div`
 
 type MapEmptyStateProps = {
   dialogsRef: MapDialogsRef;
+  dialogsMapImportRef: MapImportDialogsRef;
 };
 
-export const MapEmptyState = ({ dialogsRef }: MapEmptyStateProps) => {
+export const MapEmptyState = ({ dialogsRef, dialogsMapImportRef }: MapEmptyStateProps) => {
   const { t } = useTranslation('database_maps');
-  const dialogsMapImportRef = useDialogsRef<MapImportEditorTitle>();
 
   return (
     <PageEmptyState title={t('title_empty_state')} icon={<MapIcon />} description={t('description_empty_state')}>
@@ -43,7 +42,6 @@ export const MapEmptyState = ({ dialogsRef }: MapEmptyStateProps) => {
         <SecondaryButton onClick={() => dialogsMapImportRef.current?.openDialog('import', true)}>{t('import')}</SecondaryButton>
         <span className="helper">{t('helper_empty_state')}</span>
       </MapEmptyStateContainer>
-      <MapImportOverlay ref={dialogsMapImportRef} closeParentDialog={() => {}} />
     </PageEmptyState>
   );
 };

--- a/src/views/components/world/map/editors/MapImport/MapImportOverlay.tsx
+++ b/src/views/components/world/map/editors/MapImport/MapImportOverlay.tsx
@@ -2,8 +2,11 @@ import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import React from 'react';
 import { MapImport } from './MapImport';
+import { DialogRefData } from '@utils/useDialogsRef';
 
 export type MapImportEditorTitle = 'import';
+export type MapImportDialogsRef = React.RefObject<DialogRefData<MapImportEditorTitle>>;
+
 type MapImportOverlayProps = {
   closeParentDialog: () => void;
 };

--- a/src/views/components/world/map/index.tsx
+++ b/src/views/components/world/map/index.tsx
@@ -4,3 +4,4 @@ export { MapMenu } from './MapMenu';
 export { MapUpdate } from './MapUpdate';
 export { MapBreadcrumb } from './MapBreadcrumb';
 export { MapRMXP2StudioUpdate } from './MapRMXP2StudioUpdate';
+export { MapEmptyState } from './MapEmptyState';

--- a/src/views/pages/world/Map.page.tsx
+++ b/src/views/pages/world/Map.page.tsx
@@ -9,7 +9,7 @@ import { useDialogsRef } from '@utils/useDialogsRef';
 import { useMapPage } from '@utils/usePage';
 import { MapEditorOverlay } from '@components/world/map/editors';
 import { MapEditorAndDeletionKeys } from '@components/world/map/editors/MapEditorOverlay';
-import { MapBreadcrumb, MapFrame, MapMusics, MapRMXP2StudioUpdate, MapUpdate } from '@components/world/map';
+import { MapBreadcrumb, MapEmptyState, MapFrame, MapMusics, MapRMXP2StudioUpdate, MapUpdate } from '@components/world/map';
 import { DeleteButtonWithIcon, SecondaryButton } from '@components/buttons';
 import { BaseIcon } from '@components/icons/BaseIcon';
 import theme from '@src/AppTheme';
@@ -32,47 +32,49 @@ export const MapPage = () => {
   const { t } = useTranslation('database_maps');
   const { t: tSub } = useTranslation('submenu_database');
 
-  return hasMap ? (
+  return (
     <MapPageStyle>
-      <PageContainerStyle>
-        <PageDataConstrainerStyle>
-          <DataBlockWrapper>
-            <MapBreadcrumb />
-            {/** The component is commented on because it's currently useless */}
-            {/*<DatabaseTabsBar
-              currentTabIndex={0}
-              tabs={[
-                { label: t('data'), path: '/world/map' },
-                { label: t('map'), path: '/world/map/view', disabled: true },
-              ]}
-            />*/}
-            {hasMapModified && <MapUpdate />}
-            {isRMXPMode && <MapRMXP2StudioUpdate />}
-          </DataBlockWrapper>
-          <DataBlockWrapper>
-            <MapFrame map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
-            <MapMusics map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
-          </DataBlockWrapper>
-          <DataBlockWrapper>
-            <DataBlockWithAction size="full" title={tSub('edition')} disabled={disabledOpenTiled}>
-              <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)} disabled={disabledOpenTiled}>
-                <BaseIcon icon="mapPadded" size="s" color={disabledOpenTiled ? theme.colors.text700 : theme.colors.primaryBase} />
-                <span>{t('open_with_tiled')}</span>
-              </SecondaryButton>
-            </DataBlockWithAction>
-          </DataBlockWrapper>
-          <DataBlockWrapper>
-            <DataBlockWithAction size="full" title={t('deleting')} disabled={isRMXPMode}>
-              <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deletion', true)} disabled={isRMXPMode}>
-                {t('delete')}
-              </DeleteButtonWithIcon>
-            </DataBlockWithAction>
-          </DataBlockWrapper>
-          <MapEditorOverlay ref={dialogsRef} />
-        </PageDataConstrainerStyle>
-      </PageContainerStyle>
+      {hasMap ? (
+        <PageContainerStyle>
+          <PageDataConstrainerStyle>
+            <DataBlockWrapper>
+              <MapBreadcrumb />
+              {/** The component is commented on because it's currently useless */}
+              {/*<DatabaseTabsBar
+          currentTabIndex={0}
+          tabs={[
+            { label: t('data'), path: '/world/map' },
+            { label: t('map'), path: '/world/map/view', disabled: true },
+          ]}
+        />*/}
+              {hasMapModified && <MapUpdate />}
+              {isRMXPMode && <MapRMXP2StudioUpdate />}
+            </DataBlockWrapper>
+            <DataBlockWrapper>
+              <MapFrame map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
+              <MapMusics map={map} dialogsRef={dialogsRef} disabled={isRMXPMode} />
+            </DataBlockWrapper>
+            <DataBlockWrapper>
+              <DataBlockWithAction size="full" title={tSub('edition')} disabled={disabledOpenTiled}>
+                <SecondaryButton onClick={() => openTiled(map.tiledFilename, dialogsRef)} disabled={disabledOpenTiled}>
+                  <BaseIcon icon="mapPadded" size="s" color={disabledOpenTiled ? theme.colors.text700 : theme.colors.primaryBase} />
+                  <span>{t('open_with_tiled')}</span>
+                </SecondaryButton>
+              </DataBlockWithAction>
+            </DataBlockWrapper>
+            <DataBlockWrapper>
+              <DataBlockWithAction size="full" title={t('deleting')} disabled={isRMXPMode}>
+                <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deletion', true)} disabled={isRMXPMode}>
+                  {t('delete')}
+                </DeleteButtonWithIcon>
+              </DataBlockWithAction>
+            </DataBlockWrapper>
+          </PageDataConstrainerStyle>
+        </PageContainerStyle>
+      ) : (
+        !isRMXPMode && <MapEmptyState dialogsRef={dialogsRef} />
+      )}
+      <MapEditorOverlay ref={dialogsRef} />
     </MapPageStyle>
-  ) : (
-    <></>
   );
 };

--- a/src/views/pages/world/Map.page.tsx
+++ b/src/views/pages/world/Map.page.tsx
@@ -14,6 +14,7 @@ import { DeleteButtonWithIcon, SecondaryButton } from '@components/buttons';
 import { BaseIcon } from '@components/icons/BaseIcon';
 import theme from '@src/AppTheme';
 import { useOpenTiled } from '@utils/useOpenTiled';
+import { MapImportEditorTitle, MapImportOverlay } from '@components/world/map/editors/MapImport/MapImportOverlay';
 
 const MapPageStyle = styled.div`
   display: flex;
@@ -27,6 +28,7 @@ const MapPageStyle = styled.div`
 
 export const MapPage = () => {
   const dialogsRef = useDialogsRef<MapEditorAndDeletionKeys>();
+  const dialogsMapImportRef = useDialogsRef<MapImportEditorTitle>();
   const { map, hasMap, hasMapModified, isRMXPMode, disabledOpenTiled } = useMapPage();
   const openTiled = useOpenTiled();
   const { t } = useTranslation('database_maps');
@@ -72,9 +74,10 @@ export const MapPage = () => {
           </PageDataConstrainerStyle>
         </PageContainerStyle>
       ) : (
-        !isRMXPMode && <MapEmptyState dialogsRef={dialogsRef} />
+        !isRMXPMode && <MapEmptyState dialogsRef={dialogsRef} dialogsMapImportRef={dialogsMapImportRef} />
       )}
       <MapEditorOverlay ref={dialogsRef} />
+      <MapImportOverlay ref={dialogsMapImportRef} closeParentDialog={() => {}} />
     </MapPageStyle>
   );
 };


### PR DESCRIPTION
## Description

This PR adds information to the map page if no map exists (only in Tiled mode), to enhance the user experience.

## Note before testing

The project must be in Tiled mode and you must not have any maps.

## Tests to perform

- [x] Check if the UI works correctly

## Screenshot

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/04e81e36-b8cc-4322-9210-5a19822aeade)