### PR TITLE
Feature: The item held is available for the groups creature encounter

### DIFF
--- a/src/utils/cleanNaNValue.ts
+++ b/src/utils/cleanNaNValue.ts
@@ -167,7 +167,6 @@ export const cleanExpandPokemonSetup = (encounter: StudioGroupEncounter, species
     removeExpandPokemonSetup(encounter, 'originalTrainerName');
     removeExpandPokemonSetup(encounter, 'originalTrainerId');
     removeExpandPokemonSetup(encounter, 'givenName');
-    removeExpandPokemonSetup(encounter, 'itemHeld');
   } else {
     removeExpandPokemonSetup(encounter, 'rareness');
   }

--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -59,11 +59,11 @@ const buildExpandPokemonSetup = (set: PokemonSet, from: string) => {
     { type: 'moves', value: convertMoves(set.moves) },
     { type: 'nature', value: convertToDbSymbol(set.nature) },
     { type: 'rareness', value: -1 },
+    { type: 'itemHeld', value: convertToDbSymbol(set.item) },
   ];
 
   if (from === 'trainer') {
     setupFields.push({ type: 'caughtWith', value: convertToDbSymbol(set.pokeball) || ('poke_ball' as DbSymbol) });
-    setupFields.push({ type: 'itemHeld', value: convertToDbSymbol(set.item) });
     setupFields.push({ type: 'givenName', value: set.name || set.species });
     setupFields.push({ type: 'ivs', value: formatStats(set.ivs, 31) });
     setupFields.push({ type: 'loyalty', value: set.happiness ?? 70 });

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerMoreInfoEditor.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerMoreInfoEditor.tsx
@@ -142,17 +142,15 @@ export const PokemonBattlerMoreInfoEditor = ({
           noTooltip
         />
       </InputWithTopLabelContainer>
-      {from !== 'group' && (
-        <InputWithTopLabelContainer>
-          <Label htmlFor="select-item-held">{t('pokemon_battler_list:item_held')}</Label>
-          <SelectItemHeld
-            dbSymbol={expandPokemonSetup.itemHeld as string}
-            onChange={(itemHeld) => updateExpandPokemonSetup({ itemHeld })}
-            undefValueOption={t('pokemon_battler_list:none_item')}
-            noLabel
-          />
-        </InputWithTopLabelContainer>
-      )}
+      <InputWithTopLabelContainer>
+        <Label htmlFor="select-item-held">{t('pokemon_battler_list:item_held')}</Label>
+        <SelectItemHeld
+          dbSymbol={expandPokemonSetup.itemHeld as string}
+          onChange={(itemHeld) => updateExpandPokemonSetup({ itemHeld })}
+          undefValueOption={t('pokemon_battler_list:none_item')}
+          noLabel
+        />
+      </InputWithTopLabelContainer>
       {from !== 'group' && (
         <InputWithTopLabelContainer>
           <Label htmlFor="select-caught-with">{t('pokemon_battler_list:caught_with')}</Label>


### PR DESCRIPTION
## Description

This PR allows the user to manage the item held for the groups creature encounter.

Note: The item held by a wild creature is configured in the Pokémon page. Setting an item to a wild creature in the group overwrite the data defined in the creature. Obtaining the item is also guaranteed.

Closes: #58 

## Tests to perform

- [x] The user can manage the item held for the groups creature encounter (go to the group, choose a creature ; in the editor go to “additional information” and add a held object) 
- [x] PSDK : Catch the creature and check that it's holding the item
