### PR TITLE
Fix a rollback in the useCheckMapsModified hook

### DIFF
--- a/src/utils/useCheckMapsModified.ts
+++ b/src/utils/useCheckMapsModified.ts
@@ -44,7 +44,7 @@ export const useCheckMapsModified = () => {
       }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
+  }, [state, globalState.mapsModified, globalState.projectPath, globalState.projectData.maps]);
 
   return {
     checkMaps: (payload: CheckMapsModifiedPayload) => setState({ state: 'checkMapsModified', payload }),


### PR DESCRIPTION
## Description

This PR fixes a rollback in the useCheckMapsModified hook. After updating the maps, if new maps were detected, the old updated maps could return to the list of maps to be updated.
