### PR TITLE
Fix a bug with the Pokédex Evolution button applying to the wrong Pokémon after drag & drop

### DIFF
--- a/src/views/components/database/dex/table/DexPokemonListTable.tsx
+++ b/src/views/components/database/dex/table/DexPokemonListTable.tsx
@@ -64,8 +64,8 @@ export const DexPokemonListTable = ({ dex, dialogsRef, setCreatureIndex }: DexPo
           const desI = result.destination?.index;
           if (desI === undefined) return;
 
-          dex.creatures.splice(desI, 0, dex.creatures.splice(srcI, 1)[0]);
-          setDex({ [dex.dbSymbol]: dex });
+          currentEditedDex.creatures.splice(desI, 0, currentEditedDex.creatures.splice(srcI, 1)[0]);
+          setDex({ [currentEditedDex.dbSymbol]: currentEditedDex });
         }}
       >
         <DataPokemonVirtualizedListContainer height={dex.creatures.length <= 10 ? 40 * dex.creatures.length : 420}>


### PR DESCRIPTION
## Description

After a drag & drop in the Pokédex Pokémon list, the Evolution button applying to the wrong Pokémon. This PR fixes the issue.
Issue: https://github.com/PokemonWorkshop/PokemonStudio/issues/239

## Tests to perform

- [ ] Check that the Evolution button works properly
