### PR TITLE
Fix #277 Open the logs properly

### DIFF
--- a/src/backendTasks/openStudioLogsFolder.ts
+++ b/src/backendTasks/openStudioLogsFolder.ts
@@ -1,22 +1,27 @@
 import log from 'electron-log';
 import { app, shell } from 'electron';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import path from 'path';
 
 const getLogsPath = () => {
-  if (process.platform === 'win32') {
-    return `${app.getPath('userData')}\\logs\\renderer.log`;
-  } else if (process.platform === 'linux') {
-    return `~/.config/${app.name}/logs/renderer.log`;
-  } else {
-    return `~/Library/Logs/${app.name}/renderer.log`;
+  try {
+    // Proper way to get them
+    return path.join(app.getPath('logs'), 'renderer.log');
+  } catch (error) {
+    log.error('Failed to open logs the proper way', error);
+    if (process.platform === 'win32') {
+      return `${app.getPath('userData')}\\logs\\renderer.log`;
+    } else if (process.platform === 'linux') {
+      return `~/.config/${app.name}/logs/renderer.log`;
+    } else {
+      return `${process.env.HOME}/Library/Logs/${app.name}/renderer.log`;
+    }
   }
 };
 
 const openStudioLogsFolder = async () => {
-  log.info('open-studio-logs-folder');
-
+  log.info('open-studio-logs-folder', 'called');
   shell.showItemInFolder(getLogsPath());
-  log.info('open-studio-logs-folder/success');
   return {};
 };
 


### PR DESCRIPTION
## Description

Logs cannot be opened in MacOS because ~ is not interpreter and ignored by the shell module. ( Fix #277 )

## Note before testing

Make an error that shows the popup about opening logs. Example: corrupting a json file.

## Tests to perform

- [x] Test that it works in Windows
- [x] Test that it works in Linux
- [x] Test that it works in MacOS
