### PR TITLE
Edition modal does not close when we are highlighting texts in a Text filed

### DIFF
--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -182,7 +182,7 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     }, [currentDialog]);
 
     return ReactDOM.createPortal(
-      <DialogContainer ref={dialogRef} onClick={onClickOutside} className={isCenter ? 'center' : 'right'}>
+      <DialogContainer ref={dialogRef} onMouseDown={onClickOutside} className={isCenter ? 'center' : 'right'}>
         {currentlyRenderedDialog}
       </DialogContainer>,
       document.querySelector('#dialogs') || document.createElement('div')


### PR DESCRIPTION
## Description

My code prevents the modal from closing if you start the click in the modal, and release it outside the modal.

## Tests to perform

- [ ] Test in several modals to release the click outside, the modal should not close.
