### PR TITLE
Display the move id after the name in the MoveFrame component

### DIFF
--- a/src/views/components/database/move/MoveFrame.tsx
+++ b/src/views/components/database/move/MoveFrame.tsx
@@ -15,6 +15,7 @@ import {
 } from '../dataBlocks';
 import { StudioMove } from '@modelEntities/move';
 import { MoveDialogsRef } from './editors/MoveEditorOverlay';
+import { padStr } from '@utils/PadStr';
 
 type MoveFrameProps = {
   move: StudioMove;
@@ -33,7 +34,10 @@ export const MoveFrame = ({ move, dialogsRef }: MoveFrameProps) => {
         <DataInfoContainer>
           <DataInfoContainerHeader>
             <DataInfoContainerHeaderTitle>
-              <h1>{getMoveName(move)}</h1>
+              <h1>
+                {move && getMoveName(move)}
+                <span className="data-id">#{padStr(move?.id, 3)}</span>
+                </h1>
               <CopyIdentifier dataToCopy={move.dbSymbol} />
             </DataInfoContainerHeaderTitle>
             <DataInfoContainerHeaderBadges>


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description
Displays the move identifier 


## Note before testing

<!-- Optional but can be useful if the tester has to update a lib for example. -->

## Tests to perform

<!-- Explain all the scenario the tester has to test. -->
