### PR TITLE
Fix: The shortcut of the play button is now correctly update

### DIFF
--- a/assets/i18n/en/submenu_database.json
+++ b/assets/i18n/en/submenu_database.json
@@ -12,7 +12,7 @@
   "zones": "Zones",
   "dex": "Pokédex",
   "save_the_modifications": "Save the modifications",
-  "edition": "Édition",
+  "edition": "Edition",
   "aide": "Aide",
   "supprimer": "Supprimer"
 }

--- a/assets/i18n/en/submenu_database.json
+++ b/assets/i18n/en/submenu_database.json
@@ -13,6 +13,6 @@
   "dex": "Pokédex",
   "save_the_modifications": "Save the modifications",
   "edition": "Edition",
-  "aide": "Aide",
-  "supprimer": "Supprimer"
+  "aide": "Help",
+  "supprimer": "Delete"
 }

--- a/src/views/components/buttons/PlayButton.tsx
+++ b/src/views/components/buttons/PlayButton.tsx
@@ -103,7 +103,7 @@ export const PlayButton = () => {
       play: () => isShortcutEnabled() && startPSDKAndCloseMenu(window.api.startPSDKDebug),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [state.projectPath]);
   useShortcut(shortcutMap);
 
   return (


### PR DESCRIPTION
## Description

When the user changes project, the play button shortcut (ctrl+P) is not updated. The previous project is therefore executed instead of the current project.
This PR fixes this bug.

Fix: Typo in the map page

## Tests to perform

- [x] Check that the shortcut of the Play button works correctly
