### PR TITLE
Add portuguese language in the list of available languages to create a new projet

### DIFF
--- a/assets/i18n/de/homepage.json
+++ b/assets/i18n/de/homepage.json
@@ -28,5 +28,6 @@
   "en": "Englisch",
   "fr": "Französisch",
   "es": "Spanisch",
+  "pt": "Portugiesisch",
   "incorrect_title": "Falsche(s) Zeichen"
 }

--- a/assets/i18n/en/homepage.json
+++ b/assets/i18n/en/homepage.json
@@ -28,5 +28,6 @@
   "en": "English",
   "fr": "French",
   "es": "Spanish",
+  "pt": "Portuguese",
   "incorrect_title": "Wrong character(s)"
 }

--- a/assets/i18n/es/homepage.json
+++ b/assets/i18n/es/homepage.json
@@ -28,5 +28,6 @@
   "en": "Inglés",
   "fr": "Francés",
   "es": "Español",
+  "pt": "Portugués",
   "incorrect_title": "Caracter(es) incorrecto(s)"
 }

--- a/assets/i18n/fr/homepage.json
+++ b/assets/i18n/fr/homepage.json
@@ -28,5 +28,6 @@
   "en": "Anglais",
   "fr": "Français",
   "es": "Espagnol",
+  "pt": "Portugais",
   "incorrect_title": "Caractère(s) incorrect(s)"
 }

--- a/assets/i18n/it/homepage.json
+++ b/assets/i18n/it/homepage.json
@@ -28,5 +28,6 @@
   "en": "Inglese",
   "fr": "Francese",
   "es": "Spagnolo",
+  "pt": "Portoghese",
   "incorrect_title": "Caratteri errati"
 }

--- a/assets/i18n/pt/homepage.json
+++ b/assets/i18n/pt/homepage.json
@@ -28,5 +28,6 @@
   "en": "Inglês",
   "fr": "Francês",
   "es": "Espanhol",
+  "pt": "Português",
   "incorrect_title": "Caractere(s) inválido(s)"
 }

--- a/src/backendTasks/configureNewProject.ts
+++ b/src/backendTasks/configureNewProject.ts
@@ -54,8 +54,10 @@ const updateCSVFiles = async (projectPath: string, languageConfigData: string) =
         shouldBeSaved = true;
       }
     });
-    log.info('configure-new-project/update', 'CSV Files', textPath);
-    if (shouldBeSaved) saveCSV(textPath, csvData);
+    if (shouldBeSaved) {
+      log.info('configure-new-project/update', 'CSV Files', textPath);
+      saveCSV(textPath, csvData);
+    }
   }, Promise.resolve());
 };
 

--- a/src/backendTasks/configureNewProject.ts
+++ b/src/backendTasks/configureNewProject.ts
@@ -2,8 +2,9 @@ import { generatePSDKBatFileContent } from '@services/generatePSDKBatFileContent
 import log from 'electron-log';
 import path from 'path';
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
-import { GAME_OPTION_CONFIG_VALIDATOR, INFO_CONFIG_VALIDATOR } from '@modelEntities/config';
+import { GAME_OPTION_CONFIG_VALIDATOR, INFO_CONFIG_VALIDATOR, StudioLanguageConfig } from '@modelEntities/config';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import { addColumnCSV, getTextFileList, getTextPath, languageAvailable, loadCSV, saveCSV } from '@utils/textManagement';
 
 export type ConfigureNewProjectMetaData = {
   projectStudioData: string;
@@ -35,6 +36,29 @@ const updateGameOptionsConfig = (gameOptionsConfigPath: string) => {
   writeFileSync(gameOptionsConfigPath, JSON.stringify(gameOptionConfigValidation.data, null, 2));
 };
 
+/**
+ * Update the csv files to add missing languages if necessary
+ */
+const updateCSVFiles = async (projectPath: string, languageConfigData: string) => {
+  const languageConfig = JSON.parse(languageConfigData) as StudioLanguageConfig;
+  const textFileList = getTextFileList(projectPath, true);
+  await textFileList.reduce(async (lastPromise, fileId) => {
+    await lastPromise;
+
+    const textPath = path.join(projectPath, getTextPath(fileId), `${fileId}.csv`);
+    const csvData = await loadCSV(textPath);
+    let shouldBeSaved = false;
+    languageConfig.choosableLanguageCode.forEach((languageCode) => {
+      if (!languageAvailable(languageCode, csvData)) {
+        addColumnCSV(languageCode, csvData);
+        shouldBeSaved = true;
+      }
+    });
+    log.info('configure-new-project/update', 'CSV Files', textPath);
+    if (shouldBeSaved) saveCSV(textPath, csvData);
+  }, Promise.resolve());
+};
+
 export type ConfigureNewProjectInput = { projectDirName: string; metaData: ConfigureNewProjectMetaData };
 
 const configureNewProject = async (payload: ConfigureNewProjectInput) => {
@@ -56,6 +80,8 @@ const configureNewProject = async (payload: ConfigureNewProjectInput) => {
     log.info('configure-new-project/update game options config');
     updateGameOptionsConfig(path.join(payload.projectDirName, 'Data/configs/game_options_config.json'));
   }
+  log.info('configure-new-project/update', 'CSV Files');
+  await updateCSVFiles(payload.projectDirName, payload.metaData.languageConfig);
   return {};
 };
 

--- a/src/utils/textManagement.ts
+++ b/src/utils/textManagement.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { parse } from 'csv-parse';
+import { stringify } from 'csv-stringify/sync';
 
 export const loadCSV = async (filePath: string): Promise<string[][]> => {
   const data: string[][] = [];
@@ -67,4 +68,26 @@ export const checkTextFileReserved = (textFileList: number[], projectPath: strin
     const prevResult = await prev;
     return prevResult || fs.existsSync(path.join(dialogsPath, `${curr}.csv`));
   }, Promise.resolve(false));
+};
+
+export const languageAvailable = (languageCode: string, csvData: string[][]) => {
+  const result = csvData[0]?.indexOf(languageCode);
+  return result !== undefined && result !== -1;
+};
+
+export const addColumnCSV = (languageName: string, csvData: string[][]) => {
+  const englishIndex = csvData[0]?.indexOf('en');
+  const hasEnglish = englishIndex !== undefined && englishIndex !== -1;
+  csvData.forEach((line, index) => {
+    if (index === 0) return;
+
+    const data = hasEnglish ? line[englishIndex] : `[~${index - 1}]`;
+    line.push(data);
+  });
+  if (csvData.length === 0) csvData.push([]);
+  csvData[0].push(languageName);
+};
+
+export const saveCSV = (filePath: string, csvData: string[][]) => {
+  fs.writeFileSync(filePath, stringify(csvData));
 };

--- a/src/utils/useProjectNew/types.ts
+++ b/src/utils/useProjectNew/types.ts
@@ -1,7 +1,8 @@
 import type { StudioProject } from '@modelEntities/project';
 import type { LatestNewProject } from '@src/backendTasks/checkDownloadNewProject';
 
-export type DefaultLanguageType = 'en' | 'fr' | 'es';
+export const DefaultLanguages = ['en', 'fr', 'es', 'pt'] as const;
+export type DefaultLanguageType = (typeof DefaultLanguages)[number];
 export type NewProjectData = Omit<StudioProject, 'studioVersion' | 'iconPath' | 'isTiledMode'> & {
   icon?: string;
   defaultLanguage: DefaultLanguageType;

--- a/src/utils/useProjectNew/useProjectNewProcessor.ts
+++ b/src/utils/useProjectNew/useProjectNewProcessor.ts
@@ -18,14 +18,15 @@ const languageTexts: Record<DefaultLanguageType, string> = {
   en: 'English',
   fr: 'French',
   es: 'Spanish',
+  pt: 'Portuguese',
 };
 
 const getLanguageConfig = (projectData: { defaultLanguage: DefaultLanguageType; multiLanguage: boolean }): string => {
   const config: StudioLanguageConfig = {
     klass: 'Configs::Project::Language',
     defaultLanguage: projectData.defaultLanguage,
-    choosableLanguageCode: projectData.multiLanguage ? ['en', 'fr', 'es'] : [projectData.defaultLanguage],
-    choosableLanguageTexts: projectData.multiLanguage ? ['English', 'French', 'Spanish'] : [languageTexts[projectData.defaultLanguage]],
+    choosableLanguageCode: projectData.multiLanguage ? Object.keys(languageTexts) : [projectData.defaultLanguage],
+    choosableLanguageTexts: projectData.multiLanguage ? Object.values(languageTexts) : [languageTexts[projectData.defaultLanguage]],
   };
   return JSON.stringify(config, null, 2);
 };

--- a/src/views/components/home/editors/HomeProjectNewEditor.tsx
+++ b/src/views/components/home/editors/HomeProjectNewEditor.tsx
@@ -10,12 +10,11 @@ import { TFunction, useTranslation } from 'react-i18next';
 import { TextInputError } from '@components/inputs/Input';
 import { basename, dirname } from '@utils/path';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
-import type { DefaultLanguageType, NewProjectData } from '@utils/useProjectNew/types';
+import { DefaultLanguages, DefaultLanguageType, NewProjectData } from '@utils/useProjectNew/types';
 
-const defaultLanguage: DefaultLanguageType[] = ['en', 'fr', 'es'];
 const iconFileExtensions = ['png'];
 
-const languageEntries = (t: TFunction<'homepage'>) => defaultLanguage.map((language) => ({ value: language, label: t(language) }));
+const languageEntries = (t: TFunction<'homepage'>) => DefaultLanguages.map((language) => ({ value: language, label: t(language) }));
 const wrongTitle = (title: string) => {
   return title.match('[\\\\/:*?"<>|$.]') !== null;
 };


### PR DESCRIPTION
## Description

Add:
- The user can choice the portuguese in the list of available languages to create a new project ;
- If a language doesn't exist in the csv file, it is added when creating the project. English will be used by default to fill in the lines. If English is not available, `[~n]` will be used.

Note:

Spanish was already available.

## Tests to perform

- [x] Check that user can choice the portuguese
- [x] Check that the csv files contains the code `pt` at the first line and English text (or `[~n]`) on the other lines.
