### PR TITLE
Separate Tool & Variant

### DIFF
--- a/assets/i18n/de/database_groups.json
+++ b/assets/i18n/de/database_groups.json
@@ -16,6 +16,8 @@
   "battle_type": "Kampfart",
   "environment": "Umgebung",
   "variation": "Variante",
+  "tool": "Werkzeug",
+  "none": "Keine",
   "switch": "Wechseln zu",
   "example_name": "Pallet Town - Gras 1",
   "pokemon_group": "Pokémon der Gruppe",

--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -16,6 +16,8 @@
   "battle_type": "Battle type",
   "environment": "Environment",
   "variation": "Variation",
+  "tool": "Tool",
+  "none": "None",
   "steps_average": "Average number of steps",
   "no_steps": "Defined by the map",
   "switch": "Switch",

--- a/assets/i18n/fr/database_groups.json
+++ b/assets/i18n/fr/database_groups.json
@@ -17,6 +17,8 @@
   "battle_type": "Type de combat",
   "environment": "Environnement",
   "variation": "Variation",
+  "tool": "Outil",
+  "none": "Aucun",
   "steps_average": "Pas moyens requis",
   "no_steps": "Défini par la carte",
   "example_name": "Bourg Palette - Herbes 1",

--- a/assets/i18n/it/database_groups.json
+++ b/assets/i18n/it/database_groups.json
@@ -16,6 +16,8 @@
   "battle_type": "Tipo di lotta",
   "environment": "Ambiente",
   "variation": "Variazione",
+  "tool": "Attrezzo",
+  "none": "Niente",
   "steps_average": "Numero medio di passi",
   "switch": "Switch",
   "example_name": "Biancavilla - Erba 1",

--- a/assets/i18n/pt/database_groups.json
+++ b/assets/i18n/pt/database_groups.json
@@ -16,6 +16,8 @@
   "battle_type": "Tipo de combate",
   "environment": "Ambiente",
   "variation": "Variação",
+  "tool": "Ferramenta",
+  "none": "Nenhum",
   "steps_average": "Número médio de passos",
   "switch": "Comutador",
   "example_name": "Pallet Town - Relva 1",

--- a/src/utils/GroupUtils.ts
+++ b/src/utils/GroupUtils.ts
@@ -19,6 +19,9 @@ export const GroupVariationsMap = [
   { value: '5', label: 'variation_5' },
   { value: '6', label: 'variation_6' },
   { value: '7', label: 'variation_7' },
+] as const;
+export const GroupToolMap = [
+  { value: 'none', label: 'none' },
   { value: 'OldRod', label: 'OldRod' },
   { value: 'GoodRod', label: 'GoodRod' },
   { value: 'SuperRod', label: 'SuperRod' },
@@ -106,23 +109,6 @@ export const getSwitchValue = (activation: StudioGroupActivationType) => {
 
 export const getSwitchDefaultValue = (group: StudioGroup) =>
   group.customConditions.filter((condition) => condition.type === 'enabledSwitch')[0]?.value || 1;
-
-export const updateVariation = (value: string) => {
-  let tool;
-  let terrainTag;
-  if (isNaN(Number(value))) {
-    tool = value as StudioGroupTool;
-    terrainTag = 0;
-  } else {
-    tool = null;
-    terrainTag = Number(value);
-  }
-  return { tool, terrainTag };
-};
-
-export const getVariationValue = (group: StudioGroup) => {
-  return group.tool ?? group.terrainTag.toString();
-};
 
 export const defineRelationCustomCondition = (customConditions: StudioCustomGroupCondition[]) => {
   const mapIdConditions = customConditions.filter((conditions) => conditions.type === 'mapId');

--- a/src/views/components/database/group/GroupFrame.tsx
+++ b/src/views/components/database/group/GroupFrame.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataBlockContainer, DataFieldsetField, DataGrid, DataInfoContainer, DataInfoContainerHeaderTitle } from '../dataBlocks';
-import { getActivationLabel, getVariationValue, GroupVariationsMap } from '@utils/GroupUtils';
+import { getActivationLabel, GroupToolMap, GroupVariationsMap } from '@utils/GroupUtils';
 import styled from 'styled-components';
 import { padStr } from '@utils/PadStr';
 import { DataFieldsetFieldWithChild } from '../dataBlocks/DataFieldsetField';
@@ -44,7 +44,9 @@ const EnvironmentContainer = styled.div`
 export const GroupFrame = ({ group, dialogsRef }: GroupFrameProps) => {
   const { t } = useTranslation('database_groups');
   const getGroupName = useGetEntityNameText();
-  const variationText = GroupVariationsMap.find((variation) => variation.value === getVariationValue(group))?.label;
+  const variationText = (
+    GroupToolMap.find((variation) => variation.value === group.tool) ?? GroupVariationsMap.find(({ value }) => Number(value) === group.terrainTag)
+  )?.label;
 
   return (
     <DataBlockContainer size="full" onClick={() => dialogsRef.current?.openDialog('frame')}>


### PR DESCRIPTION
## Description

As PSDK is checking for both tool & terrain tag for Fishing we should separate tool & variant because it's possible that Maker uses another terrain tag to make more Fishing groups!

## Tests to perform

Assign a tool and a terrain tag to a group, save, close, reload, it should show the same as when saved.
