### PR TITLE
feat(selectNature): display nature bonus and maluses

### DIFF
--- a/assets/i18n/en/database_natures.json
+++ b/assets/i18n/en/database_natures.json
@@ -1,0 +1,7 @@
+{
+  "attack": "Atk",
+  "defense": "Dfe",
+  "special_attack": "Ats",
+  "special_defense": "Dfs",
+  "speed": "Spd"
+}

--- a/assets/i18n/fr/database_natures.json
+++ b/assets/i18n/fr/database_natures.json
@@ -1,0 +1,7 @@
+{
+  "attack": "Atk",
+  "defense": "Def",
+  "special_attack": "Ats",
+  "special_defense": "Dfs",
+  "speed": "Vit"
+}

--- a/assets/i18n/fr/index.js
+++ b/assets/i18n/fr/index.js
@@ -13,6 +13,7 @@ import dashboard_game_options from './dashboard_game_options.json';
 import database_abilities from './database_abilities.json';
 import database_items from './database_items.json';
 import database_moves from './database_moves.json';
+import database_natures from './database_natures.json';
 import database_pokemon from './database_pokemon.json';
 import database_types from './database_types.json';
 import database_groups from './database_groups.json';
@@ -62,6 +63,7 @@ export default {
   database_abilities,
   database_items,
   database_moves,
+  database_natures,
   database_pokemon,
   database_types,
   database_groups,

--- a/src/@types/react-i18n.d.ts
+++ b/src/@types/react-i18n.d.ts
@@ -70,6 +70,7 @@ declare module 'react-i18next' {
       database_abilities: typeof database_abilities;
       database_items: typeof database_items;
       database_moves: typeof database_moves;
+      database_natures: typeof database_natures;
       database_pokemon: typeof database_pokemon;
       database_types: typeof database_types;
       database_groups: typeof database_groups;

--- a/src/views/components/selects/SelectNature.tsx
+++ b/src/views/components/selects/SelectNature.tsx
@@ -6,10 +6,38 @@ import { SelectDataProps } from './SelectDataProps';
 import { getText } from '@utils/ReadingProjectText';
 import { SelectCustom } from '@components/SelectCustom';
 
+const statsByNature: Record<string, string> = {
+  adamant: '+Atk/-SpAtk',
+  bashful: '',
+  bold: '+Def/-Atk',
+  brave: '+Atk/-Vit',
+  calm: '+SpDef/-Def',
+  careful: '+SpDef/-SpAtk',
+  docile: '',
+  gentle: '+SpDef/-Def',
+  hardy: '',
+  hasty: '+Vit/-Def',
+  impish: '+Def/-SpAtk',
+  jolly: '+Vit/-SpAtk',
+  lax: '+Def/-SpDef',
+  lonely: '+Atk/-Def',
+  mild: '+SpAtk/-Def',
+  modest: '+SpAtk/-Atk',
+  naughty: '+Atk/-SpDef',
+  naive: '+Vit/-SpDef',
+  quiet: '+SpAtk/-Vit',
+  quirky: '',
+  rash: '+SpAtk/-SpDef',
+  relaxed: '+Def/-Vit',
+  sassy: '+SpDef/-Vit',
+  serious: '',
+  timid: '+Vit/-Atk',
+};
+
 const getNatureOptions = (state: State): SelectOption[] =>
-  Object.entries(state.projectConfig.natures.db_symbol_to_id).map(([value, natureId]) => ({
-    value,
-    label: getText(
+  Object.entries(state.projectConfig.natures.db_symbol_to_id).map(([value, natureId]) => {
+    const statByNature = statsByNature[value];
+    let label = getText(
       {
         texts: state.projectText,
         languages: state.projectStudio.languagesTranslation,
@@ -17,8 +45,15 @@ const getNatureOptions = (state: State): SelectOption[] =>
       },
       100008,
       (state.projectConfig.natures.data[natureId] || [0])[0]
-    ),
-  }));
+    );
+    if (statByNature && statByNature !== '') {
+      label += ` (${statByNature})`;
+    }
+    return {
+      value,
+      label,
+    };
+  });
 
 export const SelectNature = ({ dbSymbol, onChange, noneValue, overwriteNoneValue }: SelectDataProps) => {
   const { t } = useTranslation(['database_abilities', 'pokemon_battler_list']);

--- a/src/views/components/selects/SelectNature.tsx
+++ b/src/views/components/selects/SelectNature.tsx
@@ -72,9 +72,9 @@ const getNatureExtraStatsComparedToDependingStats = (state: State, t: TFunction<
  * @param t useTranslation
  * @returns SelectOption[]
  */
-const getNatureOptions = (state: State, t: TFunction<['database_natures']>): SelectOption[] =>
-  Object.entries(state.projectConfig.natures.db_symbol_to_id).map(([value, natureId]) => {
-    const test = getNatureExtraStatsComparedToDependingStats(state, t);
+const getNatureOptions = (state: State, t: TFunction<['database_natures']>): SelectOption[] => {
+  const test = getNatureExtraStatsComparedToDependingStats(state, t);
+  return Object.entries(state.projectConfig.natures.db_symbol_to_id).map(([value, natureId]) => {
     const statByNature = test[value];
 
     let label = getText(
@@ -94,6 +94,7 @@ const getNatureOptions = (state: State, t: TFunction<['database_natures']>): Sel
       label,
     };
   });
+};
 
 export const SelectNature = ({ dbSymbol, onChange, noneValue, overwriteNoneValue }: SelectDataProps) => {
   const { t } = useTranslation(['database_abilities', 'pokemon_battler_list', 'database_natures']);


### PR DESCRIPTION
 Display nature bonus and maluses on Select associeted.
 
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x ] Your code builds clean without any errors or warnings
- [ x] You are following the [Code guidelines](../CodeGuidelines.md)
- [ x] You tested your code to make sure it does what it is supposed to do

## Description

Add some indicator into the slect nature for Pokemon to display some stats associated !

## Tests to perform

Go into select nature component thought Battler page or Group page and test it !

Closes: https://github.com/PokemonWorkshop/PokemonStudio/issues/46