### PR TITLE
Fix Pokémon icon, rareness and given name in PokemonBattler editors

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -123,7 +123,7 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
 
 export const pokemonIconPath = (specie: StudioCreature, formId?: number, icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
   const form = specie.forms.find((f) => f.form === formId) ?? specie.forms[0];
-  if (form?.resources[icon ?? 'icon'] === '') return formResourcesPath(form, 'icon');
+  if (!form?.resources[icon ?? 'icon']) return formResourcesPath(form, 'icon');
   return formResourcesPath(form, icon ?? 'icon');
 };
 

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerMoreInfoEditor.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerMoreInfoEditor.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useMemo, useRef, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import { Input, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
 import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
 import { TFunction, useTranslation } from 'react-i18next';
@@ -83,6 +83,11 @@ export const PokemonBattlerMoreInfoEditor = ({
     }
     return { kind: 'automatic', rate: -1 };
   };
+
+  useEffect(() => {
+    if (!rarenessRef.current) return;
+    rarenessRef.current.value = expandPokemonSetup.rareness.toString();
+  }, [encounter.specie]);
 
   return (
     <InputGroupCollapse title={t(`pokemon_battler_list:more_info_title`)} gap="24px" collapseByDefault={collapseByDefault || undefined}>

--- a/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
+++ b/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
@@ -35,8 +35,9 @@ const createRecordExpandPokemonSetup = (
     return acc;
   }, {} as RecordExpandPokemonSetup);
   // Update rareness and given name
-  record.rareness = creatures[encounter.specie]?.forms.find((form) => form.form === encounter.form)?.catchRate || 0;
-  record.givenName = creatures[encounter.specie] ? getEntityName(creatures[encounter.specie]) : '???';
+  const specie = creatures[encounter.specie];
+  record.rareness = record.rareness === -1 ? specie?.forms.find((form) => form.form === encounter.form)?.catchRate || 0 : record.rareness;
+  record.givenName ||= specie ? getEntityName(specie) : '???';
   return record;
 };
 


### PR DESCRIPTION
## Description

This PR makes a few corrections in PokemonBattler editors on the following points:
- Fixed given name not displayed when editor opened
- Fixed catch rate not updated correctly
- Fixed Pokémon icon display when a female Pokémon has no shiny female icon. 

## Tests to perform

- [x] The given name is correctly showed when the user open the editor
- [x] The catch rate is correcty updated
- [x] The Pokémon icon is correcty showed
