### PR TITLE
Move the new project archive to app data home

### DIFF
--- a/src/backendTasks/checkDownloadNewProject.ts
+++ b/src/backendTasks/checkDownloadNewProject.ts
@@ -2,10 +2,10 @@ import log from 'electron-log';
 import fs from 'fs';
 import path from 'path';
 import { requestJson } from './requestJson';
-import { getAppRootPath } from './getAppRootPath';
 import { Sha1 } from '@modelEntities/sha1';
 import { calculateFileSha1, compareSha1 } from './calculateFileSha1';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import { getStudioResourcesPath } from './getStudioResourcesPath';
 
 export type CheckDownloadNewProjectInput = { url: string };
 export type CheckDownloadNewProjectOutput = { needDownload: false } | { needDownload: true; filename: string; sha1: Sha1 };
@@ -13,7 +13,7 @@ export type LatestNewProject = { filename: string; sha1: string };
 
 export const checkDownloadNewProject = async (payload: CheckDownloadNewProjectInput) => {
   log.info('check-download-new-project', payload);
-  const archivePath = path.join(getAppRootPath(), 'new-project.zip');
+  const archivePath = path.join(getStudioResourcesPath(), 'new-project.zip');
   const json = (await requestJson(payload.url)) as LatestNewProject;
   log.info('check-download-new-project/request-json', json);
 

--- a/src/backendTasks/downloadFile.ts
+++ b/src/backendTasks/downloadFile.ts
@@ -5,10 +5,10 @@ import path from 'path';
 import * as stream from 'stream';
 import { promisify } from 'util';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
-import { getAppRootPath } from './getAppRootPath';
 import { ChannelNames, sendProgress } from '@utils/BackendTask';
 import { calculateFileSha1, compareSha1 } from './calculateFileSha1';
 import { Sha1 } from '@modelEntities/sha1';
+import { getStudioResourcesPath } from './getStudioResourcesPath';
 
 type DestFile = { target: 'studio'; path?: string; filename: string } | { target: 'project'; path: string; filename: string };
 export type DownloadFileInput = { url: string; dest: DestFile; sha1?: string };
@@ -17,8 +17,8 @@ const finished = promisify(stream.finished);
 
 const getDestPath = (destFile: DestFile) => {
   if (destFile.target === 'studio') {
-    if (destFile.path) return path.join(getAppRootPath(), destFile.path, destFile.filename);
-    return path.join(getAppRootPath(), destFile.filename);
+    if (destFile.path) return path.join(getStudioResourcesPath(), destFile.path, destFile.filename);
+    return path.join(getStudioResourcesPath(), destFile.filename);
   } else {
     return path.join(destFile.path, destFile.filename);
   }

--- a/src/backendTasks/extractNewProject.ts
+++ b/src/backendTasks/extractNewProject.ts
@@ -1,12 +1,12 @@
 import type { IpcMainEvent } from 'electron';
 import log from 'electron-log';
 import { mkdirSync } from 'fs';
-import { getAppRootPath } from './getAppRootPath';
 import path from 'path';
 import extract from 'extract-zip';
 import { ZipFile } from 'yauzl';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 import { ChannelNames, sendProgress } from '@utils/BackendTask';
+import { getStudioResourcesPath } from './getStudioResourcesPath';
 
 const PSDK_PROJECT_PATH = 'new-project.zip';
 
@@ -19,7 +19,7 @@ const extractNewProject = async (payload: ExtractNewProjectInput, event: IpcMain
   log.info('extract-new-project/creating directory');
   mkdirSync(payload.projectDirName);
   log.info('extract-new-project/extract');
-  await extract(path.join(getAppRootPath(), PSDK_PROJECT_PATH), {
+  await extract(path.join(getStudioResourcesPath(), PSDK_PROJECT_PATH), {
     dir: payload.projectDirName,
     onEntry: (_, zipFile: ZipFile) => {
       const progress = Number(((countEntry.value / zipFile.entryCount) * 100).toFixed(1));

--- a/src/backendTasks/getStudioResourcesPath.ts
+++ b/src/backendTasks/getStudioResourcesPath.ts
@@ -1,0 +1,19 @@
+import { getAppRootPath } from './getAppRootPath';
+import path from 'path';
+import fs from 'fs';
+
+export const getStudioResourcesPath = () => {
+  if (process.env.NODE_ENV === 'development') return getAppRootPath();
+  if (process.env.APPDATA) return createFolder(path.join(process.env.APPDATA, './pokemon-studio-resources'));
+  if (process.env.HOME) return createFolder(path.join(process.env.HOME, './pokemon-studio-resources'));
+
+  return getAppRootPath();
+};
+
+const createFolder = (path: string) => {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path);
+  }
+
+  return path;
+};

--- a/src/backendTasks/getStudioResourcesPath.ts
+++ b/src/backendTasks/getStudioResourcesPath.ts
@@ -4,8 +4,8 @@ import fs from 'fs';
 
 export const getStudioResourcesPath = () => {
   if (process.env.NODE_ENV === 'development') return getAppRootPath();
-  if (process.env.APPDATA) return createFolder(path.join(process.env.APPDATA, './pokemon-studio-resources'));
-  if (process.env.HOME) return createFolder(path.join(process.env.HOME, './pokemon-studio-resources'));
+  if (process.env.APPDATA) return createFolder(path.join(process.env.APPDATA, '.pokemon-studio-resources'));
+  if (process.env.HOME) return createFolder(path.join(process.env.HOME, '.pokemon-studio-resources'));
 
   return getAppRootPath();
 };


### PR DESCRIPTION
- [x] Créer un nouveau projet en tant que développeur, l'archive sera placé comme avant (le dossier du projet pour séparer la prod du mode developpeur)
- [x] Créer un projet en tant qu'utilisateur (npm run make et installer Studio), l'archive sera placé dans AppData/Roaming/.pokemon-studio-resources sur Windows et /home/USERNAME/.pokemon-studio-resources sur Linux (et Mac ?)
