### PR TITLE
Allow the user to manage a custom environment

### DIFF
--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -56,6 +56,7 @@
   "UnderWater": "Underwater",
   "Snow": "Snow",
   "Ice": "Ice",
+  "custom": "Custom",
   "variation_0": "Tag 0",
   "variation_1": "Tag 1",
   "variation_2": "Tag 2",
@@ -70,5 +71,6 @@
   "RockSmash": "Rock Smash",
   "HeadButt": "Headbutt",
   "title_data_modification": "Data modification",
-  "warning_headbutt_data_change": "Headbutt should now be set in the Environment list."
+  "warning_headbutt_data_change": "Headbutt should now be set in the Environment list.",
+  "custom_environment": "Custom environment"
 }

--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -72,5 +72,6 @@
   "HeadButt": "Headbutt",
   "title_data_modification": "Data modification",
   "warning_headbutt_data_change": "Headbutt should now be set in the Environment list.",
-  "custom_environment": "Custom environment"
+  "custom_environment": "Custom environment",
+  "invalid_format": "Invalid format"
 }

--- a/assets/i18n/fr/database_groups.json
+++ b/assets/i18n/fr/database_groups.json
@@ -56,6 +56,7 @@
   "UnderWater": "Sous-marin",
   "Snow": "Neige",
   "Ice": "Glace",
+  "custom": "Personnalisé",
   "variation_0": "Tag 0",
   "variation_1": "Tag 1",
   "variation_2": "Tag 2",
@@ -70,5 +71,6 @@
   "RockSmash": "Éclate-Roc",
   "HeadButt": "Coup d'Boule",
   "title_data_modification": "Modification de données",
-  "warning_headbutt_data_change": "Coup d'Boule doit désormais être paramétrée dans la liste Environnement."
+  "warning_headbutt_data_change": "Coup d'Boule doit désormais être paramétrée dans la liste Environnement.",
+  "custom_environment": "Environnement personnalisé"
 }

--- a/assets/i18n/fr/database_groups.json
+++ b/assets/i18n/fr/database_groups.json
@@ -72,5 +72,6 @@
   "HeadButt": "Coup d'Boule",
   "title_data_modification": "Modification de données",
   "warning_headbutt_data_change": "Coup d'Boule doit désormais être paramétrée dans la liste Environnement.",
-  "custom_environment": "Environnement personnalisé"
+  "custom_environment": "Environnement personnalisé",
+  "invalid_format": "Format non valide"
 }

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -16,7 +16,23 @@ const CUSTOM_GROUP_CONDITION_VALIDATOR = z.object({
 });
 export type StudioCustomGroupCondition = z.infer<typeof CUSTOM_GROUP_CONDITION_VALIDATOR>;
 
-export const GROUP_SYSTEM_TAG_VALIDATOR = z.string();
+export const SYSTEM_TAG_CUSTOM = 'Custom_';
+
+export const GROUP_SYSTEM_TAG_VALIDATOR = z.union([
+  z.literal('RegularGround'),
+  z.literal('Grass'),
+  z.literal('TallGrass'),
+  z.literal('Cave'),
+  z.literal('Mountain'),
+  z.literal('Sand'),
+  z.literal('Pond'),
+  z.literal('Ocean'),
+  z.literal('UnderWater'),
+  z.literal('Snow'),
+  z.literal('Ice'),
+  z.literal('HeadButt'),
+  z.string().startsWith(SYSTEM_TAG_CUSTOM),
+]);
 export type StudioGroupSystemTag = z.infer<typeof GROUP_SYSTEM_TAG_VALIDATOR>;
 export const GROUP_SYSTEM_TAGS = [
   'RegularGround',

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { POSITIVE_INT, POSITIVE_OR_ZERO_INT } from './common';
+import { POSITIVE_OR_ZERO_INT } from './common';
 import { DB_SYMBOL_VALIDATOR } from './dbSymbol';
 import { ENCOUNTER_VALIDATOR } from './groupEncounter';
 
@@ -16,22 +16,9 @@ const CUSTOM_GROUP_CONDITION_VALIDATOR = z.object({
 });
 export type StudioCustomGroupCondition = z.infer<typeof CUSTOM_GROUP_CONDITION_VALIDATOR>;
 
-export const GROUP_SYSTEM_TAG_VALIDATOR = z.union([
-  z.literal('RegularGround'),
-  z.literal('Grass'),
-  z.literal('TallGrass'),
-  z.literal('Cave'),
-  z.literal('Mountain'),
-  z.literal('Sand'),
-  z.literal('Pond'),
-  z.literal('Ocean'),
-  z.literal('UnderWater'),
-  z.literal('Snow'),
-  z.literal('Ice'),
-  z.literal('HeadButt'),
-]);
+export const GROUP_SYSTEM_TAG_VALIDATOR = z.string();
 export type StudioGroupSystemTag = z.infer<typeof GROUP_SYSTEM_TAG_VALIDATOR>;
-export const GROUP_SYSTEM_TAGS: Readonly<StudioGroupSystemTag[]> = [
+export const GROUP_SYSTEM_TAGS = [
   'RegularGround',
   'Grass',
   'TallGrass',

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -16,6 +16,8 @@ const CUSTOM_GROUP_CONDITION_VALIDATOR = z.object({
 });
 export type StudioCustomGroupCondition = z.infer<typeof CUSTOM_GROUP_CONDITION_VALIDATOR>;
 
+export const SYSTEM_TAG_CUSTOM_VALIDATOR = z.string().regex(/^[A-Za-z0-9_]+$/, 'Invalid custom system tag format');
+
 export const SYSTEM_TAG_CUSTOM = 'Custom_';
 
 export const GROUP_SYSTEM_TAG_VALIDATOR = z.union([
@@ -31,7 +33,7 @@ export const GROUP_SYSTEM_TAG_VALIDATOR = z.union([
   z.literal('Snow'),
   z.literal('Ice'),
   z.literal('HeadButt'),
-  z.string().startsWith(SYSTEM_TAG_CUSTOM),
+  SYSTEM_TAG_CUSTOM_VALIDATOR.startsWith(SYSTEM_TAG_CUSTOM),
 ]);
 export type StudioGroupSystemTag = z.infer<typeof GROUP_SYSTEM_TAG_VALIDATOR>;
 export const GROUP_SYSTEM_TAGS = [

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -32,6 +32,7 @@ export const GROUP_SYSTEM_TAGS = [
   'Ice',
   'HeadButt',
 ] as const;
+export type StudioGroupDefaultSystemTag = (typeof GROUP_SYSTEM_TAGS)[number];
 
 export const GROUP_TOOL_VALIDATOR = z.union([z.null(), z.literal('OldRod'), z.literal('GoodRod'), z.literal('SuperRod'), z.literal('RockSmash')]);
 export type StudioGroupTool = z.infer<typeof GROUP_TOOL_VALIDATOR>;

--- a/src/utils/GroupUtils.ts
+++ b/src/utils/GroupUtils.ts
@@ -1,4 +1,4 @@
-import { GROUP_SYSTEM_TAGS, SYSTEM_TAG_CUSTOM, StudioCustomGroupCondition, StudioGroup } from '@modelEntities/group';
+import { GROUP_SYSTEM_TAGS, SYSTEM_TAG_CUSTOM, SYSTEM_TAG_CUSTOM_VALIDATOR, StudioCustomGroupCondition, StudioGroup } from '@modelEntities/group';
 import { assertUnreachable } from './assertUnreachable';
 
 export const CustomConditionTypes = ['enabledSwitch', 'mapId'] as const;
@@ -128,4 +128,8 @@ export const getCustomEnvironment = (systemTag: string) => {
 
 export const setCustomEnvironment = (systemTag: string) => {
   return SYSTEM_TAG_CUSTOM + systemTag;
+};
+
+export const wrongEnvironment = (systemTag: string) => {
+  return !SYSTEM_TAG_CUSTOM_VALIDATOR.safeParse(systemTag).success;
 };

--- a/src/utils/GroupUtils.ts
+++ b/src/utils/GroupUtils.ts
@@ -1,4 +1,4 @@
-import { StudioCustomGroupCondition, StudioGroup, StudioGroupTool } from '@modelEntities/group';
+import { GROUP_SYSTEM_TAGS, StudioCustomGroupCondition, StudioGroup } from '@modelEntities/group';
 import { assertUnreachable } from './assertUnreachable';
 
 export const CustomConditionTypes = ['enabledSwitch', 'mapId'] as const;
@@ -117,3 +117,5 @@ export const defineRelationCustomCondition = (customConditions: StudioCustomGrou
   const otherConditions = customConditions.filter((conditions) => conditions.type !== 'mapId');
   return mapIdConditions.concat(otherConditions);
 };
+
+export const isCustomEnvironment = (systemTag: string) => !(GROUP_SYSTEM_TAGS as readonly string[]).includes(systemTag);

--- a/src/utils/GroupUtils.ts
+++ b/src/utils/GroupUtils.ts
@@ -1,4 +1,4 @@
-import { GROUP_SYSTEM_TAGS, StudioCustomGroupCondition, StudioGroup } from '@modelEntities/group';
+import { GROUP_SYSTEM_TAGS, SYSTEM_TAG_CUSTOM, StudioCustomGroupCondition, StudioGroup } from '@modelEntities/group';
 import { assertUnreachable } from './assertUnreachable';
 
 export const CustomConditionTypes = ['enabledSwitch', 'mapId'] as const;
@@ -119,3 +119,13 @@ export const defineRelationCustomCondition = (customConditions: StudioCustomGrou
 };
 
 export const isCustomEnvironment = (systemTag: string) => !(GROUP_SYSTEM_TAGS as readonly string[]).includes(systemTag);
+
+export const getCustomEnvironment = (systemTag: string) => {
+  if (!systemTag.startsWith(SYSTEM_TAG_CUSTOM)) return systemTag;
+
+  return systemTag.substring(7);
+};
+
+export const setCustomEnvironment = (systemTag: string) => {
+  return SYSTEM_TAG_CUSTOM + systemTag;
+};

--- a/src/views/components/database/group/GroupFrame.tsx
+++ b/src/views/components/database/group/GroupFrame.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataBlockContainer, DataFieldsetField, DataGrid, DataInfoContainer, DataInfoContainerHeaderTitle } from '../dataBlocks';
-import { getActivationLabel, GroupToolMap, GroupVariationsMap } from '@utils/GroupUtils';
+import { getActivationLabel, GroupToolMap, GroupVariationsMap, isCustomEnvironment } from '@utils/GroupUtils';
 import styled from 'styled-components';
 import { padStr } from '@utils/PadStr';
 import { DataFieldsetFieldWithChild } from '../dataBlocks/DataFieldsetField';
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
-import { StudioGroup } from '@modelEntities/group';
+import type { StudioGroup, StudioGroupDefaultSystemTag } from '@modelEntities/group';
 import { GroupDialogsRef } from './editors/GroupEditorOverlay';
 
 type GroupFrameProps = {
@@ -63,7 +63,7 @@ export const GroupFrame = ({ group, dialogsRef }: GroupFrameProps) => {
             <DataFieldsetField label={t('battle_type')} data={group.isDoubleBattle ? t('double') : t('simple')} disabled={false} />
             <DataFieldsetFieldWithChild label={t('environment')}>
               <EnvironmentContainer>
-                <span>{t(group.systemTag)}</span>
+                <span>{isCustomEnvironment(group.systemTag) ? t('custom') : t(group.systemTag as StudioGroupDefaultSystemTag)}</span>
                 <span>{`(${variationText ? t(variationText) : '???'})`}</span>
               </EnvironmentContainer>
             </DataFieldsetFieldWithChild>

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -57,7 +57,6 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const [tool, setTool] = useState(group.tool || 'none');
   const [switchValue, setSwitchValue] = useState<number>(getSwitchDefaultValue(group));
   const isCustomEnvironment = useMemo(() => isCustomEnvironmentFunc(systemTag), [systemTag]);
-  const customEnvironmentRef = useRef<HTMLInputElement>(null);
 
   const saveTexts = () => {
     if (!nameRef.current) return;
@@ -168,7 +167,6 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             </Label>
             <Input
               id="custom-environment"
-              ref={customEnvironmentRef}
               defaultValue={systemTag}
               onBlur={(event) => setSystemTag(event.target.value)}
               placeholder="RegularGround"

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -19,6 +19,7 @@ import {
   isCustomEnvironment as isCustomEnvironmentFunc,
   getCustomEnvironment,
   setCustomEnvironment,
+  wrongEnvironment,
 } from '@utils/GroupUtils';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetEntityNameText, useSetProjectText } from '@utils/ReadingProjectText';
@@ -28,6 +29,7 @@ import { useGroupPage } from '@utils/usePage';
 import { useUpdateGroup } from './useUpdateGroup';
 import { useDialogsRef } from '@utils/useDialogsRef';
 import { GroupTranslationEditorTitle, GroupTranslationOverlay } from './GroupTranslationOverlay';
+import { TextInputError } from '@components/inputs/Input';
 
 const groupActivationEntries = (t: TFunction<'database_groups'>) =>
   GroupActivationsMap.map((option) => ({ value: option.value, label: t(option.label as never) }));
@@ -54,11 +56,12 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const stepsAverageRef = useRef<HTMLInputElement>(null);
   const [activation, setActivation] = useState<StudioGroupActivationType>(getActivationValue(group));
   const [battleType, setBattleType] = useState<(typeof battleTypeOptions)[number]['value']>(group.isDoubleBattle ? 'double' : 'simple');
-  const [systemTag, setSystemTag] = useState<StudioGroupSystemTag>(group.systemTag ?? 'RegularGround');
+  const [systemTag, setSystemTag] = useState<StudioGroupSystemTag>(getCustomEnvironment(group.systemTag) ?? 'RegularGround');
   const [variation, setVariation] = useState(group.terrainTag.toString());
   const [tool, setTool] = useState(group.tool || 'none');
   const [switchValue, setSwitchValue] = useState<number>(getSwitchDefaultValue(group));
   const isCustomEnvironment = useMemo(() => isCustomEnvironmentFunc(systemTag), [systemTag]);
+  const customEnvironmentError = systemTag !== '' && wrongEnvironment(systemTag);
 
   const saveTexts = () => {
     if (!nameRef.current) return;
@@ -69,7 +72,7 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const canClose = () => {
     if (!stepsAverageRef.current || !stepsAverageRef.current.validity.valid) return false;
     if (switchValue < 1 || switchValue > 99999) return false;
-    if (systemTag === '') return false;
+    if (systemTag === '' || wrongEnvironment(systemTag)) return false;
 
     return !!nameRef.current?.value && !dialogsRef.current?.currentDialog;
   };
@@ -82,8 +85,9 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     const newTool = tool === 'none' ? null : (tool as StudioGroupTool);
     const isDoubleBattle = battleType === 'double';
     const stepsAverage = isNaN(stepsAverageRef.current.valueAsNumber) ? group.stepsAverage : stepsAverageRef.current.valueAsNumber;
+    const newSystemTag = isCustomEnvironment ? setCustomEnvironment(systemTag) : systemTag;
 
-    updateGroup({ customConditions, systemTag, tool: newTool, terrainTag: Number(variation), isDoubleBattle, stepsAverage });
+    updateGroup({ customConditions, systemTag: newSystemTag, tool: newTool, terrainTag: Number(variation), isDoubleBattle, stepsAverage });
     saveTexts();
   };
   useEditorHandlingClose(ref, onClose, canClose);
@@ -169,10 +173,12 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             </Label>
             <Input
               id="custom-environment"
-              defaultValue={getCustomEnvironment(systemTag)}
-              onBlur={(event) => setSystemTag(setCustomEnvironment(event.target.value))}
+              value={systemTag}
+              onChange={(event) => setSystemTag(event.target.value)}
               placeholder="RegularGround"
+              error={customEnvironmentError}
             />
+            {customEnvironmentError && <TextInputError>{t('invalid_format')}</TextInputError>}
           </InputWithTopLabelContainer>
         )}
         <InputWithTopLabelContainer>

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -17,6 +17,8 @@ import {
   updateActivation,
   GroupToolMap,
   isCustomEnvironment as isCustomEnvironmentFunc,
+  getCustomEnvironment,
+  setCustomEnvironment,
 } from '@utils/GroupUtils';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetEntityNameText, useSetProjectText } from '@utils/ReadingProjectText';
@@ -167,8 +169,8 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             </Label>
             <Input
               id="custom-environment"
-              defaultValue={systemTag}
-              onBlur={(event) => setSystemTag(event.target.value)}
+              defaultValue={getCustomEnvironment(systemTag)}
+              onBlur={(event) => setSystemTag(setCustomEnvironment(event.target.value))}
               placeholder="RegularGround"
             />
           </InputWithTopLabelContainer>

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -16,6 +16,7 @@ import {
   onSwitchUpdateActivation,
   updateActivation,
   GroupToolMap,
+  isCustomEnvironment as isCustomEnvironmentFunc,
 } from '@utils/GroupUtils';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetEntityNameText, useSetProjectText } from '@utils/ReadingProjectText';
@@ -55,7 +56,7 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const [variation, setVariation] = useState(group.terrainTag.toString());
   const [tool, setTool] = useState(group.tool || 'none');
   const [switchValue, setSwitchValue] = useState<number>(getSwitchDefaultValue(group));
-  const isCustomEnvironment = useMemo(() => !(GROUP_SYSTEM_TAGS as readonly string[]).includes(systemTag), [systemTag]);
+  const isCustomEnvironment = useMemo(() => isCustomEnvironmentFunc(systemTag), [systemTag]);
   const customEnvironmentRef = useRef<HTMLInputElement>(null);
 
   const saveTexts = () => {

--- a/src/views/components/database/zone/table/RenderGroup.tsx
+++ b/src/views/components/database/zone/table/RenderGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { DataGroupGrid } from './ZoneTableStyle';
@@ -10,10 +10,11 @@ import { DraggableProvided } from 'react-beautiful-dnd';
 import { Code } from '@components/Code';
 import { padStr } from '@utils/PadStr';
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
-import { StudioGroup } from '@modelEntities/group';
-import { StudioZone } from '@modelEntities/zone';
+import type { StudioGroup, StudioGroupDefaultSystemTag } from '@modelEntities/group';
+import type { StudioZone } from '@modelEntities/zone';
 import { CONTROL, useKeyPress } from '@utils/useKeyPress';
 import { useShortcutNavigation } from '@utils/useShortcutNavigation';
+import { isCustomEnvironment } from '@utils/GroupUtils';
 
 type RenderGroupContainerProps = {
   isDragging: boolean;
@@ -116,7 +117,7 @@ type RenderGroupProps = {
   onClickDelete: () => void;
 };
 
-export const RenderGroup = React.forwardRef<HTMLInputElement, RenderGroupProps>(
+export const RenderGroup = forwardRef<HTMLInputElement, RenderGroupProps>(
   ({ group, zone, provided, isDragging, dragOn, onClickEdit, onClickDelete }, ref) => {
     const { t } = useTranslation('database_groups');
     const getGroupName = useGetEntityNameText();
@@ -145,7 +146,13 @@ export const RenderGroup = React.forwardRef<HTMLInputElement, RenderGroupProps>(
         ) : (
           <span className="error">{t('group_deleted')}</span>
         )}
-        {group ? <span className="environment">{t(group.systemTag)}</span> : <span className="environment" />}
+        {group ? (
+          <span className="environment">
+            {isCustomEnvironment(group.systemTag) ? t('custom') : t(group.systemTag as StudioGroupDefaultSystemTag)}
+          </span>
+        ) : (
+          <span className="environment" />
+        )}
         {group ? (
           <div className="present-on-map">
             {group.customConditions


### PR DESCRIPTION
## Description

This PR allows the user to manage a custom environement in the group.
Closes #280 

## Tests to perform

- [x] The user can manage a custom environment in the group
- [x] The user can create a group with a custom environment


PSDK tests: 
- [x] Press the F9 key in the map to check if the environment is correctly detected
- [x] The custom environment can trigger a battle

## Screenshots

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/3a8136aa-afac-4113-a40c-fc840c8170f4)