### PR TITLE
Feature: The item description is updated when the user changes the move taught for the tech item (HM/TM)

### DIFF
--- a/src/views/components/database/item/editors/ItemTechDataEditor.tsx
+++ b/src/views/components/database/item/editors/ItemTechDataEditor.tsx
@@ -4,16 +4,21 @@ import { Editor } from '@components/editor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectCustomSimple } from '@components/SelectCustom';
 import { SelectMove } from '@components/selects';
-import { LOCKED_ITEM_EDITOR } from '@modelEntities/item';
+import { ITEM_DESCRIPTION_TEXT_ID, LOCKED_ITEM_EDITOR } from '@modelEntities/item';
 import { DbSymbol } from '@modelEntities/dbSymbol';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useItemPage } from '@utils/usePage';
 import { useUpdateItem } from './useUpdateItem';
+import { useProjectDataReadonly } from '@utils/useProjectData';
+import { useCopyProjectText } from '@utils/ReadingProjectText';
+import { MOVE_DESCRIPTION_TEXT_ID } from '@modelEntities/move';
 
 export const ItemTechDataEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { currentItem: item } = useItemPage();
+  const { projectDataValues: moves } = useProjectDataReadonly('moves', 'move');
   const { t } = useTranslation(['database_items', 'database_moves']);
   const setItems = useUpdateItem(item);
+  const copyText = useCopyProjectText();
 
   const flingPowerRef = useRef<HTMLInputElement>(null);
 
@@ -37,6 +42,10 @@ export const ItemTechDataEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     const flingPower = flingPowerRef.current && !isNaN(flingPowerRef.current.valueAsNumber) ? flingPowerRef.current.valueAsNumber : item.flingPower;
 
     if (isTechItem) {
+      const move = moves[techForm.move];
+      if (!move) return;
+
+      copyText({ fileId: MOVE_DESCRIPTION_TEXT_ID, textId: move.id + 1 }, { fileId: ITEM_DESCRIPTION_TEXT_ID, textId: item.id + 1 });
       setItems({ ...techForm, flingPower: flingPower });
     } else {
       setItems({ flingPower: flingPower });

--- a/src/views/components/database/item/editors/ItemTranslationOverlay.tsx
+++ b/src/views/components/database/item/editors/ItemTranslationOverlay.tsx
@@ -1,6 +1,6 @@
 import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
 import { TranslationEditorWithCloseHandling } from '@components/editor/TranslationEditorWithCloseHandling';
-import { ITEM_NAME_TEXT_ID, StudioItem } from '@modelEntities/item';
+import { ITEM_DESCRIPTION_TEXT_ID, ITEM_NAME_TEXT_ID, ITEM_PLURAL_NAME_TEXT_ID, StudioItem } from '@modelEntities/item';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import React from 'react';
 
@@ -13,8 +13,8 @@ type Props = {
 
 const fileIdByTitle: Array<{ dialog: TranslationEditorTitle } & { id: number }> = [
   { dialog: 'translation_name', id: ITEM_NAME_TEXT_ID },
-  { dialog: 'translation_name_plural', id: ITEM_NAME_TEXT_ID },
-  { dialog: 'translation_description', id: ITEM_NAME_TEXT_ID },
+  { dialog: 'translation_name_plural', id: ITEM_PLURAL_NAME_TEXT_ID },
+  { dialog: 'translation_description', id: ITEM_DESCRIPTION_TEXT_ID },
 ];
 
 /**
@@ -31,7 +31,7 @@ export const ItemTranslationOverlay = defineEditorOverlay<TranslationEditorTitle
         return (
           <TranslationEditorWithCloseHandling
             title={dialogToShow}
-            nameTextId={textId}
+            nameTextId={ITEM_NAME_TEXT_ID}
             fileId={textId}
             textIndex={item.id}
             isMultiline={dialogToShow === 'translation_description'}

--- a/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
+++ b/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
@@ -1,6 +1,5 @@
 import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
 import { TranslationEditorWithCloseHandling } from '@components/editor/TranslationEditorWithCloseHandling';
-import { ABILITY_DESCRIPTION_TEXT_ID, ABILITY_NAME_TEXT_ID, StudioAbility } from '@modelEntities/ability';
 import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_NAME_TEXT_ID, CREATURE_SPECIE_TEXT_ID, StudioCreature } from '@modelEntities/creature';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import React from 'react';


### PR DESCRIPTION
## Description

Add:
- The item description is automatically updated when the user changes the move taught for the tech item (HM/TM).

Fix: 
- Fix an issue with the item plural and the item description (bug introduced by myself when updating 2.1.0 and trying to fix the editors' title :/)

Closes #60

## Note before testing

In the technical demo, the HM and TM have incorrect descriptions. So in the items page, opening and closing the “Techniques” editor causes the item description to be updated, even if you don't edit anything.

## Tests to perform

- [x] When the user change the "move taught", the item description is updated.
- [x] If the user edit nothing and the description is correct, the save detection should not be triggered.

## Video

https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/1cbd3fdc-c19a-4ff3-b8f8-7f5e4f33c5e2