### PR TITLE
Add: The rules.txt file is copied in the copyTiledFiles service

### DIFF
--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -141,7 +141,7 @@ const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
   const tilesetsFolderPath = path.join(projectPath, TILESETS_FOLDER);
   const assetsFolderPath = path.join(projectPath, ASSETS_FOLDER);
 
-  createTargetFolders(mapsFolderPath, tilesetsFolderPath, assetsFolderPath);
+  await createTargetFolders(mapsFolderPath, tilesetsFolderPath, assetsFolderPath);
 
   const tiledMaps: MapToImport[] = JSON.parse(payload.tiledMaps);
   const originalTiledMapPaths = tiledMaps.map(({ path }) => path);

--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -14,93 +14,98 @@ const MAPS_FOLDER = 'Data/Tiled/Maps';
 const TILESETS_FOLDER = 'Data/Tiled/Tilesets';
 const ASSETS_FOLDER = 'Data/Tiled/Assets';
 
-const copyTmxFile = (tiledMap: MapToImport, mapsFolderPath: string, tiledSrcPath: string) => {
+const getResources = (path: string) => {
+  const resources = listResources(path, []);
+  if (resources instanceof Error) {
+    throw resources;
+  }
+  return resources;
+};
+
+const copyTmxFile = async (tiledMap: MapToImport, mapsFolderPath: string, tiledSrcPath: string) => {
   const tiledFilePath = tiledMap.path;
   const relativePath = path.dirname(path.relative(tiledSrcPath, tiledFilePath));
   const destFolderPath = path.join(mapsFolderPath, relativePath);
   if (!fs.existsSync(destFolderPath)) {
-    fs.mkdirSync(destFolderPath, { recursive: true });
+    await fsPromises.mkdir(destFolderPath, { recursive: true });
   }
   const destPath = path.join(destFolderPath, path.basename(tiledFilePath));
-  fs.copyFileSync(tiledFilePath, destPath);
+  await fsPromises.copyFile(tiledFilePath, destPath);
   tiledMap.path = path.relative(mapsFolderPath, destPath).replaceAll('\\', '/').replaceAll('.tmx', '');
 };
 
-const copyTsxFile = (tiledMap: MapToImport, tilesetsFolderPath: string, tiledSrcPath: string) => {
-  tiledMap.tileMetadata.tilesets.forEach((tileset) => {
+const copyTsxFile = async (tiledMap: MapToImport, tilesetsFolderPath: string, tiledSrcPath: string) => {
+  return tiledMap.tileMetadata.tilesets.reduce(async (lastPromise, tileset) => {
+    await lastPromise;
+
     const tilesetPath = tileset.source;
     const filename = path.basename(tilesetPath);
-    if (path.isAbsolute(tilesetPath)) {
-      fs.copyFileSync(tilesetPath, path.join(tilesetsFolderPath, filename));
-    } else {
-      const absolutePath = path.join(path.dirname(path.join(tiledSrcPath, tiledMap.path)), tilesetPath);
-      fs.copyFileSync(absolutePath, path.join(tilesetsFolderPath, filename));
+    const destPath = path.join(tilesetsFolderPath, filename);
+    if (!fs.existsSync(destPath)) {
+      if (path.isAbsolute(tilesetPath)) {
+        await fsPromises.copyFile(tilesetPath, destPath);
+      } else {
+        const absolutePath = path.join(path.dirname(path.join(tiledSrcPath, tiledMap.path)), tilesetPath);
+        await fsPromises.copyFile(absolutePath, destPath);
+      }
     }
     tileset.source = path.join('../Tilesets', filename).replaceAll('\\', '/');
-  });
+  }, Promise.resolve());
 };
 
-const copyAssetFile = (tiledMap: MapToImport, assetsFolderPath: string, tiledSrcPath: string) => {
+const copyAssetFile = async (tiledMap: MapToImport, assetsFolderPath: string, tiledSrcPath: string) => {
   const tmxFilePath = `${path.join(tiledSrcPath, tiledMap.path)}.tmx`;
-  const resources = listResources(tmxFilePath, []);
-  if (resources instanceof Error) {
-    throw resources;
-  }
+  const resources = getResources(tmxFilePath);
 
-  const assetSources = resources.assetSources;
-  assetSources.forEach((asset) => {
+  return resources.assetSources.reduce(async (lastPromise, asset) => {
+    await lastPromise;
+
     const assetPath = asset.pathIncludingMapDirname;
     const basename = path.basename(assetPath);
+    const destPath = path.join(assetsFolderPath, basename);
+    if (fs.existsSync(destPath)) return;
+
     if (path.isAbsolute(assetPath)) {
-      fs.copyFileSync(assetPath, path.join(assetsFolderPath, basename));
+      await fsPromises.copyFile(assetPath, destPath);
     } else {
       const absolutePath = path.join(tiledSrcPath, assetPath);
-      fs.copyFileSync(absolutePath, path.join(assetsFolderPath, basename));
+      await fsPromises.copyFile(absolutePath, destPath);
     }
-  });
+  }, Promise.resolve());
 };
 
-const updateTmxFile = (tiledMap: MapToImport, mapsFolderPath: string, originalTiledMapPath: string) => {
+const updateTmxFile = async (tiledMap: MapToImport, mapsFolderPath: string, originalTiledMapPath: string) => {
   const tmxFilePath = `${path.join(mapsFolderPath, path.basename(tiledMap.path))}.tmx`;
+  const resources = getResources(originalTiledMapPath);
 
-  const resources = listResources(originalTiledMapPath, []);
-  if (resources instanceof Error) {
-    throw resources;
-  }
-
-  let data = fs.readFileSync(tmxFilePath).toString();
-  const tilesetSources = resources.tilesetSources;
-  tilesetSources.forEach((tileset) => {
+  let data = (await fsPromises.readFile(tmxFilePath)).toString();
+  resources.tilesetSources.forEach((tileset) => {
     const basename = path.basename(tileset);
     data = data.replaceAll(`"${tileset}"`, `"../Tilesets/${basename}"`);
   });
-  fs.writeFileSync(tmxFilePath, data);
+  await fsPromises.writeFile(tmxFilePath, data);
 };
 
-const updateTsxFile = (tiledMap: MapToImport, mapsFolderPath: string, tilesetsFolderPath: string) => {
+const updateTsxFile = async (tiledMap: MapToImport, mapsFolderPath: string, tilesetsFolderPath: string) => {
   const tmxFilePath = `${path.join(mapsFolderPath, path.basename(tiledMap.path))}.tmx`;
+  const resources = getResources(tmxFilePath);
 
-  const resources = listResources(tmxFilePath, []);
-  if (resources instanceof Error) {
-    throw resources;
-  }
+  return resources.tilesetSources.reduce(async (lastPromise, tileset) => {
+    await lastPromise;
 
-  const tilesetSources = resources.tilesetSources;
-  const assetSources = resources.assetSources;
-  tilesetSources.forEach((tileset) => {
     const tsxFilePath = path.join(tilesetsFolderPath, path.basename(tileset));
-    let data = fs.readFileSync(tsxFilePath).toString();
-    assetSources.forEach((asset) => {
+    let data = (await fsPromises.readFile(tsxFilePath)).toString();
+    resources.assetSources.forEach((asset) => {
       const basename = path.basename(asset.inTileset);
       data = data.replaceAll(`"${asset.inTileset}"`, `"../Assets/${basename}"`);
     });
-    fs.writeFileSync(tsxFilePath, data);
-  });
+    await fsPromises.writeFile(tsxFilePath, data);
+  }, Promise.resolve());
 };
 
 const updateMetadata = async (tiledMap: MapToImport, mapsFolderPath: string) => {
   const tmxPath = `${path.join(mapsFolderPath, path.basename(tiledMap.path))}.tmx`;
-  const stat = fs.statSync(tmxPath);
+  const stat = await fsPromises.stat(tmxPath);
   const sha1 = await calculateFileSha1(tmxPath);
 
   tiledMap.mtime = stat.mtime.getTime();
@@ -113,18 +118,19 @@ const copyRulesFile = async (tiledSrcPath: string, mapsFolderPath: string) => {
   if (!fs.existsSync(rulesSrcPath)) return;
   if (fs.existsSync(rulesDestPath)) return;
 
-  await fsPromises.copyFile(rulesSrcPath, path.join(mapsFolderPath, 'rules.txt'));
+  log.info('copy-tiled-files/process', rulesSrcPath);
+  await fsPromises.copyFile(rulesSrcPath, rulesDestPath);
 };
 
-const createTargetFolders = (mapsFolderPath: string, tilesetsFolderPath: string, assetsFolderPath: string) => {
+const createTargetFolders = async (mapsFolderPath: string, tilesetsFolderPath: string, assetsFolderPath: string) => {
   if (!fs.existsSync(mapsFolderPath)) {
-    fs.mkdirSync(mapsFolderPath);
+    await fsPromises.mkdir(mapsFolderPath);
   }
   if (!fs.existsSync(tilesetsFolderPath)) {
-    fs.mkdirSync(tilesetsFolderPath);
+    await fsPromises.mkdir(tilesetsFolderPath);
   }
   if (!fs.existsSync(assetsFolderPath)) {
-    fs.mkdirSync(assetsFolderPath);
+    await fsPromises.mkdir(assetsFolderPath);
   }
 };
 
@@ -144,11 +150,11 @@ const copyTiledFiles = async (payload: CopyTiledFilesInput) => {
     await lastPromise;
 
     log.info('copy-tiled-files/process', tiledMap.path);
-    copyTmxFile(tiledMap, mapsFolderPath, payload.tiledSrcPath);
-    copyTsxFile(tiledMap, tilesetsFolderPath, payload.tiledSrcPath);
-    copyAssetFile(tiledMap, assetsFolderPath, payload.tiledSrcPath);
-    updateTmxFile(tiledMap, mapsFolderPath, originalTiledMapPaths[currentIndex]);
-    updateTsxFile(tiledMap, mapsFolderPath, tilesetsFolderPath);
+    await copyTmxFile(tiledMap, mapsFolderPath, payload.tiledSrcPath);
+    await copyTsxFile(tiledMap, tilesetsFolderPath, payload.tiledSrcPath);
+    await copyAssetFile(tiledMap, assetsFolderPath, payload.tiledSrcPath);
+    await updateTmxFile(tiledMap, mapsFolderPath, originalTiledMapPaths[currentIndex]);
+    await updateTsxFile(tiledMap, mapsFolderPath, tilesetsFolderPath);
     await updateMetadata(tiledMap, mapsFolderPath);
   }, Promise.resolve());
 


### PR DESCRIPTION
## Description

Add:
- The file rules.txt is now copied automatically if it exists at the time of import. If the file already exists, it is ignored.
- The maps contained in the rules.txt file are copied

Change:
- The tilesets and assets resources are not now copied if the file already exists.
- The service now uses asynchronous functions

## Note before testing

The project must be in Tiled mode.

## Tests to perform

- [ ] Check if the import works correcly
- [ ] Check if the rules.txt file is copied
