### PR TITLE
Enable PlayButton on Linux and authorises the launch of PSDK

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -86,6 +86,7 @@ const createWindow = async () => {
     useContentSize: true,
     icon: getAssetPath('icon.png'),
     titleBarStyle: process.platform === 'win32' ? 'hidden' : 'default',
+    autoHideMenuBar: process.platform === 'linux',
     webPreferences: {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },

--- a/src/services/generatePSDKBatFileContent.ts
+++ b/src/services/generatePSDKBatFileContent.ts
@@ -12,3 +12,10 @@ source ./setup.sh
 cd "${projectPath}"
 PSDK_BINARY_PATH="${getPSDKBinariesPath()}/" ruby Game.rb "$@"
 `;
+
+export const generateGameLinuxFileContent = (projectPath: string) => `#!/bin/bash
+cd "${getPSDKBinariesPath()}/ruby-dist"
+source ./setup.sh
+cd "${projectPath}"
+PSDK_BINARY_PATH="${getPSDKBinariesPath()}/" ruby --disable=gems,rubyopt,did_you_mean Game.rb "$@"
+`;

--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -1,13 +1,22 @@
 import { spawn } from 'child_process';
 import path from 'path';
-import { generateGameMacFileContent, generatePSDKBatFileContent } from '@services/generatePSDKBatFileContent';
+import { generateGameLinuxFileContent, generateGameMacFileContent, generatePSDKBatFileContent } from '@services/generatePSDKBatFileContent';
 import { writeFileSync, existsSync, readFileSync, renameSync, chmodSync } from 'fs';
 import { getPSDKBinariesPath } from '@services/getPSDKVersion';
+import log from 'electron-log';
 
 export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, string[]] => {
   if (process.platform === 'win32') {
     return ['cmd.exe', ['/c', `"${projectPath}/psdk.bat" ${args.join(' ')}`]];
   } else if (process.platform === 'linux') {
+    const linuxArgs = ['-e', `"${projectPath.replaceAll(' ', '\\ ')}/game-linux.sh ${args.join(' ')}"`];
+    if (existsSync('/usr/bin/gnome-terminal')) {
+      return ['gnome-terminal', linuxArgs];
+    }
+    if (existsSync('/usr/bin/konsole')) {
+      return ['konsole', linuxArgs];
+    }
+    log.info('No terminal found. The PSDK console will not be displayed.');
     return ['./game-linux.sh', args];
   } else if (process.platform === 'darwin') {
     // TODO: figure out how to display the console :v
@@ -17,12 +26,19 @@ export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, s
   }
 };
 
-const bootLoadFilename = process.platform === 'darwin' ? 'game-mac.sh' : 'psdk.bat';
-const generateBootLoadContent = (projectPath: string) =>
-  process.platform === 'darwin' ? generateGameMacFileContent(projectPath) : generatePSDKBatFileContent();
+const bootLoadFilename = () => {
+  if (process.platform === 'darwin') return 'game-mac.sh';
+  if (process.platform === 'linux') return 'game-linux.sh';
+  return 'psdk.bat';
+};
+const generateBootLoadContent = (projectPath: string) => {
+  if (process.platform === 'darwin') return generateGameMacFileContent(projectPath);
+  if (process.platform === 'linux') return generateGameLinuxFileContent(projectPath);
+  return generatePSDKBatFileContent();
+};
 
 export const RMXP2StudioSafetyNet = (projectPath: string) => {
-  const psdkBatPath = path.join(projectPath, bootLoadFilename);
+  const psdkBatPath = path.join(projectPath, bootLoadFilename());
   const psdkBatContent = generateBootLoadContent(projectPath);
   const realPsdkBatContent = existsSync(psdkBatPath) && readFileSync(psdkBatPath).toString('utf-8');
   if (realPsdkBatContent !== psdkBatContent) writeFileSync(psdkBatPath, psdkBatContent);
@@ -40,13 +56,28 @@ export const RMXP2StudioSafetyNet = (projectPath: string) => {
   }
 };
 
+// To prevent multiple launches of PSDK (delay 250 ms)
+let lastDatePSDKLaunch = 0;
+const canLaunchPSDK = () => {
+  const now = Date.now();
+  if (now > lastDatePSDKLaunch + 250) {
+    lastDatePSDKLaunch = now;
+    return true;
+  }
+  return false;
+};
+
 export const startPSDK = (projectPath: string) => {
+  if (!canLaunchPSDK()) return;
+
   RMXP2StudioSafetyNet(projectPath);
   const childProcess = spawn(...getSpawnArgs(projectPath), { cwd: projectPath, shell: true, detached: true, stdio: 'ignore' });
   childProcess.unref();
 };
 
 const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
+  if (!canLaunchPSDK()) return;
+
   RMXP2StudioSafetyNet(projectPath);
   const childProcess = spawn(...getSpawnArgs(projectPath, ...args), { cwd: projectPath, shell: true, detached: true, stdio: 'ignore' });
   childProcess.unref();

--- a/src/views/components/buttons/PlayButton.tsx
+++ b/src/views/components/buttons/PlayButton.tsx
@@ -84,8 +84,6 @@ const PlayButtonContainer = styled.div`
   }
 `;
 
-const isEnabled = () => window.api.platform === 'win32' || window.api.platform === 'darwin';
-
 export const PlayButton = () => {
   const [state] = useGlobalState();
   const [isOpen, setIsOpen] = useState(false);
@@ -107,9 +105,9 @@ export const PlayButton = () => {
   useShortcut(shortcutMap);
 
   return (
-    <PlayButtonContainer className={isOpen ? 'open' : undefined} data-disabled={(!isEnabled()).toString()} onMouseLeave={() => setIsOpen(false)}>
-      <StyledNavLinkActionItem data-disabled={(!isEnabled()).toString()} onMouseEnter={() => isEnabled() && setIsOpen(true)}>
-        <NavigationBarItemContainer onClick={() => isEnabled() && startPSDKAndCloseMenu(window.api.startPSDKDebug)} disabled={!isEnabled()}>
+    <PlayButtonContainer className={isOpen ? 'open' : undefined} onMouseLeave={() => setIsOpen(false)}>
+      <StyledNavLinkActionItem onMouseEnter={() => setIsOpen(true)}>
+        <NavigationBarItemContainer onClick={() => startPSDKAndCloseMenu(window.api.startPSDKDebug)}>
           <PlayIcon />
           <span className="triangle" />
         </NavigationBarItemContainer>


### PR DESCRIPTION
## Description

This PR enables the PlayButton on Linux and adds everything needed to launch PSDK. The menu bar is also hidden by default.
The feature is enabled for all Linux systems, but in practice the binaries allow PSDK to be run on operating systems using the x11 window system (tested on Ubuntu 22, Debian 12 and SteamOS).

## Note before testing

A Linux system is required to test this PR. Don't forget to add the binaries.
Extract the archive in psdk-binaries folder: https://download.psdk.pokemonworkshop.com/binaries/Linux.7z

## Tests to perform

- [ ] The user can launch PSDK on Linux
