### PR TITLE
Update the mtime of the map json files after the extraction of the new project archive

### DIFF
--- a/src/backendTasks/checkMapsModified.ts
+++ b/src/backendTasks/checkMapsModified.ts
@@ -54,7 +54,7 @@ export const checkMapsModified = async (payload: CheckMapModifiedInput) => {
       }
     } else {
       const stat = await getFileStats(filePath);
-      if (stat.mtime.getTime() !== map.mtime) {
+      if (stat.mtime.getTime() > map.mtime) {
         return [...acc, map.dbSymbol];
       } else {
         return acc;

--- a/src/backendTasks/checkMapsModified.ts
+++ b/src/backendTasks/checkMapsModified.ts
@@ -14,7 +14,7 @@ type StudioMapBackend = {
   tiledFilename: string;
 };
 
-const getFileStats = (filePath: string): Promise<fs.Stats> => {
+export const getFileStats = (filePath: string): Promise<fs.Stats> => {
   return new Promise((resolve, reject) => {
     fs.stat(filePath, (err, stats) => {
       if (err) {

--- a/src/backendTasks/configureNewProject.ts
+++ b/src/backendTasks/configureNewProject.ts
@@ -5,6 +5,10 @@ import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { GAME_OPTION_CONFIG_VALIDATOR, INFO_CONFIG_VALIDATOR, StudioLanguageConfig } from '@modelEntities/config';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 import { addColumnCSV, getTextFileList, getTextPath, languageAvailable, loadCSV, saveCSV } from '@utils/textManagement';
+import { readProjectFolder } from './readProjectData';
+import { MAP_VALIDATOR } from '@modelEntities/map';
+import { getFileStats } from './checkMapsModified';
+import fsPromise from 'fs/promises';
 
 export type ConfigureNewProjectMetaData = {
   projectStudioData: string;
@@ -61,6 +65,25 @@ const updateCSVFiles = async (projectPath: string, languageConfigData: string) =
   }, Promise.resolve());
 };
 
+/**
+ * Update the mtime of the maps
+ */
+const updateMapsMtime = async (projectPath: string) => {
+  const maps = await readProjectFolder(projectPath, 'maps');
+  await maps.reduce(async (lastPromise, map) => {
+    await lastPromise;
+    const mapParsed = MAP_VALIDATOR.safeParse(JSON.parse(map));
+    if (mapParsed.success) {
+      const stats = await getFileStats(`${path.join(projectPath, 'Data/Tiled/Maps', mapParsed.data.tiledFilename)}.tmx`);
+      mapParsed.data.mtime = stats.mtime.getTime();
+      await fsPromise.writeFile(
+        path.join(projectPath, 'Data/Studio/maps', `${mapParsed.data.dbSymbol}.json`),
+        JSON.stringify(mapParsed.data, null, 2)
+      );
+    }
+  }, Promise.resolve());
+};
+
 export type ConfigureNewProjectInput = { projectDirName: string; metaData: ConfigureNewProjectMetaData };
 
 const configureNewProject = async (payload: ConfigureNewProjectInput) => {
@@ -84,6 +107,8 @@ const configureNewProject = async (payload: ConfigureNewProjectInput) => {
   }
   log.info('configure-new-project/update', 'CSV Files');
   await updateCSVFiles(payload.projectDirName, payload.metaData.languageConfig);
+  log.info('configure-new-project/update', 'Maps mtime');
+  await updateMapsMtime(payload.projectDirName);
   return {};
 };
 

--- a/src/backendTasks/configureNewProject.ts
+++ b/src/backendTasks/configureNewProject.ts
@@ -70,12 +70,12 @@ const updateCSVFiles = async (projectPath: string, languageConfigData: string) =
  */
 const updateMapsMtime = async (projectPath: string) => {
   const maps = await readProjectFolder(projectPath, 'maps');
+  const mtime = new Date().getTime();
   await maps.reduce(async (lastPromise, map) => {
     await lastPromise;
     const mapParsed = MAP_VALIDATOR.safeParse(JSON.parse(map));
     if (mapParsed.success) {
-      const stats = await getFileStats(`${path.join(projectPath, 'Data/Tiled/Maps', mapParsed.data.tiledFilename)}.tmx`);
-      mapParsed.data.mtime = stats.mtime.getTime();
+      mapParsed.data.mtime = mtime;
       await fsPromise.writeFile(
         path.join(projectPath, 'Data/Studio/maps', `${mapParsed.data.dbSymbol}.json`),
         JSON.stringify(mapParsed.data, null, 2)


### PR DESCRIPTION
## Description

This PR updates the mtime of the map json files after the extraction of the new project archive, because when the tmx files are extracted, it have the current date.
So the application detects that the files have been modified, when this is not the case.

## Tests to perform

- [x] Check that after the creation of the new project, the modified map detection service should not find any maps.
