### PR TITLE
Implement new select

### DIFF
--- a/config/webpack.main.config.ts
+++ b/config/webpack.main.config.ts
@@ -1,28 +1,29 @@
-import path from "path";
-import type { Configuration } from "webpack";
+import path from 'path';
+import type { Configuration } from 'webpack';
 
-import { rules } from "./webpack.rules";
+import { rules } from './webpack.rules';
 
 export const mainConfig: Configuration = {
   /**
    * This is the main entry point for your application, it's the first file
    * that runs in the main process.
    */
-  entry: "./src/main/index.ts",
+  entry: './src/main/index.ts',
   // Put your normal webpack config below here
   module: {
     rules,
   },
   resolve: {
-    extensions: [".js", ".ts", ".jsx", ".tsx", ".css", ".json"],
+    extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
     alias: {
-      "@components": path.resolve(__dirname, "..", "src/views/components"),
-      "@pages": path.resolve(__dirname, "..", "src/views/pages"),
-      "@modelEntities": path.resolve(__dirname, "..", "src/models/entities"),
-      "@services": path.resolve(__dirname, "..", "src/services"),
-      "@utils": path.resolve(__dirname, "..", "src/utils"),
-      "@assets": path.resolve(__dirname, "..", "assets"),
-      "@src": path.resolve(__dirname, "..", "src"),
+      '@components': path.resolve(__dirname, '..', 'src/views/components'),
+      '@ds': path.resolve(__dirname, '..', 'src/designSystem'),
+      '@pages': path.resolve(__dirname, '..', 'src/views/pages'),
+      '@modelEntities': path.resolve(__dirname, '..', 'src/models/entities'),
+      '@services': path.resolve(__dirname, '..', 'src/services'),
+      '@utils': path.resolve(__dirname, '..', 'src/utils'),
+      '@assets': path.resolve(__dirname, '..', 'assets'),
+      '@src': path.resolve(__dirname, '..', 'src'),
     },
   },
 };

--- a/config/webpack.renderer.config.ts
+++ b/config/webpack.renderer.config.ts
@@ -1,12 +1,12 @@
-import path from "path";
-import type { Configuration } from "webpack";
+import path from 'path';
+import type { Configuration } from 'webpack';
 
-import { rules } from "./webpack.rules";
-import { plugins } from "./webpack.plugins";
+import { rules } from './webpack.rules';
+import { plugins } from './webpack.plugins';
 
 rules.push({
   test: /\.css$/,
-  use: [{ loader: "style-loader" }, { loader: "css-loader" }],
+  use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
 });
 
 export const rendererConfig: Configuration = {
@@ -15,15 +15,16 @@ export const rendererConfig: Configuration = {
   },
   plugins,
   resolve: {
-    extensions: [".js", ".ts", ".jsx", ".tsx", ".css"],
+    extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],
     alias: {
-      "@components": path.resolve(__dirname, "..", "src/views/components"),
-      "@pages": path.resolve(__dirname, "..", "src/views/pages"),
-      "@modelEntities": path.resolve(__dirname, "..", "src/models/entities"),
-      "@services": path.resolve(__dirname, "..", "src/services"),
-      "@utils": path.resolve(__dirname, "..", "src/utils"),
-      "@assets": path.resolve(__dirname, "..", "assets"),
-      "@src": path.resolve(__dirname, "..", "src"),
+      '@components': path.resolve(__dirname, '..', 'src/views/components'),
+      '@ds': path.resolve(__dirname, '..', 'src/designSystem'),
+      '@pages': path.resolve(__dirname, '..', 'src/views/pages'),
+      '@modelEntities': path.resolve(__dirname, '..', 'src/models/entities'),
+      '@services': path.resolve(__dirname, '..', 'src/services'),
+      '@utils': path.resolve(__dirname, '..', 'src/utils'),
+      '@assets': path.resolve(__dirname, '..', 'assets'),
+      '@src': path.resolve(__dirname, '..', 'src'),
     },
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import WorldRouter from '@pages/world/World.Router.page';
 import SettingsRouter from '@pages/settings/Settings.Router.page';
 
 import './i18n';
+import DesignSystemRouterComponent from '@ds/DesignSystem.router';
 
 const App = () => {
   return (
@@ -41,6 +42,7 @@ const App = () => {
               <Route path="/help" />
               <Route path="/settings/*" element={<SettingsRouter />} />
               <Route path="/account" />
+              <Route path="/designSystem/*" element={<DesignSystemRouterComponent />} />
               <Route path="/" element={<Navigate to="/home" />} />
             </Routes>
           </MemoryRouter>

--- a/src/designSystem/DesignSystem.router.tsx
+++ b/src/designSystem/DesignSystem.router.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { PageWithMenu, PageWithMenuProps } from '@components/pages';
+import { NavigationDatabaseStyle } from '@components/database/navigation/NavigationDatabase/NavigationDatabaseStyle';
+import { NavigationDatabaseGroup } from '@components/database/navigation/NavigationDatabaseGroup';
+import { NavigationDatabaseItem } from '@components/database/navigation/NavigationDatabaseItem';
+import { DesignSystem } from './DesignSystem';
+import { SelectExamples } from './Select/Examples';
+
+const DesignSystemNavigation = () => {
+  return (
+    <NavigationDatabaseStyle>
+      <NavigationDatabaseGroup title="Inputs">
+        <NavigationDatabaseItem path="/designSystem/select" label="Select" />
+      </NavigationDatabaseGroup>
+      <NavigationDatabaseGroup title="Navigation">
+        <NavigationDatabaseItem path="/designSystem/home" label="Design System Home" />
+        <NavigationDatabaseItem path="/" label="Pokémon Studio Home" />
+      </NavigationDatabaseGroup>
+    </NavigationDatabaseStyle>
+  );
+};
+
+const DesignSystemPageWithMenu = ({ children }: Omit<PageWithMenuProps, 'navigation'>) => (
+  <PageWithMenu navigation={<DesignSystemNavigation />}>{children}</PageWithMenu>
+);
+
+const DesignSystemRouterComponent = () => {
+  return (
+    <Routes>
+      <Route
+        path="/home"
+        element={
+          <DesignSystemPageWithMenu>
+            <DesignSystem />
+          </DesignSystemPageWithMenu>
+        }
+        index
+      />
+      <Route
+        path="select"
+        element={
+          <DesignSystemPageWithMenu>
+            <SelectExamples />
+          </DesignSystemPageWithMenu>
+        }
+      />
+    </Routes>
+  );
+};
+
+export default DesignSystemRouterComponent;

--- a/src/designSystem/DesignSystem.tsx
+++ b/src/designSystem/DesignSystem.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const DesignSystem = () => (
+  <div style={{ margin: '32px' }}>
+    <h1>Design System</h1>
+    <p>You're on the design system section of Pokémon Studio.</p>
+    <p>This hidden section allows you to see how the generic components of Pokémon Studio work in regard of the established design system!</p>
+  </div>
+);

--- a/src/designSystem/Select/Examples.tsx
+++ b/src/designSystem/Select/Examples.tsx
@@ -5,7 +5,7 @@ import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/
 import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { useDialogsRef } from '@utils/useDialogsRef';
-import React, { FormEventHandler, forwardRef, useRef, useState } from 'react';
+import React, { FormEventHandler, forwardRef, useMemo, useRef, useState } from 'react';
 import { Select } from './Select';
 import { SelectContainerWithLabel } from '@components/selects/SelectContainerWithLabel';
 
@@ -44,10 +44,13 @@ export const SelectExamples = () => {
         <Select options={genericOptions} defaultValue="value_c" notFoundLabel={'Not found'} />
       </SelectContainerWithLabel>
       <br />
+      <h2>With disabled effect</h2>
+      <PotentiallyDisabledComponent />
+      <br />
       <h2>Test dialogs</h2>
       <PrimaryButton onClick={() => dialogsRef.current?.openDialog('dialog')}>Open Dialog</PrimaryButton>
       <SelectEditorOverlay ref={dialogsRef} />
-      <h2 style={{ marginTop: '20vh' }}>Uncontrolled selects</h2>
+      <h2 style={{ marginTop: '10vh' }}>Uncontrolled selects</h2>
       <UncontrolledSelects />
     </div>
   );
@@ -104,6 +107,42 @@ const UncontrolledSelects = () => {
           <Select options={bigOptions} placeholder="Choose a value" defaultValue="value_1023" optionRef={ref2} />
           <button onClick={() => alert(`Value: ${ref2.current}`)}>Show Value</button>
         </InputWithLeftLabelContainer>
+      </InputContainer>
+    </div>
+  );
+};
+
+const PotentiallyDisabledComponent = () => {
+  const [value1, setValue1] = useState<GenericOptionValue | 'choose'>('choose');
+  const [value2, setValue2] = useState<GenericOptionValue | 'choose'>('choose');
+  const [value3, setValue3] = useState<GenericOptionValue | 'choose'>('choose');
+  const options = useMemo(() => genericOptions.slice(0, 2), []);
+  const options1 = options.filter(({ value }) => value !== value2 && value !== value3);
+  const options2 = options.filter(({ value }) => value !== value1 && value !== value3);
+  const options3 = options.filter(({ value }) => value !== value1 && value !== value2);
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Choice 1</Label>
+          <Select value={value1} options={options1} chooseValue="choose" placeholder="Choose a value" onChange={setValue1} />
+          <button onClick={() => setValue1('choose')}>Reset</button>
+        </InputWithTopLabelContainer>
+      </InputContainer>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Choice 2</Label>
+          <Select value={value2} options={options2} placeholder="Choose a value" onChange={setValue2} />
+          <button onClick={() => setValue2('choose')}>Reset</button>
+        </InputWithTopLabelContainer>
+      </InputContainer>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Choice 3</Label>
+          <Select value={value3} options={options3} placeholder="Choose a value" onChange={setValue3} />
+          <button onClick={() => setValue3('choose')}>Reset</button>
+        </InputWithTopLabelContainer>
       </InputContainer>
     </div>
   );

--- a/src/designSystem/Select/Examples.tsx
+++ b/src/designSystem/Select/Examples.tsx
@@ -1,0 +1,139 @@
+import { PrimaryButton, SecondaryButton } from '@components/buttons';
+import { Editor } from '@components/editor';
+import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { assertUnreachable } from '@utils/assertUnreachable';
+import { useDialogsRef } from '@utils/useDialogsRef';
+import React, { forwardRef, useRef, useState } from 'react';
+import { Select } from './Select';
+import { SelectContainerWithLabel } from '@components/selects/SelectContainerWithLabel';
+
+export const SelectEditorOverlay = defineEditorOverlay<'dialog', {}>('SelectExampleOverlay', (dialogToShow, handleCloseRef, closeDialog, props) => {
+  switch (dialogToShow) {
+    case 'dialog':
+      return <SelectDialog ref={handleCloseRef} closeDialog={closeDialog} />;
+    default:
+      return assertUnreachable(dialogToShow);
+  }
+});
+
+const genericOptions = [
+  { value: 'value_a', label: 'Option A' },
+  { value: 'value_b', label: 'Choice B' },
+  { value: 'value_c', label: 'Very long stuff C that needs tooltip', tooltip: 'Very long stuff C that needs tooltip' },
+  { value: 'value_d', label: 'Option D' },
+  { value: 'value_e', label: 'Choice E' },
+  { value: 'value_f', label: 'Choice F' },
+  { value: 'value_g', label: 'Option G' },
+] as const;
+type GenericOptionValue = (typeof genericOptions)[number]['value'];
+
+export const SelectExamples = () => {
+  const dialogsRef = useDialogsRef<'dialog'>();
+
+  return (
+    <div style={{ padding: '32px', width: '100%', overflow: 'auto' }}>
+      <h2>Controlled selects</h2>
+      <ControlledSelects />
+      <p>Note: Tooltip is not yet on steroid so they don't show but they will show once they under steroid!</p>
+      <br />
+      <h2>Select like ControlBar</h2>
+      <SelectContainerWithLabel>
+        <span>Options</span>
+        <Select options={genericOptions} defaultValue="value_c" notFoundLabel={'Not found'} />
+      </SelectContainerWithLabel>
+      <br />
+      <h2>Test dialogs</h2>
+      <PrimaryButton onClick={() => dialogsRef.current?.openDialog('dialog')}>Open Dialog</PrimaryButton>
+      <SelectEditorOverlay ref={dialogsRef} />
+      <h2 style={{ marginTop: '20vh' }}>Unconrolled selects</h2>
+      <UnconrolledSelects />
+    </div>
+  );
+};
+
+const ControlledSelects = () => {
+  const [value1, setValue1] = useState<GenericOptionValue | 'choose'>('choose');
+  const [value2, setValue2] = useState<GenericOptionValue>('invalid' as unknown as GenericOptionValue);
+  const [value3, setValue3] = useState<GenericOptionValue>('value_d');
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Nothing selected</Label>
+          <Select value={value1} options={genericOptions} chooseValue="choose" placeholder="Choose a value" onChange={setValue1} />
+          <button onClick={() => setValue1('choose')}>Reset</button>
+        </InputWithTopLabelContainer>
+      </InputContainer>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Invalid selection</Label>
+          <Select value={value2} options={genericOptions} notFoundLabel="Value not found" onChange={setValue2} />
+          <button onClick={() => setValue2('invalid' as unknown as GenericOptionValue)}>Make invalid</button>
+        </InputWithTopLabelContainer>
+      </InputContainer>
+      <InputContainer size="s">
+        <InputWithTopLabelContainer>
+          <Label>Normal selection</Label>
+          <Select value={value3} options={genericOptions} onChange={setValue3} />
+        </InputWithTopLabelContainer>
+      </InputContainer>
+    </div>
+  );
+};
+
+const UnconrolledSelects = () => {
+  const ref1 = useRef<string | undefined>();
+  const ref2 = useRef<string | undefined>();
+  const bigOptions = Array.from({ length: 2000 }, (_, i) => ({ value: `value_${i}`, label: `Option ${i}` }));
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+      <InputContainer size="s">
+        <InputWithLeftLabelContainer>
+          <Label>Nothing</Label>
+          <Select options={bigOptions} placeholder="Choose a value" optionRef={ref1} />
+          <button onClick={() => alert(`Value: ${ref1.current}`)}>Show Value</button>
+        </InputWithLeftLabelContainer>
+      </InputContainer>
+      <InputContainer size="s">
+        <InputWithLeftLabelContainer>
+          <Label>Normal</Label>
+          <Select options={bigOptions} placeholder="Choose a value" defaultValue="value_1023" optionRef={ref2} />
+          <button onClick={() => alert(`Value: ${ref2.current}`)}>Show Value</button>
+        </InputWithLeftLabelContainer>
+      </InputContainer>
+    </div>
+  );
+};
+
+const SelectDialog = forwardRef<EditorHandlingClose, { closeDialog: () => void }>(({ closeDialog }, ref) => {
+  const dialogsRef = useDialogsRef<'dialog'>();
+  useEditorHandlingClose(ref);
+
+  return (
+    <Editor type="studio" title={'Dialog'}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <InputContainer size="s">
+          <InputWithTopLabelContainer>
+            <Label>Nothing selected</Label>
+            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" />
+          </InputWithTopLabelContainer>
+          <InputWithLeftLabelContainer>
+            <Label>Normal</Label>
+            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" defaultValue="value_e" />
+          </InputWithLeftLabelContainer>
+        </InputContainer>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '32px' }}>
+        <SecondaryButton onClick={() => dialogsRef.current?.openDialog('dialog', true)}>Sub dialog centered</SecondaryButton>
+        <SecondaryButton onClick={() => dialogsRef.current?.openDialog('dialog')}>Sub dialog on right</SecondaryButton>
+        <PrimaryButton onClick={closeDialog}>Close</PrimaryButton>
+      </div>
+      <SelectEditorOverlay ref={dialogsRef} />
+    </Editor>
+  );
+});
+SelectDialog.displayName = 'SelectDialog';

--- a/src/designSystem/Select/Examples.tsx
+++ b/src/designSystem/Select/Examples.tsx
@@ -5,7 +5,7 @@ import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/
 import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { useDialogsRef } from '@utils/useDialogsRef';
-import React, { forwardRef, useRef, useState } from 'react';
+import React, { FormEventHandler, forwardRef, useRef, useState } from 'react';
 import { Select } from './Select';
 import { SelectContainerWithLabel } from '@components/selects/SelectContainerWithLabel';
 
@@ -113,20 +113,28 @@ const SelectDialog = forwardRef<EditorHandlingClose, { closeDialog: () => void }
   const dialogsRef = useDialogsRef<'dialog'>();
   useEditorHandlingClose(ref);
 
+  const onSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const values = Object.fromEntries(formData);
+    alert(JSON.stringify(values));
+  };
+
   return (
     <Editor type="studio" title={'Dialog'}>
-      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <form onSubmit={onSubmit}>
         <InputContainer size="s">
           <InputWithTopLabelContainer>
             <Label>Nothing selected</Label>
-            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" />
+            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" name="nothing" />
           </InputWithTopLabelContainer>
           <InputWithLeftLabelContainer>
             <Label>Normal</Label>
-            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" defaultValue="value_e" />
+            <Select options={genericOptions} chooseValue="choose" placeholder="Choose a value" defaultValue="value_e" name="normal" />
           </InputWithLeftLabelContainer>
+          <button type="submit">Submit</button>
         </InputContainer>
-      </div>
+      </form>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '32px' }}>
         <SecondaryButton onClick={() => dialogsRef.current?.openDialog('dialog', true)}>Sub dialog centered</SecondaryButton>
         <SecondaryButton onClick={() => dialogsRef.current?.openDialog('dialog')}>Sub dialog on right</SecondaryButton>

--- a/src/designSystem/Select/Examples.tsx
+++ b/src/designSystem/Select/Examples.tsx
@@ -47,8 +47,8 @@ export const SelectExamples = () => {
       <h2>Test dialogs</h2>
       <PrimaryButton onClick={() => dialogsRef.current?.openDialog('dialog')}>Open Dialog</PrimaryButton>
       <SelectEditorOverlay ref={dialogsRef} />
-      <h2 style={{ marginTop: '20vh' }}>Unconrolled selects</h2>
-      <UnconrolledSelects />
+      <h2 style={{ marginTop: '20vh' }}>Uncontrolled selects</h2>
+      <UncontrolledSelects />
     </div>
   );
 };
@@ -84,7 +84,7 @@ const ControlledSelects = () => {
   );
 };
 
-const UnconrolledSelects = () => {
+const UncontrolledSelects = () => {
   const ref1 = useRef<string | undefined>();
   const ref2 = useRef<string | undefined>();
   const bigOptions = Array.from({ length: 2000 }, (_, i) => ({ value: `value_${i}`, label: `Option ${i}` }));

--- a/src/designSystem/Select/RenderOptions.tsx
+++ b/src/designSystem/Select/RenderOptions.tsx
@@ -54,6 +54,7 @@ export const RenderOptions = <Value extends string, ChooseValue extends string>(
           rowRenderer={rowRenderer}
           width={(props.popover.current?.clientWidth || 0) - (options.length > 5 ? 12 : 8)}
           style={LIST_STYLE}
+          tabIndex={null}
         />
       ) : null}
     </div>

--- a/src/designSystem/Select/RenderOptions.tsx
+++ b/src/designSystem/Select/RenderOptions.tsx
@@ -1,0 +1,62 @@
+import List, { ListRowProps } from 'react-virtualized/dist/es/List';
+import { SelectOption } from './types';
+import { RenderOptionsProps, useRenderOptions } from './useRenderOptions';
+import React, { MouseEventHandler } from 'react';
+
+const CLASSES = ['option', 'option highlighted', 'option current', 'option highlighted current'];
+
+const getClassName = (option: SelectOption<string>, currentValue: string | undefined, index: number, highlightIndex: number) => {
+  if (index === highlightIndex) {
+    return CLASSES[option.value === currentValue ? 3 : 1];
+  }
+  return CLASSES[option.value === currentValue ? 2 : 0];
+};
+
+const LIST_STYLE = { height: 'auto', maxHeight: '195px' };
+
+const allowScroll: MouseEventHandler<HTMLDivElement> = (event) => {
+  if (event.target instanceof HTMLElement && event.target.tagName === 'DIV') {
+    event.preventDefault();
+  }
+};
+
+export const RenderOptions = <Value extends string, ChooseValue extends string>(props: RenderOptionsProps<Value, ChooseValue>) => {
+  const { options, highlightIndex, currentValue } = useRenderOptions(props);
+
+  const rowRenderer = ({ style, index, key }: ListRowProps) => {
+    if (!options) return null;
+    const option = options[index];
+    return (
+      <span
+        key={key}
+        className={getClassName(option, currentValue, index, highlightIndex)}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          props.onSelectValue(option.value);
+        }}
+        data-tool-tip={option.tooltip}
+        style={style}
+      >
+        {option.label}
+      </span>
+    );
+  };
+
+  return (
+    <div className="select-popover" ref={props.popover} onMouseDown={allowScroll}>
+      {options ? (
+        <List
+          ref={props.listRef}
+          className="select-list"
+          height={195}
+          rowHeight={39}
+          rowCount={options.length}
+          rowRenderer={rowRenderer}
+          width={(props.popover.current?.clientWidth || 0) - (options.length > 5 ? 12 : 8)}
+          style={LIST_STYLE}
+        />
+      ) : null}
+    </div>
+  );
+};
+RenderOptions.displayName = 'RenderOptions';

--- a/src/designSystem/Select/Select.tsx
+++ b/src/designSystem/Select/Select.tsx
@@ -8,7 +8,7 @@ export const Select = <Value extends string, ChooseValue extends string>(props: 
   const { onSelectValue, optionsUtilsRef, popoverRef, inputRef, outputRef, listRef, inputProps, outputProps } = useSelect(props);
 
   return (
-    <SelectContainer>
+    <SelectContainer className={props.className}>
       <input type="text" ref={inputRef} {...inputProps} />
       <input type="hidden" ref={outputRef} {...outputProps} />
       <DownIcon />

--- a/src/designSystem/Select/Select.tsx
+++ b/src/designSystem/Select/Select.tsx
@@ -3,7 +3,6 @@ import { RenderOptions } from './RenderOptions';
 import { SelectProps, useSelect } from './useSelect';
 import { SelectContainer } from './SelectContainer';
 import { ReactComponent as DownIcon } from '@assets/icons/global/down-icon.svg';
-import { ReactComponent as UpIcon } from '@assets/icons/global/down-icon.svg';
 
 export const Select = <Value extends string, ChooseValue extends string>(props: SelectProps<Value, ChooseValue>) => {
   const { onSelectValue, optionsUtilsRef, popoverRef, inputRef, listRef, inputProps } = useSelect(props);

--- a/src/designSystem/Select/Select.tsx
+++ b/src/designSystem/Select/Select.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { RenderOptions } from './RenderOptions';
+import { SelectProps, useSelect } from './useSelect';
+import { SelectContainer } from './SelectContainer';
+import { ReactComponent as DownIcon } from '@assets/icons/global/down-icon.svg';
+import { ReactComponent as UpIcon } from '@assets/icons/global/down-icon.svg';
+
+export const Select = <Value extends string, ChooseValue extends string>(props: SelectProps<Value, ChooseValue>) => {
+  const { onSelectValue, optionsUtilsRef, popoverRef, inputRef, listRef, inputProps } = useSelect(props);
+
+  return (
+    <SelectContainer>
+      <input type="text" ref={inputRef} {...inputProps} />
+      <DownIcon />
+      <RenderOptions onSelectValue={onSelectValue} utils={optionsUtilsRef} popover={popoverRef} listRef={listRef} />
+    </SelectContainer>
+  );
+};

--- a/src/designSystem/Select/Select.tsx
+++ b/src/designSystem/Select/Select.tsx
@@ -5,11 +5,12 @@ import { SelectContainer } from './SelectContainer';
 import { ReactComponent as DownIcon } from '@assets/icons/global/down-icon.svg';
 
 export const Select = <Value extends string, ChooseValue extends string>(props: SelectProps<Value, ChooseValue>) => {
-  const { onSelectValue, optionsUtilsRef, popoverRef, inputRef, listRef, inputProps } = useSelect(props);
+  const { onSelectValue, optionsUtilsRef, popoverRef, inputRef, outputRef, listRef, inputProps, outputProps } = useSelect(props);
 
   return (
     <SelectContainer>
       <input type="text" ref={inputRef} {...inputProps} />
+      <input type="hidden" ref={outputRef} {...outputProps} />
       <DownIcon />
       <RenderOptions onSelectValue={onSelectValue} utils={optionsUtilsRef} popover={popoverRef} listRef={listRef} />
     </SelectContainer>

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -1,0 +1,139 @@
+import styled from 'styled-components';
+
+export const SelectContainer = styled.div`
+  display: flex;
+  position: relative;
+  height: 40px;
+  min-width: 240px;
+  box-sizing: border-box;
+  user-select: none;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.text400};
+  ${({ theme }) => theme.fonts.normalMedium}
+
+  & svg {
+    position: absolute;
+    right: 16px;
+    top: calc((100% - 6px) / 2);
+  }
+
+  & input {
+    box-sizing: border-box;
+    padding: 9.5px 15px;
+    margin: 0;
+    background-color: ${({ theme }) => theme.colors.dark20};
+    border: 1px solid transparent;
+    border-radius: 8px;
+    ${({ theme }) => theme.fonts.normalMedium}
+    color: ${({ theme }) => theme.colors.text100};
+    min-width: 180px;
+    width: 100%;
+    height: 40px;
+    cursor: pointer;
+
+    &:hover {
+      border-color: ${({ theme }) => theme.colors.dark24};
+      outline: 1.5px solid ${({ theme }) => theme.colors.dark24};
+    }
+
+    &:active,
+    &:focus {
+      border-color: ${({ theme }) => theme.colors.primaryBase};
+      outline: 1.5px solid ${({ theme }) => theme.colors.primaryBase};
+    }
+
+    &:invalid::placeholder {
+      color: ${({ theme }) => theme.colors.dangerBase};
+    }
+
+    &::placeholder {
+      color: ${({ theme }) => theme.colors.text400};
+    }
+
+    &:invalid {
+      color: ${({ theme }) => theme.colors.dangerBase};
+    }
+  }
+
+  &:has(.visible) {
+    color: ${({ theme }) => theme.colors.text400};
+
+    svg {
+      transform: rotate(180deg);
+      color: ${({ theme }) => theme.colors.text100};
+    }
+
+    & input {
+      background-color: ${({ theme }) => theme.colors.dark12};
+      cursor: text;
+    }
+  }
+
+  & > .select-popover {
+    display: none;
+    position: absolute;
+    background-color: ${({ theme }) => theme.colors.dark20};
+    border-radius: 8px;
+    padding: 8px 4px 8px 8px;
+    z-index: 2;
+    box-shadow: 0px 2px 4px ${({ theme }) => theme.colors.dark14};
+    user-select: none;
+    cursor: default;
+    overflow: hidden;
+  }
+
+  & > .select-popover.visible {
+    display: block;
+  }
+
+  & .select-list {
+    padding-right: 4px;
+
+    & span {
+      display: block;
+      margin: 2px 0;
+      max-height: 35px;
+      max-width: calc(100% - 4px);
+      padding: 8px 16px;
+      border-radius: 8px;
+      box-sizing: border-box;
+      ${({ theme }) => theme.fonts.normalMedium}
+      color: ${({ theme }) => theme.colors.text400};
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: pointer;
+    }
+
+    & span.highlighted:not(.current),
+    & span:hover:not(.current) {
+      background-color: ${({ theme }) => theme.colors.dark22};
+    }
+
+    & span.current {
+      color: ${({ theme }) => theme.colors.text100};
+      background: ${({ theme }) => theme.colors.dark23};
+    }
+
+    ::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+
+    ::-webkit-scrollbar-track {
+      margin-bottom: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background-color: ${({ theme }) => theme.colors.dark12};
+      opacity: 0.8;
+      box-sizing: border-box;
+      border: 1px solid ${({ theme }) => theme.colors.text500};
+      border-radius: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: ${({ theme }) => theme.colors.dark15};
+      border-color: ${({ theme }) => theme.colors.text400};
+    }
+  }
+`;

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -4,7 +4,6 @@ export const SelectContainer = styled.div`
   display: flex;
   position: relative;
   height: 40px;
-  min-width: 240px;
   box-sizing: border-box;
   user-select: none;
   cursor: pointer;
@@ -36,6 +35,8 @@ export const SelectContainer = styled.div`
   & input {
     box-sizing: border-box;
     padding: 9.5px 15px;
+    padding-right: 36px;
+    text-overflow: ellipsis;
     margin: 0;
     background-color: ${({ theme }) => theme.colors.dark20};
     border: 1px solid transparent;
@@ -116,6 +117,7 @@ export const SelectContainer = styled.div`
       color: ${({ theme }) => theme.colors.text400};
       overflow: hidden;
       text-overflow: ellipsis;
+      text-wrap: nowrap;
       cursor: pointer;
     }
 

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -15,6 +15,22 @@ export const SelectContainer = styled.div`
     position: absolute;
     right: 16px;
     top: calc((100% - 6px) / 2);
+    transform: scaleY(1);
+    transition: 0.2s;
+  }
+
+  &:has(.visible) {
+    color: ${({ theme }) => theme.colors.text400};
+
+    svg {
+      transform: scaleY(-1);
+      color: ${({ theme }) => theme.colors.text100};
+    }
+
+    & input {
+      background-color: ${({ theme }) => theme.colors.dark12};
+      cursor: text;
+    }
   }
 
   & input {
@@ -55,17 +71,12 @@ export const SelectContainer = styled.div`
     }
   }
 
-  &:has(.visible) {
-    color: ${({ theme }) => theme.colors.text400};
-
-    svg {
-      transform: rotate(180deg);
-      color: ${({ theme }) => theme.colors.text100};
+  @keyframes selectPopoverOpen {
+    from {
+      opacity: 0;
     }
-
-    & input {
-      background-color: ${({ theme }) => theme.colors.dark12};
-      cursor: text;
+    to {
+      opacity: 1;
     }
   }
 
@@ -80,10 +91,14 @@ export const SelectContainer = styled.div`
     user-select: none;
     cursor: default;
     overflow: hidden;
+    opacity: 0;
   }
 
   & > .select-popover.visible {
     display: block;
+    animation-name: selectPopoverOpen;
+    animation-duration: 0.1s;
+    opacity: 1;
   }
 
   & .select-list {
@@ -104,9 +119,12 @@ export const SelectContainer = styled.div`
       cursor: pointer;
     }
 
-    & span.highlighted:not(.current),
     & span:hover:not(.current) {
       background-color: ${({ theme }) => theme.colors.dark22};
+    }
+
+    & span.highlighted:not(.current) {
+      background-color: ${({ theme }) => theme.colors.dark18};
     }
 
     & span.current {

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -48,13 +48,18 @@ export const SelectContainer = styled.div`
     height: 40px;
     cursor: pointer;
 
-    &:hover {
+    &:hover:not(:disabled) {
       border-color: ${({ theme }) => theme.colors.dark24};
       outline: 1.5px solid ${({ theme }) => theme.colors.dark24};
     }
 
-    &:active,
-    &:focus {
+    &:disabled {
+      cursor: not-allowed;
+      filter: opacity(60%);
+    }
+
+    &:active:not(:disabled),
+    &:focus:not(:disabled) {
       border-color: ${({ theme }) => theme.colors.primaryBase};
       outline: 1.5px solid ${({ theme }) => theme.colors.primaryBase};
     }

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -43,7 +43,7 @@ export const SelectContainer = styled.div`
     border: 1px solid transparent;
     border-radius: 8px;
     ${({ theme }) => theme.fonts.normalMedium}
-    color: ${({ theme }) => theme.colors.text100};
+    color: ${({ theme }) => theme.colors.text400};
     min-width: 180px;
     width: 100%;
     height: 40px;
@@ -132,7 +132,7 @@ export const SelectContainer = styled.div`
     }
 
     & span.highlighted:not(.current) {
-      background-color: ${({ theme }) => theme.colors.dark18};
+      background-color: ${({ theme }) => theme.colors.dark16};
     }
 
     & span.current {
@@ -146,7 +146,8 @@ export const SelectContainer = styled.div`
     }
 
     ::-webkit-scrollbar-track {
-      margin-bottom: 4px;
+      margin-bottom: 3px;
+      margin-top: 3px;
     }
 
     ::-webkit-scrollbar-thumb {

--- a/src/designSystem/Select/SelectContainer.tsx
+++ b/src/designSystem/Select/SelectContainer.tsx
@@ -16,6 +16,7 @@ export const SelectContainer = styled.div`
     top: calc((100% - 6px) / 2);
     transform: scaleY(1);
     transition: 0.2s;
+    pointer-events: none;
   }
 
   &:has(.visible) {

--- a/src/designSystem/Select/index.ts
+++ b/src/designSystem/Select/index.ts
@@ -1,0 +1,3 @@
+export * from './Select';
+export * from './useSelect';
+export * from './useRenderOptions';

--- a/src/designSystem/Select/types.ts
+++ b/src/designSystem/Select/types.ts
@@ -5,7 +5,7 @@ export type SelectOption<Value extends string> = {
 };
 
 export type RenderOptionRef<Value extends string, ChooseValue extends string> = {
-  show: (value: Value | ChooseValue, options: Readonly<SelectOption<Value>[]>) => void;
+  show: (value: Value | ChooseValue | undefined, options: Readonly<SelectOption<Value>[]>) => void;
   hide: () => void;
   refine: (options: Readonly<SelectOption<Value>[]>) => void;
   highlightNext: () => void;

--- a/src/designSystem/Select/types.ts
+++ b/src/designSystem/Select/types.ts
@@ -1,0 +1,14 @@
+export type SelectOption<Value extends string> = {
+  value: Value;
+  label: string;
+  tooltip?: string;
+};
+
+export type RenderOptionRef<Value extends string, ChooseValue extends string> = {
+  show: (value: Value | ChooseValue, options: Readonly<SelectOption<Value>[]>) => void;
+  hide: () => void;
+  refine: (options: Readonly<SelectOption<Value>[]>) => void;
+  highlightNext: () => void;
+  highlightPrevious: () => void;
+  pickHighlighted: () => void;
+};

--- a/src/designSystem/Select/useRenderOptions.ts
+++ b/src/designSystem/Select/useRenderOptions.ts
@@ -1,0 +1,59 @@
+import { useState, useImperativeHandle, RefObject } from 'react';
+import type { RenderOptionRef, SelectOption } from './types';
+import { findOptionIndexOrZero } from './utils';
+import type { List } from 'react-virtualized/dist/es/List';
+
+export type RenderOptionsProps<Value extends string, ChooseValue extends string> = {
+  onSelectValue: (value: Value) => void;
+  utils: RefObject<RenderOptionRef<Value, ChooseValue>>;
+  popover: RefObject<HTMLDivElement>;
+  listRef: RefObject<List>;
+};
+
+export const useRenderOptions = <Value extends string, ChooseValue extends string>({
+  utils,
+  onSelectValue,
+  listRef,
+}: RenderOptionsProps<Value, ChooseValue>) => {
+  const [options, setOptions] = useState<Readonly<SelectOption<Value>[]> | undefined>();
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const [currentValue, setCurrentValue] = useState<Value | ChooseValue | undefined>();
+
+  useImperativeHandle(
+    utils,
+    () => ({
+      show: (value, options) => {
+        setCurrentValue(value);
+        setOptions(options);
+        const newHighlightIndex = findOptionIndexOrZero(options, value);
+        setHighlightIndex(newHighlightIndex);
+        setTimeout(() => listRef.current?.scrollToRow(newHighlightIndex), 0);
+      },
+      hide: () => setOptions(undefined),
+      refine: (newOptions) => {
+        if (newOptions.length === 0) return;
+
+        const newHighlightIndex = options ? Math.max(0, newOptions.indexOf(options[highlightIndex])) : 0;
+        setOptions(newOptions);
+        setHighlightIndex(newHighlightIndex);
+        listRef.current?.scrollToRow(newHighlightIndex);
+      },
+      highlightNext: () => {
+        if (!options) return;
+
+        const newHighlightIndex = highlightIndex === options.length - 1 ? highlightIndex : highlightIndex + 1;
+        setHighlightIndex(newHighlightIndex);
+        listRef.current?.scrollToRow(newHighlightIndex);
+      },
+      highlightPrevious: () => {
+        const newHighlightIndex = highlightIndex === 0 ? 0 : highlightIndex - 1;
+        setHighlightIndex(newHighlightIndex);
+        listRef.current?.scrollToRow(newHighlightIndex);
+      },
+      pickHighlighted: () => options && onSelectValue(options[highlightIndex].value),
+    }),
+    [setHighlightIndex, options, onSelectValue, highlightIndex]
+  );
+
+  return { options, highlightIndex, currentValue };
+};

--- a/src/designSystem/Select/useSelect.ts
+++ b/src/designSystem/Select/useSelect.ts
@@ -1,0 +1,127 @@
+import { ChangeEventHandler, FocusEventHandler, InputHTMLAttributes, KeyboardEventHandler, useEffect, useMemo, useRef, useState } from 'react';
+import { RenderOptionRef, SelectOption } from './types';
+import { getNotFoundExclusionPattern, getSelectDefaultLabel, positionAndShowPopover } from './utils';
+import type { List } from 'react-virtualized/dist/es/List';
+
+export type SelectProps<Value extends string, ChooseValue extends string> = {
+  options: Readonly<SelectOption<Value>[]>;
+  chooseValue: ChooseValue;
+  className?: string;
+  notFoundLabel?: string;
+  value?: Value | ChooseValue;
+  defaultValue?: Value | ChooseValue;
+  optionRef?: React.MutableRefObject<Value>;
+  onChange?: (value: Value) => void;
+  disabled?: boolean;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'min' | 'max' | 'value' | 'onChange' | 'type' | 'multiple' | 'list' | 'checked'>;
+
+export const useSelect = <Value extends string, ChooseValue extends string>({
+  options,
+  chooseValue,
+  className,
+  notFoundLabel,
+  value,
+  defaultValue,
+  optionRef,
+  onChange,
+  disabled: disabledFromOutside,
+  ...props
+}: SelectProps<Value, ChooseValue>) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const optionsUtilsRef = useRef<RenderOptionRef<Value, ChooseValue>>(null);
+  const [currentValue, setCurrentValue] = useState(value ?? defaultValue ?? chooseValue);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<List>(null);
+  const defaultInputValue = useMemo(() => getSelectDefaultLabel(value, defaultValue, options, currentValue, notFoundLabel), [value]);
+  const disabled = disabledFromOutside || options.length === 0;
+
+  // Reset input value whenever defaultInputValue changes because defaultValue is definitive so value change can't be forwarded through defaultValue
+  useEffect(() => {
+    // If defaultInputValue did change, then current value must change
+    if (value && value != currentValue) {
+      setCurrentValue(value);
+      if (optionRef?.current) optionRef.current = value as Value;
+      if (inputRef.current) inputRef.current.value = getSelectDefaultLabel(value, defaultValue, options, value, notFoundLabel);
+    }
+  }, [value]);
+
+  // Apply selected value
+  const onSelectValue = (value: Value) => {
+    optionsUtilsRef.current?.hide();
+    setCurrentValue(value);
+    onChange?.(value);
+    if (optionRef) optionRef.current = value;
+
+    // Timeout let react re-render
+    setTimeout(() => {
+      if (inputRef.current) inputRef.current.blur();
+    }, 25);
+  };
+
+  // Let the popover know what to show when the input gets focus
+  const onFocus: FocusEventHandler<HTMLInputElement> = (event) => {
+    if (disabled || !popoverRef.current) return;
+
+    optionsUtilsRef.current?.show(currentValue, options);
+    positionAndShowPopover(event.currentTarget, popoverRef.current);
+  };
+
+  // Hide the popover when it loses focus and revert text value to appropriate one
+  const onBlur: FocusEventHandler<HTMLInputElement> = (event) => {
+    if (disabled || !popoverRef.current) return;
+
+    optionsUtilsRef.current?.hide();
+    popoverRef.current.classList.remove('visible');
+    event.currentTarget.value =
+      options.find((o) => o.value === currentValue)?.label || getSelectDefaultLabel(value, defaultValue, options, currentValue, notFoundLabel);
+  };
+
+  // Handle navigation in select elements
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (disabled) return;
+    if (event.key !== 'Enter' && event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Escape') return;
+
+    event.preventDefault();
+    switch (event.key) {
+      case 'Enter':
+        optionsUtilsRef.current?.pickHighlighted();
+        break;
+      case 'ArrowDown':
+        optionsUtilsRef.current?.highlightNext();
+        break;
+      case 'ArrowUp':
+        optionsUtilsRef.current?.highlightPrevious();
+        break;
+      case 'Escape':
+        event.currentTarget.blur();
+        break;
+    }
+  };
+
+  // Handle search when user inputs stuff in the input, we let the select unfiltered by default so user knows there's more options than the current one!
+  const onInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (disabled) return;
+
+    const value = event.currentTarget.value.toLowerCase();
+    const newOptions = options.filter((o) => o.value.toLowerCase().includes(value) || o.label.toLowerCase().includes(value));
+    optionsUtilsRef.current?.refine(newOptions);
+  };
+
+  return {
+    onSelectValue,
+    optionsUtilsRef,
+    inputRef,
+    popoverRef,
+    listRef,
+    inputProps: {
+      ...props,
+      disabled,
+      onFocus,
+      onBlur,
+      onKeyDown,
+      onChange: onInputChange,
+      pattern: getNotFoundExclusionPattern(notFoundLabel),
+      defaultValue: defaultInputValue,
+    },
+  };
+};

--- a/src/designSystem/Select/utils.ts
+++ b/src/designSystem/Select/utils.ts
@@ -1,0 +1,54 @@
+import type { SelectOption } from './types';
+
+export const findOptionIndexOrZero = <Value extends string>(options: Readonly<SelectOption<Value>[]>, currentValue: Value) =>
+  Math.max(
+    0,
+    options.findIndex(({ value }) => value === currentValue)
+  );
+
+export const getSelectDefaultLabel = <Value extends string>(
+  value: string | undefined,
+  defaultValue: string | undefined,
+  options: Readonly<SelectOption<Value>[]>,
+  currentValue: Value,
+  notFoundLabel: string | undefined
+) => {
+  if (!value && !defaultValue) return '';
+
+  const optionIndex = findOptionIndexOrZero(options, currentValue);
+  if (options.length > 0 && options[optionIndex].value === currentValue) {
+    return options[optionIndex].label;
+  }
+
+  return notFoundLabel || '';
+};
+
+export const getNotFoundExclusionPattern = (notFoundLabel: string | undefined) => {
+  if (!notFoundLabel) return undefined;
+
+  const negativePattern = notFoundLabel.replace(/([\[\(\.\*\\\]\)\{\}])/g, '\\$1');
+  return `^(?:(?!${negativePattern}).)+$`;
+};
+
+// Constant defining how much space we need to display a select
+const SELECT_CLEARANCE = 195;
+// Constant defining how far we put the select display from its input
+const SELECT_SPACING = 4;
+// Popover padding to take into account
+const POPOVER_ADJUSTMENT = 10;
+
+export const positionAndShowPopover = (anchorElement: HTMLElement, popoverElement: HTMLDivElement) => {
+  const clientPos = anchorElement.getBoundingClientRect();
+
+  // TODO: Swap with CSS Anchor once it's available
+  if (clientPos.top > window.innerHeight - SELECT_CLEARANCE - SELECT_SPACING) {
+    popoverElement.style.top = '';
+    popoverElement.style.bottom = `${clientPos.height + SELECT_SPACING}px`;
+  } else {
+    popoverElement.style.top = `${clientPos.height + SELECT_SPACING}px`;
+    popoverElement.style.bottom = '';
+  }
+  popoverElement.style.width = `${clientPos.width - POPOVER_ADJUSTMENT}px`;
+  popoverElement.style.maxHeight = `${SELECT_CLEARANCE}px`;
+  popoverElement.classList.add('visible');
+};

--- a/src/designSystem/Select/utils.ts
+++ b/src/designSystem/Select/utils.ts
@@ -33,9 +33,9 @@ export const getNotFoundExclusionPattern = (notFoundLabel: string | undefined) =
 // Constant defining how much space we need to display a select
 const SELECT_CLEARANCE = 195;
 // Constant defining how far we put the select display from its input
-const SELECT_SPACING = 4;
+const SELECT_SPACING = 7;
 // Popover padding to take into account
-const POPOVER_ADJUSTMENT = 10;
+const POPOVER_ADJUSTMENT = 12;
 
 export const positionAndShowPopover = (anchorElement: HTMLElement, popoverElement: HTMLDivElement) => {
   const clientPos = anchorElement.getBoundingClientRect();

--- a/src/designSystem/Select/utils.ts
+++ b/src/designSystem/Select/utils.ts
@@ -1,6 +1,6 @@
 import type { SelectOption } from './types';
 
-export const findOptionIndexOrZero = <Value extends string>(options: Readonly<SelectOption<Value>[]>, currentValue: Value) =>
+export const findOptionIndexOrZero = <Value extends string>(options: Readonly<SelectOption<Value>[]>, currentValue: Value | undefined) =>
   Math.max(
     0,
     options.findIndex(({ value }) => value === currentValue)
@@ -10,7 +10,7 @@ export const getSelectDefaultLabel = <Value extends string>(
   value: string | undefined,
   defaultValue: string | undefined,
   options: Readonly<SelectOption<Value>[]>,
-  currentValue: Value,
+  currentValue: Value | undefined,
   notFoundLabel: string | undefined
 ) => {
   if (!value && !defaultValue) return '';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -42,6 +42,7 @@ import type { RequestJsonInput, RequestJsonOutput } from './backendTasks/request
 import type { CheckDownloadNewProjectInput, CheckDownloadNewProjectOutput } from './backendTasks/checkDownloadNewProject';
 
 contextBridge.exposeInMainWorld('api', {
+  isDev: process.env.NODE_ENV === 'development',
   clearCache: () => webFrame.clearCache(),
   md5: (value) => ipcRenderer.sendSync('get-md5-hash', value),
   shortcut: {
@@ -148,6 +149,7 @@ type AnyObj = Record<string, never>;
 declare global {
   interface Window {
     api: {
+      isDev: boolean;
       clearCache: () => void;
       md5: (value: string) => string;
       shortcut: {

--- a/src/views/components/inputs/Input.tsx
+++ b/src/views/components/inputs/Input.tsx
@@ -16,7 +16,7 @@ export const Input = styled.input<InputProps>`
   color: ${({ theme, error }) => (error ? theme.colors.dangerBase : theme.colors.text100)};
   text-align: ${(props) => (props.type === 'number' ? 'right' : 'left')};
 
-  &:hover:not(:disabled) {
+  &:hover {
     border-color: ${({ theme }) => theme.colors.dark24};
     outline: 1.5px solid ${({ theme }) => theme.colors.dark24};
   }
@@ -27,8 +27,8 @@ export const Input = styled.input<InputProps>`
   }
 
   &.active,
-  &:active:not(:disabled),
-  &:focus:not(:disabled) {
+  &:active,
+  &:focus {
     border-color: ${({ theme }) => theme.colors.primaryBase};
     outline: 1.5px solid ${({ theme }) => theme.colors.primaryBase};
   }

--- a/src/views/components/inputs/Input.tsx
+++ b/src/views/components/inputs/Input.tsx
@@ -16,14 +16,19 @@ export const Input = styled.input<InputProps>`
   color: ${({ theme, error }) => (error ? theme.colors.dangerBase : theme.colors.text100)};
   text-align: ${(props) => (props.type === 'number' ? 'right' : 'left')};
 
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: ${({ theme }) => theme.colors.dark24};
     outline: 1.5px solid ${({ theme }) => theme.colors.dark24};
   }
 
+  &:disabled {
+    cursor: not-allowed;
+    filter: opacity(60%);
+  }
+
   &.active,
-  &:active,
-  &:focus {
+  &:active:not(:disabled),
+  &:focus:not(:disabled) {
     border-color: ${({ theme }) => theme.colors.primaryBase};
     outline: 1.5px solid ${({ theme }) => theme.colors.primaryBase};
   }

--- a/src/views/components/inputs/InputWithLeftLabelContainer.tsx
+++ b/src/views/components/inputs/InputWithLeftLabelContainer.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Input } from './Input';
+import { SelectContainer } from '@ds/Select/SelectContainer';
 
 export const InputWithLeftLabelContainer = styled.div`
   display: flex;
@@ -8,7 +9,7 @@ export const InputWithLeftLabelContainer = styled.div`
   align-items: center;
   gap: 12px;
 
-  & > ${Input}, & > div > ${Input} {
+  & > ${Input}, & > div > ${Input}, & > div > input {
     width: 80px;
   }
 `;

--- a/src/views/components/inputs/InputWithTopLabelContainer.tsx
+++ b/src/views/components/inputs/InputWithTopLabelContainer.tsx
@@ -1,3 +1,4 @@
+import { SelectContainer } from '@ds/Select/SelectContainer';
 import styled from 'styled-components';
 
 export const InputWithTopLabelContainer = styled.div`

--- a/src/views/components/selects/SelectContainerWithLabel.tsx
+++ b/src/views/components/selects/SelectContainerWithLabel.tsx
@@ -1,3 +1,4 @@
+import { SelectContainer } from '@ds/Select/SelectContainer';
 import styled from 'styled-components';
 
 export const SelectContainerWithLabel = styled.div`
@@ -10,5 +11,9 @@ export const SelectContainerWithLabel = styled.div`
   & span {
     ${({ theme }) => theme.fonts.normalRegular};
     user-select: none;
+  }
+
+  & > ${SelectContainer} {
+    min-width: 240px;
   }
 `;

--- a/src/views/components/selects/SelectPokemon.tsx
+++ b/src/views/components/selects/SelectPokemon.tsx
@@ -4,6 +4,7 @@ import { useSelectOptions } from '@utils/useSelectOptions';
 import { StudioDropDown } from '@components/StudioDropDown';
 import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 import styled from 'styled-components';
+import { Select } from '@ds/Select';
 
 export const BreakableSpan = styled.span<{ breakpoint?: string }>`
   @media ${({ theme, breakpoint }) => (breakpoint ? breakpoint : theme.breakpoints.dataBox422)} {
@@ -36,7 +37,8 @@ export const SelectPokemon = ({ dbSymbol, onChange, breakpoint, noLabel, undefVa
   return (
     <SelectContainerWithLabel>
       <BreakableSpan breakpoint={breakpoint}>{t('pokemon')}</BreakableSpan>
-      <StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />
+      <Select options={options} value={dbSymbol} chooseValue="" onChange={onChange} notFoundLabel={t('pokemon_deleted')} />
+      {/*<StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />*/}
     </SelectContainerWithLabel>
   );
 };

--- a/src/views/components/selects/SelectPokemon.tsx
+++ b/src/views/components/selects/SelectPokemon.tsx
@@ -4,7 +4,6 @@ import { useSelectOptions } from '@utils/useSelectOptions';
 import { StudioDropDown } from '@components/StudioDropDown';
 import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 import styled from 'styled-components';
-import { Select } from '@ds/Select';
 
 export const BreakableSpan = styled.span<{ breakpoint?: string }>`
   @media ${({ theme, breakpoint }) => (breakpoint ? breakpoint : theme.breakpoints.dataBox422)} {
@@ -37,8 +36,7 @@ export const SelectPokemon = ({ dbSymbol, onChange, breakpoint, noLabel, undefVa
   return (
     <SelectContainerWithLabel>
       <BreakableSpan breakpoint={breakpoint}>{t('pokemon')}</BreakableSpan>
-      <Select options={options} value={dbSymbol} chooseValue="" onChange={onChange} notFoundLabel={t('pokemon_deleted')} />
-      {/*<StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />*/}
+      <StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />
     </SelectContainerWithLabel>
   );
 };

--- a/src/views/pages/Home.page.tsx
+++ b/src/views/pages/Home.page.tsx
@@ -17,12 +17,14 @@ import { RecentProjectContainer } from '@components/home/ActionContainer';
 import { HomeEditorAndDeletionKeys, HomeEditorOverlay } from '@components/home/editors/HomeEditorOverlay';
 import { deleteProjectToList, getProjectList } from '@utils/projectList';
 import { useDialogsRef } from '@utils/useDialogsRef';
+import { useNavigate } from 'react-router-dom';
 
 const HomePageComponent = () => {
   const dialogsRef = useDialogsRef<HomeEditorAndDeletionKeys>();
   const [appVersion, setAppVersion] = useState('');
   const [projectList, setProjectList] = useState(getProjectList());
   const { t } = useTranslation('homepage');
+  const navigate = useNavigate();
 
   const onDeleteProjectToList = (event: React.MouseEvent<HTMLSpanElement>, projectPath: string) => {
     event.stopPropagation();
@@ -45,7 +47,7 @@ const HomePageComponent = () => {
       </Header>
       <ActionContainer>
         <BrandingActionContainer>
-          <BrandingTitleContainer>
+          <BrandingTitleContainer onClick={() => window.api.isDev && navigate('/designSystem/home')}>
             <StudioIcon />
             <BrandingTitle>Pokémon Studio</BrandingTitle>
           </BrandingTitleContainer>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "paths": {
       "*": ["node_modules/*"],
       "@components/*": ["src/views/components/*"],
+      "@ds/*": ["src/designSystem/*"],
       "@pages/*": ["src/views/pages/*"],
       "@modelEntities/*": ["src/models/entities/*"],
       "@services/*": ["src/services/*"],


### PR DESCRIPTION
## Description

Ce code ajoute le composant Select selon les termes explicité sur la page: https://github.com/PokemonWorkshop/PokemonStudio/wiki/Select-as-input-tags

Aucune utilisation n'a été faite en dehors des exemples. Le but de cette PR est de s'accorder sur le code et ses exemple puis de merger dans le but de convertir les StudioDropDown / SelectXXX en ce qu'ils devraient être (ce Select).

## Note before testing

Vous pouvez accéder au design System depuis l'accueil de Pokémon Studio en cliquant sur le Logo. Vous trouverez les exemples dans l'onglet **Select**.

J'ai improvisé l'état disabled car il n'existe aucune définition de cette état à ce jour.

## Tests to perform

Tester tous les exemples pour s'assurer que ça correspond bien aux intentions du design system.
