### PR TITLE
Map import: Add a check to ignore the maps if they don't exist in the rules file

### DIFF
--- a/src/backendTasks/copyTiledFiles.ts
+++ b/src/backendTasks/copyTiledFiles.ts
@@ -130,7 +130,7 @@ const copyRulesFile = async (tiledSrcPath: string, mapsFolderPath: string) => {
   if (!fs.existsSync(rulesSrcPath)) return;
   if (fs.existsSync(rulesDestPath)) return;
 
-  log.info('copy-tiled-files/process', rulesSrcPath);
+  log.info('copy-tiled-files/rules', rulesSrcPath);
   await fsPromises.copyFile(rulesSrcPath, rulesDestPath);
   const rules = (await fsPromises.readFile(rulesDestPath)).toString();
   const lines = rules.split(/\r\n|\r|\n/);
@@ -138,7 +138,12 @@ const copyRulesFile = async (tiledSrcPath: string, mapsFolderPath: string) => {
     await lastPromise;
     if (line.startsWith('#')) return;
 
-    const tiledMap = { path: path.join(tiledSrcPath, line) };
+    const mapPath = path.join(tiledSrcPath, line);
+    if (!fs.existsSync(mapPath)) {
+      log.warn('copy-tiled-files/rules: map not found', mapPath);
+      return;
+    }
+    const tiledMap = { path: mapPath };
     await copyTmxFile(tiledMap, mapsFolderPath, tiledSrcPath);
     await updateTmxFile(tiledMap, mapsFolderPath, path.join(tiledSrcPath, line));
   }, Promise.resolve());


### PR DESCRIPTION
## Description

Users sometimes leave maps that no longer exist in the rules.txt file, which causes an error during import.
This PR add a check to ignore the maps if they don't exist in the rules file (a warning is logged).

