### PR TITLE
Fix the Pokemon max level for the trainers

### DIFF
--- a/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
+++ b/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
@@ -265,10 +265,10 @@ export const usePokemonBattler = ({ action, currentBattler, from }: Props) => {
 
     const levelSetup = encounter.levelSetup;
     const defaultLevelSetup = defaultEncounter.levelSetup;
-    if (levelSetup.kind === 'fixed' && defaultLevelSetup.kind === 'fixed' && notBetween(levelSetup.level, 1, 100)) {
+    const pokemonMaxLevel = state.projectConfig.settings_config.pokemonMaxLevel;
+    if (levelSetup.kind === 'fixed' && defaultLevelSetup.kind === 'fixed' && notBetween(levelSetup.level, 1, pokemonMaxLevel)) {
       return false;
     } else if (levelSetup.kind === 'minmax' && defaultLevelSetup.kind === 'minmax') {
-      const pokemonMaxLevel = state.projectConfig.settings_config.pokemonMaxLevel;
       const minLevel = levelSetup.level.minimumLevel;
       const maxLevel = levelSetup.level.maximumLevel;
       if (notBetween(minLevel, 1, pokemonMaxLevel) || notBetween(maxLevel, 1, pokemonMaxLevel) || maxLevel < minLevel) return false;


### PR DESCRIPTION
## Description

This PR fixes an issue with the Pokémon max level for the trainers. It was hard-coded (100), whereas it should depend on the maximum level defined in the configuration.

## Tests to perform

- [x] The Pokémon max level for the trainers works correctly
