### PR TITLE
Fix an issue with the spaces in the map names on Linux

### DIFF
--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -15,11 +15,15 @@ const openTiled = async (payload: OpenTiledPayload) => {
   const mapFilename = path.join(payload.projectPath, 'Data', 'Tiled', 'Maps', payload.tiledMapFilename + '.tmx');
   if (process.platform === 'darwin') {
     await util.promisify(execFile)('open', [payload.tiledPath, mapFilename]);
-  }
-  else if (process.platform === 'linux') {
+  } else if (process.platform === 'linux') {
+    const linuxMapFilename = path.basename(mapFilename);
     const defaultDir = process.cwd();
     process.chdir(path.dirname(mapFilename));
-    await util.promisify(execFile)(payload.tiledPath, [path.basename(mapFilename)]);
+    if (payload.tiledPath.endsWith('AppImage') && linuxMapFilename.indexOf(' ') !== -1) {
+      throw new Error("Tiled's AppImage doesn't support spaces in map names.");
+    }
+    const result = await util.promisify(execFile)(payload.tiledPath, [`"${linuxMapFilename}"`]);
+    if (result.stderr) log.error(result.stderr);
     process.chdir(defaultDir);
   } else {
     await util.promisify(execFile)(payload.tiledPath, [mapFilename]);

--- a/src/views/components/world/map/editors/MapOpenTiledError.tsx
+++ b/src/views/components/world/map/editors/MapOpenTiledError.tsx
@@ -11,18 +11,27 @@ import {
 } from '@components/MessageBoxContainer';
 import { useNavigate } from 'react-router-dom';
 import { BaseIcon } from '@components/icons/BaseIcon';
-import { PrimaryButton } from '@components/buttons';
+import { PrimaryButton, SecondaryButton } from '@components/buttons';
 import theme from '@src/AppTheme';
 import { getSetting } from '@utils/settings';
+import { useOpenStudioLogsFolder } from '@utils/useOpenStudioLogsFolder';
 
 type MapOpenTiledErrorProps = {
   closeDialog: () => void;
 };
 
 export const MapOpenTiledError = forwardRef<EditorHandlingClose, MapOpenTiledErrorProps>(({ closeDialog }, ref) => {
-  const { t } = useTranslation('database_maps');
+  const { t } = useTranslation(['database_maps', 'error']);
   const navigate = useNavigate();
+  const openStudioLogsFolder = useOpenStudioLogsFolder();
   const isTiledPathConfigured = !!getSetting('tiledPath');
+
+  const onClickLogs = async () => {
+    openStudioLogsFolder(
+      () => {},
+      ({ errorMessage }) => window.api.log.error(errorMessage)
+    );
+  };
 
   useEditorHandlingClose(ref);
 
@@ -32,19 +41,20 @@ export const MapOpenTiledError = forwardRef<EditorHandlingClose, MapOpenTiledErr
         <MessageBoxIconErrorContainer>
           <BaseIcon icon="map" size="s" color={theme.colors.dangerBase} />
         </MessageBoxIconErrorContainer>
-        <h3>{t('title_open_tiled_error')}</h3>
+        <h3>{t('database_maps:title_open_tiled_error')}</h3>
       </MessageBoxTitleIconContainer>
       <MessageBoxTextContainer>
-        {isTiledPathConfigured ? <p>{t('message_open_tiled_error')}</p> : <p>{t('message_config_open_tiled_error')}</p>}
+        {isTiledPathConfigured ? <p>{t('database_maps:message_open_tiled_error')}</p> : <p>{t('database_maps:message_config_open_tiled_error')}</p>}
       </MessageBoxTextContainer>
       {isTiledPathConfigured ? (
         <MessageBoxActionContainer>
-          <PrimaryButton onClick={closeDialog}>{t('close')}</PrimaryButton>
+          <SecondaryButton onClick={onClickLogs}>{t('error:logs')}</SecondaryButton>
+          <PrimaryButton onClick={closeDialog}>{t('database_maps:close')}</PrimaryButton>
         </MessageBoxActionContainer>
       ) : (
         <MessageBoxActionContainer>
-          <MessageBoxCancelLink onClick={closeDialog}>{t('close')}</MessageBoxCancelLink>
-          <PrimaryButton onClick={() => navigate('/settings/maps')}>{t('configure_tiled_path')}</PrimaryButton>
+          <MessageBoxCancelLink onClick={closeDialog}>{t('database_maps:close')}</MessageBoxCancelLink>
+          <PrimaryButton onClick={() => navigate('/settings/maps')}>{t('database_maps:configure_tiled_path')}</PrimaryButton>
         </MessageBoxActionContainer>
       )}
     </MessageBoxContainer>


### PR DESCRIPTION
## Description

This PR fixes an issue with spaces in map names when opening Tiled under Linux and improve the error feedback. 

**This fix does not work with Tiled's AppImage**. Indeed, after several tests, the results showed that it was not possible to open a map with a space in the name, as spaces are interpreted as an additional argument or causes an error, so Tiled will try to open "n" maps. Using " or \ does not work. **We recommend that you compile Tiled yourself to fix this issue.**

The documentation for compiling Tiled can be found here in the readme: https://github.com/mapeditor/tiled
It's very simple!

After compilation, the Tiled runtime file can be found in `tiled/default/install-root/usr/local/bin/tiled`.
This is the file to be set in Studio's map settings.