### PR TITLE
Allow T2Rv2 to coexist with invalid maps (start, intro, event sources)

### DIFF
--- a/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
+++ b/src/backendTasks/studioMapToRMXPConversionFacilitator.ts
@@ -74,8 +74,8 @@ export const processSavedMaps = async (projectDataPath: string, savedMaps: strin
   try {
     if (savedMaps.length === 0) return;
 
-    const newSavedMaps = savedMaps.map((s) => JSON.parse(s) as StudioMap);
-    if (newSavedMaps.some(({ tileMetadata }) => !tileMetadata)) return;
+    const newSavedMaps = savedMaps.map((s) => JSON.parse(s) as StudioMap).filter(({ tileMetadata }) => !!tileMetadata);
+    if (newSavedMaps.length === 0) return;
 
     const filteredMaps = filterOutMaps(newSavedMaps);
     const tilesets = getAllMapTilesets(projectDataPath, filteredMaps, newSavedMaps);


### PR DESCRIPTION
## Description

The initial idea was being full Tiled but unfortunately we still have to coexist with abomination of nature so the code is slightly changed to let those horrors remain in user's project.

## Tests to perform

Have a project with RMXP only map and Tiled map in tiled mode. When updating a tiled map and a RMXP map, it should update the convert the tiled map when launching PSDK.