### PR TITLE
Fix Inputs refresh and add commitChanges when we change the evolution in the evolution editor

### DIFF
--- a/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor.tsx
@@ -45,6 +45,8 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
     creature,
     form,
   });
+  /* Force evolution editor to refresh the evolutions (otherwise commitChanges function doesn't work when changing evolution) */
+  form.evolutions.forEach((e) => e);
 
   const inputValidityEnsured = () => {
     if (state.evolveTo === '__undef__' && !state.isMega && evolutionIndex !== 0) return false;
@@ -60,6 +62,7 @@ export const EvolutionEditor = forwardRef<EditorHandlingClose, Props>(({ evoluti
   const onChangeIndex = (arrow: 'left' | 'right') => {
     if (!inputValidityEnsured()) return;
 
+    commitChanges();
     if (arrow === 'left') {
       if (evolutionIndex > 0) setEvolutionIndex(evolutionIndex - 1);
     } else {

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/DayNightInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/DayNightInput.tsx
@@ -1,6 +1,6 @@
 import { InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectCustomSimple } from '@components/SelectCustom';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EvolutionConditionEditorInput } from './InputProps';
 
@@ -14,8 +14,13 @@ export const DayNightInput = ({ state, inputRefs }: EvolutionConditionEditorInpu
       { value: '0', label: t('evolutionValue_dayNight_night') } as const,
       { value: '2', label: t('evolutionValue_dayNight_morning') } as const,
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
+
+  useEffect(() => {
+    setValue(state.defaults.dayNight?.toString());
+  }, [state]);
 
   return (
     <InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/EvolutionConditionEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/EvolutionConditionEditor.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { ReactComponent as DeleteIcon } from '@assets/icons/global/delete-icon.svg';
-import { Input, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { InputWithTopLabelContainer, Label } from '@components/inputs';
 import { DayNightInput } from './DayNightInput';
 import { ItemInput } from './ItemInput';
 import { GenderInput } from './GenderInput';
@@ -12,6 +12,7 @@ import { MoveInput } from './MoveInput';
 import { PokemonInput } from './PokemonInput';
 import { WeatherInput } from './WeatherInput';
 import { NumberInput } from './NumberInput';
+import { TextInput } from './TextInput';
 import { SelectOption } from '@components/SelectCustom/SelectCustomPropsInterface';
 import { StudioEvolutionConditionKey } from '@modelEntities/creature';
 import { EvolutionConditionEditorInput } from './InputProps';
@@ -110,13 +111,6 @@ const ConditionContainerWithSelect = ({ currentType, keysToExclude, onChange, ch
   );
 };
 
-const EvolutionInfo = styled.p`
-  ${({ theme }) => theme.fonts.normalSmall};
-  color: ${({ theme }) => theme.colors.text400};
-  user-select: none;
-  margin: 0;
-`;
-
 const ConditionFields = ({ type, state, dispatch, inputRefs }: EvolutionConditionEditorInput) => {
   const { t } = useTranslation('database_pokemon');
   const keysToExclude = state.conditionInUse.filter((otherCondition) => otherCondition !== type);
@@ -132,11 +126,7 @@ const ConditionFields = ({ type, state, dispatch, inputRefs }: EvolutionConditio
     case 'func': // string
       return (
         <ConditionContainerWithSelect currentType={type} keysToExclude={keysToExclude} onChange={onKeyChange}>
-          <InputWithTopLabelContainer>
-            <Label>{t('evolutionValue_func')}</Label>
-            <Input type="text" defaultValue={state.defaults.func?.toString()} ref={(ref) => (inputRefs.current.func = ref)} />
-            <EvolutionInfo>{t('evolution_func_info')}</EvolutionInfo>
-          </InputWithTopLabelContainer>
+          <TextInput type={type} state={state} dispatch={dispatch} inputRefs={inputRefs} evolutionInfo={t('evolution_func_info')} />
         </ConditionContainerWithSelect>
       );
     case 'gemme': // item string
@@ -156,11 +146,7 @@ const ConditionFields = ({ type, state, dispatch, inputRefs }: EvolutionConditio
     case 'maps': // number[]
       return (
         <ConditionContainerWithSelect currentType={type} keysToExclude={keysToExclude} onChange={onKeyChange}>
-          <InputWithTopLabelContainer>
-            <Label>{t('evolutionValue_maps')}</Label>
-            <Input type="text" defaultValue={state.defaults.maps?.toString()} ref={(ref) => (inputRefs.current.maps = ref)} />
-            <EvolutionInfo>{t('evolution_maps_info')}</EvolutionInfo>
-          </InputWithTopLabelContainer>
+          <TextInput type={type} state={state} dispatch={dispatch} inputRefs={inputRefs} evolutionInfo={t('evolution_maps_info')} />
         </ConditionContainerWithSelect>
       );
     case 'maxLevel': // number

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/GenderInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/GenderInput.tsx
@@ -1,6 +1,6 @@
 import { InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectCustomSimple } from '@components/SelectCustom';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EvolutionConditionEditorInput } from './InputProps';
 
@@ -13,8 +13,13 @@ export const GenderInput = ({ state, inputRefs }: EvolutionConditionEditorInput)
       { value: '2', label: t('evolutionValue_gender_female') } as const,
       { value: '0', label: t('evolutionValue_gender_unknown') } as const,
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
+
+  useEffect(() => {
+    setValue(state.defaults.gender?.toString());
+  }, [state]);
 
   return (
     <InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/NumberInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/NumberInput.tsx
@@ -1,6 +1,6 @@
 import { InputWithLeftLabelContainer, Input, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { TextInputError } from '@components/inputs/Input';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EvolutionConditionEditorInput } from './InputProps';
 
@@ -17,6 +17,17 @@ const isTypeValidInput = (type: unknown): type is NumberType => validInputs.incl
 export const NumberInput = ({ state, inputRefs, type, min, max, label }: NumberInputProps) => {
   const { t } = useTranslation('database_pokemon');
   const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!isTypeValidInput(type)) return;
+
+    const ref = inputRefs.current[type];
+    if (!ref) return;
+
+    ref.value = state.defaults[type]?.toString() || '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
   if (!isTypeValidInput(type)) return null;
 
   const value = state.defaults[type];

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/TextInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/TextInput.tsx
@@ -1,0 +1,44 @@
+import { Input, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { EvolutionConditionEditorInput } from './InputProps';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+const EvolutionInfo = styled.p`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+  margin: 0;
+`;
+
+const validInputs = ['maps', 'func'] as const;
+type StringType = (typeof validInputs)[number];
+const isTypeValidInput = (type: unknown): type is StringType => validInputs.includes(type as StringType);
+
+type TextInputProps = EvolutionConditionEditorInput & {
+  evolutionInfo?: string;
+};
+
+export const TextInput = ({ type, state, inputRefs, evolutionInfo }: TextInputProps) => {
+  const { t } = useTranslation('database_pokemon');
+
+  useEffect(() => {
+    if (!isTypeValidInput(type)) return;
+
+    const ref = inputRefs.current[type];
+    if (!ref) return;
+
+    ref.value = state.defaults[type]?.toString() || '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  if (!isTypeValidInput(type)) return null;
+
+  return (
+    <InputWithTopLabelContainer>
+      <Label>{t(`evolutionValue_${type}`)}</Label>
+      <Input type="text" defaultValue={state.defaults[type]?.toString()} ref={(ref) => (inputRefs.current[type] = ref)} />
+      {evolutionInfo && <EvolutionInfo>{evolutionInfo}</EvolutionInfo>}
+    </InputWithTopLabelContainer>
+  );
+};

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/useEvolutionEditorState.ts
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/useEvolutionEditorState.ts
@@ -159,7 +159,16 @@ export const useEvolutionEditorState = ({ evolutionIndex, creature, form }: Evol
       }
       if (type === 'trade') return { type, value: true };
       if (type === 'func') return { type, value: inputRefs.current.func?.value || '' };
-      if (type === 'maps') return { type, value: inputRefs.current.maps?.value.split(',').map(Number) || [] };
+      if (type === 'maps') {
+        const value = inputRefs.current.maps?.value
+          .split(',')
+          .map(Number)
+          .filter((id) => !isNaN(id));
+        return {
+          type,
+          value: value || [],
+        };
+      }
       if (type === 'none') return { type, value: undefined };
       // We have to do that because valueAsNumber of hidden = NaN for some reason
       if (type === 'dayNight') return { type, value: Number(inputRefs.current[type]?.value || 0) as 0 };


### PR DESCRIPTION
## Description

Add: 
- Changing evolution saves previous evolution

Fix:
- Fix inputs refresh (inputs were not updated when changing evolutions)
- Fix mapId array, can introduce a NaN value (so a null value later in the json)

Closes: https://github.com/PokemonWorkshop/PokemonStudio/issues/266

## Tests to perform

- [x] Check that the inputs are correctly refresh
- [x] Check that if the input used to set a list of map ids is empty, the Pokémon can be reloaded by opening the project.
- [x] When we change evolution, check that the changes made in the previous evolution have been saved.
