### PR TITLE
All the pre existing RMXP maps are available on RMXP after the first bulk import

### DIFF
--- a/assets/i18n/en/database_maps.json
+++ b/assets/i18n/en/database_maps.json
@@ -59,6 +59,7 @@
   "no_files_found": "No file found",
   "reading_data_tiled_files": "Reading data from Tiled maps",
   "copy_tiled_files": "Copy the Tiled maps to the project folder",
+  "add_missing_rmxp_maps": "Addition of missing RPG Maker XP maps",
   "create_new_maps": "Creating new maps",
   "import_success_message_singular": "The map has been successfully imported.",
   "import_success_message_plurial": "The maps has been successfully imported.",

--- a/assets/i18n/fr/database_maps.json
+++ b/assets/i18n/fr/database_maps.json
@@ -59,6 +59,7 @@
   "no_files_found": "Aucun fichier trouvé",
   "reading_data_tiled_files": "Lecture des données des cartes Tiled",
   "copy_tiled_files": "Copie des cartes Tiled dans le répertoire du projet",
+  "add_missing_rmxp_maps": "Ajout des cartes RPG Maker XP manquantes",
   "create_new_maps": "Création des nouvelles cartes",
   "import_success_message_singular": "La carte a été importée avec succès.",
   "import_success_message_plurial": "Les cartes ont été importées avec succès.",

--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -37,7 +37,10 @@ const copyTmxFile = async (tiledMap: { path: string }, mapsFolderPath: string, t
 };
 
 const copyTsxFile = async (tiledMap: MapToImport, tilesetsFolderPath: string, tiledSrcPath: string) => {
-  return tiledMap.tileMetadata.tilesets.reduce(async (lastPromise, tileset) => {
+  const tileMetadata = tiledMap.tileMetadata;
+  if (!tileMetadata) return;
+
+  return tileMetadata.tilesets.reduce(async (lastPromise, tileset) => {
     await lastPromise;
 
     const tilesetPath = tileset.source;

--- a/src/utils/useMapImport/index.ts
+++ b/src/utils/useMapImport/index.ts
@@ -1,4 +1,4 @@
-import type { MapImportFailureCallback, MapImportSuccessCallback } from './types';
+import type { MapImportFailureCallback, MapImportSuccessCallback, RMXPMapInfo } from './types';
 import { DEFAULT_PROCESS_STATE, useProcess } from '@utils/useProcess';
 import { useMapImportProcessor } from './useMapImportProcessor';
 import type { MapImportFiles } from '@components/world/map/editors/MapImport/MapImportType';
@@ -8,11 +8,16 @@ export const useMapImport = () => {
   const setState = useProcess(processors, DEFAULT_PROCESS_STATE);
 
   return (
-    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapIds: number[] },
+    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] },
     onSuccess: MapImportSuccessCallback,
     onFailure: MapImportFailureCallback
   ) => {
     binding.current = { onFailure, onSuccess };
-    setState({ state: 'import', filesToImport: payload.filesToImport, tiledFilesSrcPath: payload.tiledFilesSrcPath, rmxpMapIds: payload.rmxpMapIds });
+    setState({
+      state: 'import',
+      filesToImport: payload.filesToImport,
+      tiledFilesSrcPath: payload.tiledFilesSrcPath,
+      rmxpMapInfo: payload.rmxpMapInfo,
+    });
   };
 };

--- a/src/utils/useMapImport/types.ts
+++ b/src/utils/useMapImport/types.ts
@@ -2,7 +2,11 @@ import type { MapImportFiles } from '@components/world/map/editors/MapImport/Map
 import type { RMXPMap } from '@src/backendTasks/readRMXPMap';
 import type { PartialStudioMap } from 'ts-tiled-converter';
 
-export type MapToImport = { mtime: number } & Omit<MapImportFiles, 'shouldBeImport' | 'error' | 'filename'> & PartialStudioMap;
+export type RMXPMapInfo = { id: number; name: string };
+export type MapToImport = { mtime: number; sha1: string; tileMetadata?: PartialStudioMap['tileMetadata'] } & Omit<
+  MapImportFiles,
+  'shouldBeImport' | 'error' | 'filename'
+>;
 export type MapToImportWithRMXPMap = { rmxpMap?: RMXPMap } & MapToImport;
 export type MapImportError = { path: string; errorMessage?: string };
 
@@ -10,10 +14,11 @@ export type MapImportFailureCallback = (error: MapImportError[], genericError?: 
 export type MapImportSuccessCallback = (payload: Record<string, never>) => void;
 export type MapImportStateObject =
   | { state: 'done' }
-  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapIds: number[] }
-  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string; rmxpMapIds: number[] }
+  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] }
+  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] }
+  | { state: 'addMissingRMXPMaps'; mapsToImport: MapToImport[]; rmxpMapInfo: RMXPMapInfo[] }
   | { state: 'getRMXPMapsData'; mapsToImport: MapToImport[]; rmxpMapIds: number[] }
-  | { state: 'createNewMaps'; mapsToImportWithRMXPMap: MapToImportWithRMXPMap[]; rmxpMapIds: number[] };
+  | { state: 'createNewMaps'; mapsToImport: MapToImport[]; rmxpMaps: Record<number, RMXPMap>; rmxpMapIds: number[] };
 export type MapImportFunctionBinding = {
   onSuccess: MapImportSuccessCallback;
   onFailure: MapImportFailureCallback;

--- a/src/views/components/world/map/editors/MapFrameEditor.tsx
+++ b/src/views/components/world/map/editors/MapFrameEditor.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef, useState } from 'react';
-import { EditorWithCollapse } from '@components/editor';
+import { Editor } from '@components/editor';
 import { useTranslation } from 'react-i18next';
 import { useMapPage } from '@utils/usePage';
 import { useUpdateMap } from './useUpdateMap';
@@ -45,8 +45,7 @@ export const MapFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     setText(MAP_DESCRIPTION_TEXT_ID, map.id, descriptionRef.current.value);
   };
 
-  const canClose = () =>
-    !!nameRef.current?.value && !dialogsRef.current?.currentDialog && !!stepsAverageRef.current?.validity.valid && !!tiledFilename;
+  const canClose = () => !!nameRef.current?.value && !dialogsRef.current?.currentDialog && !!stepsAverageRef.current?.validity.valid;
   const onClose = () => {
     if (!nameRef.current || !descriptionRef.current || !stepsAverageRef.current || !canClose()) return;
 
@@ -83,7 +82,7 @@ export const MapFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
 
   return (
-    <EditorWithCollapse type="edit" title={t('information')}>
+    <Editor type="edit" title={t('information')}>
       <InputContainer size="l">
         <PaddedInputContainer size="m">
           <InputWithTopLabelContainer>
@@ -105,9 +104,7 @@ export const MapFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             <Input type="number" name="steps-average" min="1" max="999" defaultValue={map.stepsAverage} ref={stepsAverageRef} />
           </InputWithLeftLabelContainer>
           <InputWithTopLabelContainer>
-            <Label htmlFor="tiled-file" required>
-              {t('map_made_tiled')}
-            </Label>
+            <Label htmlFor="tiled-file">{t('map_made_tiled')}</Label>
             {!tiledFilename ? (
               <DropInput
                 name={t('tiled_file')}
@@ -130,7 +127,7 @@ export const MapFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
         </PaddedInputContainer>
       </InputContainer>
       <MapTranslationOverlay map={map} onClose={onTranslationOverlayClose} ref={dialogsRef} />
-    </EditorWithCollapse>
+    </Editor>
   );
 });
 MapFrameEditor.displayName = 'MapFrameEditor';

--- a/src/views/components/world/map/editors/MapNewEditor.tsx
+++ b/src/views/components/world/map/editors/MapNewEditor.tsx
@@ -63,7 +63,7 @@ export const MapNewEditor = forwardRef<EditorHandlingClose, MapNewEditorProps>((
   useEditorHandlingClose(ref);
 
   const onClickNew = () => {
-    if (!name || !descriptionRef.current || !tiledFilename) return;
+    if (!name || !descriptionRef.current) return;
 
     const newMap = createMap(maps, stepsAverage, tiledFilename, bgm, bgs);
     const dbSymbol = newMap.dbSymbol;
@@ -88,7 +88,7 @@ export const MapNewEditor = forwardRef<EditorHandlingClose, MapNewEditorProps>((
   };
 
   const checkDisabled = () => {
-    return !name || stepsAverage < 1 || stepsAverage > 999 || isNaN(stepsAverage) || !tiledFilename;
+    return !name || stepsAverage < 1 || stepsAverage > 999 || isNaN(stepsAverage);
   };
 
   const onChangeStepsAverage = (value: string) => {
@@ -131,9 +131,7 @@ export const MapNewEditor = forwardRef<EditorHandlingClose, MapNewEditorProps>((
               />
             </InputWithLeftLabelContainer>
             <InputWithTopLabelContainer>
-              <Label htmlFor="tiled-file" required>
-                {t('database_maps:map_made_tiled')}
-              </Label>
+              <Label htmlFor="tiled-file">{t('database_maps:map_made_tiled')}</Label>
               {!tiledFilename ? (
                 <DropInput
                   name={t('database_maps:tiled_file')}


### PR DESCRIPTION
## Description

Add:
- All existing RMXP maps are added during bulk import

Change:
- The tmx files isn't now required in the creation and edition of the maps

## Note before testing

Your project must be in Tiled mode.

## Tests to perform

- [x] Check that all existing RMXP maps are added during bulk import
