### PR TITLE
Update the pokemonbattlerlist pokmon icons depending on the gender or the shiny value

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -121,11 +121,16 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
   return formResourcesPath(form, 'front');
 };
 
-export const pokemonIconPath = (specie: StudioCreature, formId?: number) => {
+export const pokemonIconPath = (specie: StudioCreature, formId?: number,icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
   if (formId) {
     const form = specie.forms.find((f) => f.form === formId);
-    if (form) return formResourcesPath(form, 'icon');
+    if(form && icon){
+      return formResourcesPath(form, icon);
+    }else if(form){
+      return formResourcesPath(form, 'icon');
+    }
   }
+  if(icon) return formResourcesPath(specie.forms[0], icon);
   return formResourcesPath(specie.forms[0], 'icon');
 };
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -121,17 +121,12 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
   return formResourcesPath(form, 'front');
 };
 
-export const pokemonIconPath = (specie: StudioCreature, formId?: number,icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
+export const pokemonIconPath = (specie: StudioCreature, formId?: number, icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
   if (formId) {
     const form = specie.forms.find((f) => f.form === formId);
-    if(form && icon){
-      return formResourcesPath(form, icon);
-    }else if(form){
-      return formResourcesPath(form, 'icon');
-    }
+    if (form) return formResourcesPath(form, icon ?? 'icon');
   }
-  if(icon) return formResourcesPath(specie.forms[0], icon);
-  return formResourcesPath(specie.forms[0], 'icon');
+  return formResourcesPath(specie.forms[0], icon ?? 'icon');
 };
 
 export const itemIconPath = (icon: string) => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -122,11 +122,9 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
 };
 
 export const pokemonIconPath = (specie: StudioCreature, formId?: number, icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
-  if (formId) {
-    const form = specie.forms.find((f) => f.form === formId);
-    if (form) return formResourcesPath(form, icon ?? 'icon');
-  }
-  return formResourcesPath(specie.forms[0], icon ?? 'icon');
+  const form = specie.forms.find((f) => f.form === formId) ?? specie.forms[0];
+  if(form?.resources[icon ?? 'icon'] === '') return formResourcesPath(form,'icon');
+  return formResourcesPath(form, icon ?? 'icon');
 };
 
 export const itemIconPath = (icon: string) => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -123,7 +123,7 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
 
 export const pokemonIconPath = (specie: StudioCreature, formId?: number, icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
   const form = specie.forms.find((f) => f.form === formId) ?? specie.forms[0];
-  if(form?.resources[icon ?? 'icon'] === '') return formResourcesPath(form,'icon');
+  if (form?.resources[icon ?? 'icon'] === '') return formResourcesPath(form, 'icon');
   return formResourcesPath(form, icon ?? 'icon');
 };
 

--- a/src/views/components/pokemonBattler/PokemonBattler.tsx
+++ b/src/views/components/pokemonBattler/PokemonBattler.tsx
@@ -272,21 +272,13 @@ export const PokemonBattler = ({ pokemon, index, from, dialogsRef, setCurrentBat
   const shortcutAbilityNavigation = useShortcutNavigation('abilities', 'ability', '/database/abilities/');
   const shortcutItemNavigation = useShortcutNavigation('items', 'item', '/database/items/');
 
-  const iconSelector = (pokemon : StudioGroupEncounter) => {
-    if(pokemon.shinySetup.kind === 'rate' && pokemon.shinySetup.rate === 1) {
-      if(pokemon.expandPokemonSetup.find((setup) => setup.type === 'gender')?.value as number === 2){
-        return 'iconShinyF'
-      }else{
-        return 'iconShiny'
-      }
-    }else{
-      if(pokemon.expandPokemonSetup.find((setup) => setup.type === 'gender')?.value as number === 2){
-        return 'iconF'
-      }else{
-        return 'icon'
-      }
+  const iconSelector = (pokemon: StudioGroupEncounter) => {
+    const isFemale = pokemon.expandPokemonSetup.find((setup) => setup.type === 'gender')?.value === 2;
+    if (pokemon.shinySetup.kind === 'rate' && pokemon.shinySetup.rate === 1) {
+      return isFemale ? 'iconShinyF' : 'iconShiny';
     }
-  }
+    return isFemale ? 'iconF' : 'icon';
+  };
 
   const onDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -319,7 +311,7 @@ export const PokemonBattler = ({ pokemon, index, from, dialogsRef, setCurrentBat
         <PokemonBattlerHeader>
           {specie ? (
             <ResourceImage
-              imagePathInProject={pokemonIconPath(specie, pokemon.form,iconSelector(pokemon))}
+              imagePathInProject={pokemonIconPath(specie, pokemon.form, iconSelector(pokemon))}
               fallback={pokemon.form === 0 ? undefined : pokemonIconPath(specie)}
             />
           ) : (

--- a/src/views/components/pokemonBattler/PokemonBattler.tsx
+++ b/src/views/components/pokemonBattler/PokemonBattler.tsx
@@ -272,6 +272,22 @@ export const PokemonBattler = ({ pokemon, index, from, dialogsRef, setCurrentBat
   const shortcutAbilityNavigation = useShortcutNavigation('abilities', 'ability', '/database/abilities/');
   const shortcutItemNavigation = useShortcutNavigation('items', 'item', '/database/items/');
 
+  const iconSelector = (pokemon : StudioGroupEncounter) => {
+    if(pokemon.shinySetup.kind === 'rate' && pokemon.shinySetup.rate === 1) {
+      if(pokemon.expandPokemonSetup.find((setup) => setup.type === 'gender')?.value as number === 2){
+        return 'iconShinyF'
+      }else{
+        return 'iconShiny'
+      }
+    }else{
+      if(pokemon.expandPokemonSetup.find((setup) => setup.type === 'gender')?.value as number === 2){
+        return 'iconF'
+      }else{
+        return 'icon'
+      }
+    }
+  }
+
   const onDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setCurrentBattler({ index, kind: undefined });
@@ -303,7 +319,7 @@ export const PokemonBattler = ({ pokemon, index, from, dialogsRef, setCurrentBat
         <PokemonBattlerHeader>
           {specie ? (
             <ResourceImage
-              imagePathInProject={pokemonIconPath(specie, pokemon.form)}
+              imagePathInProject={pokemonIconPath(specie, pokemon.form,iconSelector(pokemon))}
               fallback={pokemon.form === 0 ? undefined : pokemonIconPath(specie)}
             />
           ) : (


### PR DESCRIPTION

## Description

Refacto du code pour pokemonIconPath et ajout de la fonctionnalité pour les icons shiny || femelle  et shiny && femelle.
Avec l'ajout d'un paramètre non obligatoire icon qui est transmis par PokemonBattler.

Dans PokemonBattler j'ai rajouté une fonction iconSelector qui choisie l'icon qui correspond bien pour le pokemon.
'icon' | 'iconF' | 'iconShiny' | 'iconShinyF'


## Tests to perform

- [x] Un pokemon shiny
- [x] Un pokemon shiny femelle où le pokemon a un changement en fonction du sexe
- [x] Un pokemon non shiny où le pokemon a un changement en fonction du sexe
- [x] Lorsqu'un pokemon n a pas la bonne ressource et donc icon de base sera mis 
