### PR TITLE
Fix: Map validator (mtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you plan on using, modifying or doing anything related to Pokémon Studio. Yo
 You'll need to **install NodeJS** first: https://nodejs.org/en/download
 
 We recommend using [NVM](https://github.com/nvm-sh/nvm) (MacOS/Linux) or [Volta](https://volta.sh/) (Windows) to manage easely your NodeJS version.
-We use the version **18** of NodeJS.
+We use the version **20** of NodeJS.
 
 ### Cloning and installation
 

--- a/src/models/entities/map.ts
+++ b/src/models/entities/map.ts
@@ -11,7 +11,7 @@ export const MAP_VALIDATOR = z.object({
   bgm: z.string(),
   bgs: z.string(),
   tiledFilename: z.string(),
-  mtime: POSITIVE_INT,
+  mtime: POSITIVE_OR_ZERO_INT,
   sha1: SHA1_VALIDATOR.or(z.literal('')),
   tileMetadata: z.unknown(),
 });

--- a/src/utils/useMapImport/useMapImportProcessor.ts
+++ b/src/utils/useMapImport/useMapImportProcessor.ts
@@ -55,7 +55,7 @@ export const useMapImportProcessor = () => {
                 path: file.path,
                 mapName: file.mapName,
                 mapId: file.mapId,
-                mtime: 0,
+                mtime: 1,
                 ...tiledMetadata[index],
               }));
               setState({ state: 'copyTmxFiles', mapsToImport, tiledFilesSrcPath, rmxpMapInfo });
@@ -100,7 +100,7 @@ export const useMapImportProcessor = () => {
           rmxpMapInfo.forEach(({ id: rmxpMapId, name }) => {
             if (mapsToImport.find(({ mapId }) => mapId === rmxpMapId) || studioMaps.find(({ id }) => id === rmxpMapId)) return;
 
-            mapsToImport.push({ mapName: name, mtime: 0, sha1: '', path: '', tileMetadata: undefined, mapId: rmxpMapId });
+            mapsToImport.push({ mapName: name, mtime: 1, sha1: '', path: '', tileMetadata: undefined, mapId: rmxpMapId });
           });
           // the news maps must be create after the maps with a map id defined
           mapsToImport.sort((a, b) => {


### PR DESCRIPTION
## Description

This PR fixes a bug with the map validator. It doesn't authorize mtime = 0, although this value is possible (although not very logical). The validator has been updated to authorise 0 (this avoids having to migrate projects that have already been imported).
Changes have been imported to set 1 and not 0 by default.
Correction of the node version in the readme.

## Tests to perform

- [x] Check that the user can open the project with a mtime = 0
