### PR TITLE
Fix crash in MapTree component after deletion maps

### DIFF
--- a/src/utils/MapInfoUtils.ts
+++ b/src/utils/MapInfoUtils.ts
@@ -11,19 +11,14 @@ const removeMapInfoChildren = (mapInfo: StudioMapInfo, id: number) => {
   mapInfoValue.hasChildren = mapInfoValue.children.length > 0;
 };
 
-const getMapInfoChildrenIdRec = (mapInfo: StudioMapInfo, mapInfoValue: StudioMapInfoValue): number[] => {
-  if (mapInfoValue.children.length === 0) return [mapInfoValue.id];
-
-  const result: number[] = [];
-  mapInfoValue.children.forEach((id) => {
-    result.push(...getMapInfoChildrenIdRec(mapInfo, mapInfo[id.toString()]));
-  });
-  return result;
-};
-
 const getMapInfoChildrenId = (mapInfo: StudioMapInfo, mapInfoValue: StudioMapInfoValue): number[] => {
   if (mapInfoValue.children.length === 0) return [];
-  return [...mapInfoValue.children, ...getMapInfoChildrenIdRec(mapInfo, mapInfoValue)];
+
+  const children: number[] = [...mapInfoValue.children];
+  mapInfoValue.children.forEach((id) => {
+    children.push(...getMapInfoChildrenId(mapInfo, mapInfo[id.toString()]));
+  });
+  return children;
 };
 
 export const findMapInfoMap = (mapInfo: StudioMapInfo, mapDbSymbol: DbSymbol): StudioMapInfoMap | undefined => {


### PR DESCRIPTION
## Description

The deletion maps can crash because the `getMapInfoChildrenId` function was poorly implemented. This PR fixes the issue.

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/fa163f15-c468-4d07-938b-42bcab776023)

The log shows a problem with the parent, because when the maps were deleted, all the children were not found, so a map still existed even though it no longer had a parent.

## How to reproduce

Create a new project and use this archive because the bug depends on the mapinfo structure. (replace your Data folder by the archive):
[Data.zip](https://github.com/PokemonWorkshop/PokemonStudio/files/14142602/Data.zip)

Delete the PSDK .25.0 map to cause a crash.

## Tests to perform

- [x] Check that the maps or folder deletion works correctly. 
