### PR TITLE
Fix the Pokemon resources page crash

### DIFF
--- a/src/views/pages/database/Pokemon.Resources.page.tsx
+++ b/src/views/pages/database/Pokemon.Resources.page.tsx
@@ -26,7 +26,7 @@ export const PokemonResourcesPage = () => {
   const currentEditedPokemon = useMemo(() => cloneEntity(pokemon[pokemonIdentifier.specie]), [pokemonIdentifier.specie, pokemon]);
   const currentEditedPokemonWithForm: PokemonWithForm = {
     species: currentEditedPokemon,
-    form: currentEditedPokemon.forms[pokemonIdentifier.form],
+    form: currentEditedPokemon.forms.find((form) => form.form === pokemonIdentifier.form) || currentEditedPokemon.forms[0],
   };
 
   const onResourceChoosen = (filePath: string, resource: CreatureFormResourcesPath) => {


### PR DESCRIPTION
## Description

This PR fixes a crash in the Pokemon resources page. If you try to change the resource of a form (other than 0), it will crash because there has been confusion between the id and the index of the form.

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/9275a50f-34e0-484a-af5f-b2527dedff4f)

## Tests to perform

- [ ] Check that the user can change a Pokémon's resources under any circumstances
