### PR TITLE
Fix a crash with the form in the movepool import

### DIFF
--- a/src/views/components/database/pokemon/movepool/MovepoolImport.tsx
+++ b/src/views/components/database/pokemon/movepool/MovepoolImport.tsx
@@ -36,12 +36,14 @@ export const MovepoolImport = ({ type, onClose }: MovepoolImportProps) => {
   } = useProjectData('pokemon', 'pokemon');
   const [selectedPokemon, setSelectedPokemon] = useState('__undef__');
   const [selectedForm, setSelectedForm] = useState(0);
-  const { t } = useTranslation(['database_pokemon']);
+  const { t } = useTranslation(['database_pokemon', 'select']);
   const currentEditedPokemon = useMemo(() => cloneEntity(pokemon[currentPokemon.specie]), [pokemon, currentPokemon.specie]);
 
   const onClickValidate = () => {
     const klass = type === 'level' ? 'LevelLearnableMove' : getMoveKlass(type);
-    const form = currentEditedPokemon.forms[currentPokemon.form];
+    const form = currentEditedPokemon.forms.find((f) => f.form === currentPokemon.form);
+    if (!form) return;
+
     const currentSelectedForm = pokemon[selectedPokemon].forms.find((f) => f.form === selectedForm);
     if (!currentSelectedForm) return;
 
@@ -63,6 +65,7 @@ export const MovepoolImport = ({ type, onClose }: MovepoolImportProps) => {
               setSelectedForm(0);
             }}
             noLabel
+            undefValueOption={t('select:none')}
           />
           {selectedPokemon !== '__undef__' && pokemon[selectedPokemon].forms.length > 1 && (
             <SelectPokemonForm dbSymbol={selectedPokemon} form={selectedForm} onChange={(event) => setSelectedForm(Number(event))} noLabel />


### PR DESCRIPTION
## Description

This PR fixes a crash in movepool import if we try to import a movepool with a form other than 0 because there has been confusion between the id of the form and its index. (the usual bug...)

In practice, it's with mega evolutions that have form equal to or greater than 30 that the problem occurs. (because the index is different to the form id)

Bonus: a default value has been added to Select to avoid opening the editor with "Pokémon deleted".

## Tests to perform

- [x] The user can import a movepool (from basic, regional or mega evolution form to all available forms)

## Error

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/166a8bcb-d5fd-47d8-8869-6d805b304016)

Discord: https://discord.com/channels/143824995867557888/1255523750078713979