### PR TITLE
Fix the UX issue regarding the language selection in PSDK

### DIFF
--- a/src/views/components/dashboard/gameStart/DashboardGameStartTitleScreen.tsx
+++ b/src/views/components/dashboard/gameStart/DashboardGameStartTitleScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { useConfigLanguage, useConfigSceneTitle } from '@hooks/useProjectConfig';
+import { useConfigSceneTitle } from '@hooks/useProjectConfig';
 import { useTranslation } from 'react-i18next';
 import { PageEditor } from '@components/pages';
 import { Input, InputWithTopLabelContainer, InputWithLeftLabelContainer, Label, Toggle, InputContainer, AudioInput } from '@components/inputs';
@@ -25,7 +25,6 @@ const DurationContainer = styled(InputWithLeftLabelContainer)`
 export const DashboardGameStartTitleScreen = () => {
   const { t } = useTranslation('dashboard_game_start');
   const { projectConfigValues: gameStart, setProjectConfigValues: setGameStart } = useConfigSceneTitle();
-  const { projectConfigValues: language } = useConfigLanguage();
   const currentEditedGameStart = useMemo(() => cloneEntity(gameStart), [gameStart]);
   const [titleScreenData, setTitleScreenData] = useState({ duration: gameStart.bgmDuration, controlWaitTime: gameStart.controlWaitTime });
 
@@ -68,19 +67,17 @@ export const DashboardGameStartTitleScreen = () => {
 
   return (
     <PageEditor editorTitle={t('game_start')} title={t('title_screen')}>
-      {language.choosableLanguageCode.length > 1 && (
-        <InputWithLeftLabelContainer>
-          <Label htmlFor="show-language-selection">{t('show_language_selection')}</Label>
-          <Toggle
-            name="show-language-selection"
-            checked={gameStart.isLanguageSelectionEnabled}
-            onChange={(event) => {
-              currentEditedGameStart.isLanguageSelectionEnabled = event.target.checked;
-              setGameStart(currentEditedGameStart);
-            }}
-          />
-        </InputWithLeftLabelContainer>
-      )}
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="show-language-selection">{t('show_language_selection')}</Label>
+        <Toggle
+          name="show-language-selection"
+          checked={gameStart.isLanguageSelectionEnabled}
+          onChange={(event) => {
+            currentEditedGameStart.isLanguageSelectionEnabled = event.target.checked;
+            setGameStart(currentEditedGameStart);
+          }}
+        />
+      </InputWithLeftLabelContainer>
       <InputWithTopLabelContainer>
         <Label htmlFor="music">{t('music')}</Label>
         {gameStart.bgmName.length === 0 ? (

--- a/src/views/components/dashboard/gameStart/useUpdateGameStart.ts
+++ b/src/views/components/dashboard/gameStart/useUpdateGameStart.ts
@@ -1,7 +1,7 @@
 import { cloneEntity } from '@utils/cloneEntity';
 import { useCallback } from 'react';
 import { StudioSceneTitleConfig } from '@modelEntities/config';
-import { useConfigSceneTitle } from '@utils/useProjectConfig';
+import { useConfigSceneTitle } from '@hooks/useProjectConfig';
 
 export const useUpdateGameStart = (gameStart: StudioSceneTitleConfig) => {
   const { setProjectConfigValues: setGameStart } = useConfigSceneTitle();

--- a/src/views/components/dashboard/gameStart/useUpdateGameStart.ts
+++ b/src/views/components/dashboard/gameStart/useUpdateGameStart.ts
@@ -1,0 +1,20 @@
+import { cloneEntity } from '@utils/cloneEntity';
+import { useCallback } from 'react';
+import { StudioSceneTitleConfig } from '@modelEntities/config';
+import { useConfigSceneTitle } from '@utils/useProjectConfig';
+
+export const useUpdateGameStart = (gameStart: StudioSceneTitleConfig) => {
+  const { setProjectConfigValues: setGameStart } = useConfigSceneTitle();
+
+  return useCallback(
+    (updates: Partial<StudioSceneTitleConfig>) => {
+      const updatedGameStart = {
+        ...cloneEntity(gameStart),
+        ...updates,
+      };
+      setGameStart(updatedGameStart);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [gameStart]
+  );
+};

--- a/src/views/components/dashboard/language/useDashboardLanguage.ts
+++ b/src/views/components/dashboard/language/useDashboardLanguage.ts
@@ -1,10 +1,11 @@
-import { useProjectConfigReadonly } from '@hooks/useProjectConfig';
+import { useConfigSceneTitle, useProjectConfigReadonly } from '@hooks/useProjectConfig';
 import { useProjectStudio } from '@hooks/useProjectStudio';
 import { useUpdateLanguage } from './editors/useUpdateLanguage';
 import { useUpdateGameOptions } from '../gameOptions';
 import { useUpdateProjectStudio } from '@hooks/useUpdateProjectStudio';
 import { cloneEntity } from '@utils/cloneEntity';
 import { StudioLanguageConfig } from '@modelEntities/config';
+import { useUpdateGameStart } from '../gameStart/useUpdateGameStart';
 
 export type DashboardLanguageType = 'translation' | 'player';
 
@@ -21,6 +22,8 @@ export const useDashboardLanguage = () => {
   const updateGameOptions = useUpdateGameOptions(gameOptions);
   const { projectStudioValues: projectStudio } = useProjectStudio();
   const updateProjectStudio = useUpdateProjectStudio(projectStudio);
+  const { projectConfigValues: gameStart } = useConfigSceneTitle();
+  const updateGameStart = useUpdateGameStart(gameStart);
 
   const disabledLanguage = (code: string) => {
     if (language.choosableLanguageCode.length <= 1) return;
@@ -33,6 +36,7 @@ export const useDashboardLanguage = () => {
     languageEdited.choosableLanguageTexts.splice(index, 1);
     if (languageEdited.choosableLanguageCode.length <= 1) {
       updateGameOptions({ order: gameOptions.order.filter((k) => k !== 'language') });
+      updateGameStart({ isLanguageSelectionEnabled: false });
     }
     updateDefaultLanguage(languageEdited);
     updateLanguage(languageEdited);


### PR DESCRIPTION
## Description

This PR fix an issue with the UX with the language selection.

When you create a project, Studio will disable the display of the choice of languages in PSDK if the project is not multi-language.

Note: 
Currently, the projects can't be multi-language when they're created because the UI doesn't allow it any more, but the multiLanguage property still exists and is transferred to the backend, although for the moment it's still set to false.

Other changes:
- The toggle to display the choice of languages is always displayed.
- If there is only one language left for PSDK, the language display is automatically disabled.

Closes #319 

## Tests to perform

- [x] Create a new project and check that the language selection is disabled.
- [x] Check that the toggle for the language selection is always available
- [x] Check that if there is only one language left for PSDK, the display of the choice of languages is disabled.
