### PR TITLE
Fix assets with no lowercase extension

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -22,7 +22,9 @@ export const basename = (str: string | undefined, stripExtension?: string): stri
   let finalStr: string | undefined = str;
 
   if (stripExtension) {
-    finalStr = finalStr.replaceAll(stripExtension, '');
+    // result example: /\.png$/i
+    const regex = new RegExp(`\\${stripExtension}$`, 'i');
+    finalStr = str.replace(regex, '');
   }
 
   finalStr = finalStr.replaceAll('\\', '/').split('/').pop();

--- a/src/views/components/database/pokemon/resources/useUpdateResources.tsx
+++ b/src/views/components/database/pokemon/resources/useUpdateResources.tsx
@@ -9,7 +9,7 @@ export const useUpdateResources = (creature: StudioCreature, form: StudioCreatur
     updateForm({
       resources: {
         ...form.resources,
-        [resource]: basename(resourcePath, '.png').replace(/\.gif$/, ''),
+        [resource]: basename(resourcePath, '.png').replace(/\.gif$/i, ''),
       },
     });
   };

--- a/src/views/components/database/trainer/resources/useUpdateResources.tsx
+++ b/src/views/components/database/trainer/resources/useUpdateResources.tsx
@@ -9,7 +9,7 @@ export const useUpdateResources = (trainer: StudioTrainer) => {
     updateTrainer({
       resources: {
         ...trainer.resources,
-        [resource]: basename(resourcePath, '.png').replace(/\.gif$/, ''),
+        [resource]: basename(resourcePath, '.png').replace(/\.gif$/i, ''),
       },
     });
   };


### PR DESCRIPTION
## Description

This PR fixes the basename function and the gif replace regex to become insensitive when using assets with no lowercase extension.

Note:
It's a very bad idea to have reimplemented the path functions in the front end. We should use the backend path functions and link it to the front end with the window.api. We need a task to change this (https://github.com/PokemonWorkshop/PokemonStudio/issues/340).

Closes #336 

## Tests to perform

- [x] The user can use a resource with an extension which is not lowercase

You can test with the Pokémon resources or the trainer resources. Try with png and gif extension.
