### PR TITLE
fix/onClickCopy-csv-text-studio

### DIFF
--- a/src/views/components/textmanagement/TextList.tsx
+++ b/src/views/components/textmanagement/TextList.tsx
@@ -41,7 +41,7 @@ export const TextList = ({ dialogsRef, disabledTranslation }: TextListProps) => 
   const onClickCopy = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>, row: number) => {
     event.stopPropagation();
     navigator.clipboard.writeText(
-      textInfo.fileId >= 100000 && textInfo.fileId < 200000 ? `text_get(${textInfo.fileId}, ${row})` : `ext_text(${textInfo.fileId}, ${row})`
+      textInfo.fileId >= 100000 && textInfo.fileId < 200000 ? `text_get(${textInfo.fileId - 100000}, ${row})` : `ext_text(${textInfo.fileId}, ${row})`
     );
     window.dispatchEvent(new CustomEvent('tooltip:ChangeText', { detail: t('copy:copied') }));
   };

--- a/src/views/components/textmanagement/TextList.tsx
+++ b/src/views/components/textmanagement/TextList.tsx
@@ -41,7 +41,7 @@ export const TextList = ({ dialogsRef, disabledTranslation }: TextListProps) => 
   const onClickCopy = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>, row: number) => {
     event.stopPropagation();
     navigator.clipboard.writeText(
-      textInfo.fileId >= 100000 ? `text_get(${textInfo.fileId - 100000}, ${row})` : `ext_text(${textInfo.fileId}, ${row})`
+      textInfo.fileId >= 100000 && textInfo.fileId < 200000 ? `text_get(${textInfo.fileId}, ${row})` : `ext_text(${textInfo.fileId}, ${row})`
     );
     window.dispatchEvent(new CustomEvent('tooltip:ChangeText', { detail: t('copy:copied') }));
   };


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Fix bug où il y avait le -100 000 dans la fonction a copié pour l'utilisateur. lorsque ID > 200 000

## Note before testing

<!-- Optional but can be useful if the tester has to update a lib for example. -->

## Tests to perform

ext_text(ID, row) pour 0 à 99999
text_get(ID - 100000, row) pour 100000 à 199999
ext_text(ID, row) pour 200000+
