### PR TITLE
Fix: Map import with the generating map overview if the tmx filename is empty

### DIFF
--- a/src/utils/useMapImport/useMapImportProcessor.ts
+++ b/src/utils/useMapImport/useMapImportProcessor.ts
@@ -150,14 +150,18 @@ export const useMapImportProcessor = () => {
             return () => {};
           }
           const tiledFilename = mapsToImport[index].path;
-          return window.api.generatingMapOverview(
-            { projectPath: globalState.projectPath!, tiledFilename, tiledExecPath: getSetting('tiledPath') },
-            () => generatingMapOverview(++index),
-            ({ errorMessage }) => {
-              setState(DEFAULT_PROCESS_STATE);
-              fail(binding, mapsToImport, errorMessage);
-            }
-          );
+          if (tiledFilename) {
+            return window.api.generatingMapOverview(
+              { projectPath: globalState.projectPath!, tiledFilename, tiledExecPath: getSetting('tiledPath') },
+              () => generatingMapOverview(++index),
+              ({ errorMessage }) => {
+                setState(DEFAULT_PROCESS_STATE);
+                fail(binding, mapsToImport, errorMessage);
+              }
+            );
+          } else {
+            return toAsyncProcess(() => generatingMapOverview(++index));
+          }
         };
         return generatingMapOverview();
       },


### PR DESCRIPTION
## Description

This PR fixes an issue with the map import and the generating map overview.
Studio imports automatically the missing rmxp maps, but its maps have not a tmx file. A check has been added to ignore the generation if the tmx filename is empty.

Issue: https://discord.com/channels/143824995867557888/1238780892130836532

## Tests to perform

- [x] The user can import their maps, even if missing rmxp maps are also imported
