### PR TITLE
Improve tmx file selection in map new editor and map frame editor

### DIFF
--- a/src/utils/useMapCopy/helpers.ts
+++ b/src/utils/useMapCopy/helpers.ts
@@ -1,0 +1,6 @@
+export const toAsyncProcess = (func: () => void) => {
+  (async () => {
+    func();
+  })();
+  return () => {};
+};

--- a/src/utils/useMapCopy/index.ts
+++ b/src/utils/useMapCopy/index.ts
@@ -1,0 +1,21 @@
+import type { MapCopyFailureCallback, MapCopyGenericFailureCallback, MapCopySuccessCallback } from './types';
+import { DEFAULT_PROCESS_STATE, useProcess } from '@utils/useProcess';
+import { useMapCopyProcessor } from './useMapCopyProcessor';
+
+export const useMapCopy = () => {
+  const { processors, binding } = useMapCopyProcessor();
+  const setState = useProcess(processors, DEFAULT_PROCESS_STATE);
+
+  return (
+    payload: { tmxFile: string },
+    onSuccess: MapCopySuccessCallback,
+    onFailure: MapCopyFailureCallback,
+    onGenericFailure: MapCopyGenericFailureCallback
+  ) => {
+    binding.current = { onFailure, onSuccess, onGenericFailure };
+    setState({
+      state: 'copy',
+      tmxFile: payload.tmxFile,
+    });
+  };
+};

--- a/src/utils/useMapCopy/types.ts
+++ b/src/utils/useMapCopy/types.ts
@@ -1,0 +1,9 @@
+export type MapCopyGenericFailureCallback = (genericError: string) => void;
+export type MapCopyFailureCallback = (errorMessage: string) => void;
+export type MapCopySuccessCallback = (payload: Record<string, never>) => void;
+export type MapCopyStateObject = { state: 'done' } | { state: 'copy'; tmxFile: string };
+export type MapCopyFunctionBinding = {
+  onSuccess: MapCopySuccessCallback;
+  onFailure: MapCopyFailureCallback;
+  onGenericFailure: MapCopyGenericFailureCallback;
+};

--- a/src/utils/useMapCopy/useMapCopyProcessor.ts
+++ b/src/utils/useMapCopy/useMapCopyProcessor.ts
@@ -1,0 +1,61 @@
+import { MapImportFiles } from '@components/world/map/editors/MapImport/MapImportType';
+import { useMapImport } from '../useMapImport';
+import { basename, dirname, join } from '../path';
+import { useMemo, useRef } from 'react';
+import { MapCopyFunctionBinding, MapCopyStateObject } from './types';
+import { DEFAULT_PROCESS_STATE, PROCESS_DONE_STATE, SpecialStateProcessors } from '@utils/useProcess';
+import { toAsyncProcess } from './helpers';
+import { useGlobalState } from '@src/GlobalStateProvider';
+
+const DEFAULT_BINDING: MapCopyFunctionBinding = {
+  onFailure: () => {},
+  onSuccess: () => {},
+  onGenericFailure: () => {},
+};
+
+export const useMapCopyProcessor = () => {
+  const [state] = useGlobalState();
+  const mapImport = useMapImport();
+  const binding = useRef<MapCopyFunctionBinding>(DEFAULT_BINDING);
+
+  const processors: SpecialStateProcessors<MapCopyStateObject> = useMemo(
+    () => ({
+      ...PROCESS_DONE_STATE,
+      copy: ({ tmxFile }, setState) => {
+        const filesToImport: MapImportFiles[] = [{ filename: tmxFile, mapName: '', path: tmxFile, shouldBeImport: true }];
+        return toAsyncProcess(() => {
+          // If the tmx file is in Data/Tiled/Map folder of the project, we don't do copy
+          if (tmxFile.replaceAll('\\', '/').startsWith(join(state.projectPath?.replaceAll('\\', '/') || '', 'Data/Tiled/Maps'))) {
+            binding.current.onSuccess({});
+            return setState(DEFAULT_PROCESS_STATE);
+          }
+
+          return mapImport(
+            { filesToImport: filesToImport, tiledFilesSrcPath: dirname(tmxFile), rmxpMapInfo: [], copyMode: true },
+            () => {
+              binding.current.onSuccess({});
+              return setState(DEFAULT_PROCESS_STATE);
+            },
+            (error, genericError) => {
+              const errorMessage = error[0]?.errorMessage;
+              if (errorMessage) {
+                binding.current.onFailure(`${basename(tmxFile)}: ${errorMessage}`);
+                return setState(DEFAULT_PROCESS_STATE);
+              }
+              if (genericError) {
+                binding.current.onGenericFailure(genericError);
+                return setState(DEFAULT_PROCESS_STATE);
+              }
+              binding.current.onGenericFailure('Unknown error');
+              return setState(DEFAULT_PROCESS_STATE);
+            }
+          );
+        });
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return { processors, binding };
+};

--- a/src/utils/useMapImport/index.ts
+++ b/src/utils/useMapImport/index.ts
@@ -8,7 +8,7 @@ export const useMapImport = () => {
   const setState = useProcess(processors, DEFAULT_PROCESS_STATE);
 
   return (
-    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] },
+    payload: { filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[]; copyMode?: boolean },
     onSuccess: MapImportSuccessCallback,
     onFailure: MapImportFailureCallback
   ) => {
@@ -18,6 +18,7 @@ export const useMapImport = () => {
       filesToImport: payload.filesToImport,
       tiledFilesSrcPath: payload.tiledFilesSrcPath,
       rmxpMapInfo: payload.rmxpMapInfo,
+      copyMode: payload.copyMode || false,
     });
   };
 };

--- a/src/utils/useMapImport/types.ts
+++ b/src/utils/useMapImport/types.ts
@@ -14,8 +14,8 @@ export type MapImportFailureCallback = (error: MapImportError[], genericError?: 
 export type MapImportSuccessCallback = (payload: Record<string, never>) => void;
 export type MapImportStateObject =
   | { state: 'done' }
-  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] }
-  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[] }
+  | { state: 'import'; filesToImport: MapImportFiles[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[]; copyMode: boolean }
+  | { state: 'copyTmxFiles'; mapsToImport: MapToImport[]; tiledFilesSrcPath: string; rmxpMapInfo: RMXPMapInfo[]; copyMode: boolean }
   | { state: 'addMissingRMXPMaps'; mapsToImport: MapToImport[]; rmxpMapInfo: RMXPMapInfo[] }
   | { state: 'getRMXPMapsData'; mapsToImport: MapToImport[]; rmxpMapIds: number[] }
   | { state: 'createNewMaps'; mapsToImport: MapToImport[]; rmxpMaps: Record<number, RMXPMap>; rmxpMapIds: number[] };

--- a/src/views/components/world/map/editors/MapEditorOverlay.tsx
+++ b/src/views/components/world/map/editors/MapEditorOverlay.tsx
@@ -28,7 +28,7 @@ export const MapEditorOverlay = defineEditorOverlay<MapEditorAndDeletionKeys, Pr
       case 'new':
         return <MapNewEditor ref={handleCloseRef} closeDialog={closeDialog} mapInfoParent={mapInfoValue} />;
       case 'frame':
-        return <MapFrameEditor ref={handleCloseRef} />;
+        return <MapFrameEditor ref={handleCloseRef} closeDialog={closeDialog} />;
       case 'musics':
         return <MapMusicsEditor ref={handleCloseRef} />;
       case 'deletion':


### PR DESCRIPTION
## Description

This PR improves the selection of the tmx file in the MapNewEditor and MapFrameEditor, to copy the resources associated with the selected tmx file.

When the user selects a tmx file, it is copied with these resources. If the file is already in the project's Data/Tiled/Maps folder, no copy operation is performed: the file is simply selected.

Two error cases are handled separately:
- If an error occurs in the converter, Studio displays the error in red under the input (tmx_name.tmx: error_message).
- If the error is generic, the editor is closed (the data is not saved) and a pop-up is displayed to show the error (loaderRef.setError). I would remind you that it is not currently possible in Studio to display an error pop-up and an editor because, as the editor is a dialog, it has priority and the pop-up cannot be closed.

## Note before testing

The project must be in Tiled mode.

## Tests to perform

- [x] Check that the tmx file and resources associated are copied
