### PR TITLE
Hide the systemtags option from the PlayButton in tiled mode

### DIFF
--- a/src/views/components/buttons/PlayButton.tsx
+++ b/src/views/components/buttons/PlayButton.tsx
@@ -118,7 +118,7 @@ export const PlayButton = () => {
         <div className="play-menu">
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDK)}>{t('play_release_mode')}</span>
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKDebug)}>{t('play_debug_mode')}</span>
-          <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKTags)}>{t('play_tags_mode')}</span>
+          {!state.projectStudio.isTiledMode && <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKTags)}>{t('play_tags_mode')}</span>}
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKWorldmap)}>{t('play_worldmap_mode')}</span>
         </div>
       </PlayMenuButtonContainer>


### PR DESCRIPTION
## Description

This PR hides the systemtags option from the PlayButton in Tiled mode. In Tiled mode, the systemtags editor is useless.

## Tests to perform

- [ ] Check that the option is available in RMXP mode
- [ ] Check that the option is unavailable in Tiled mode
