### PR TITLE
Fix crash with the deletion in movepool page due to confusion with the creature form

### DIFF
--- a/src/views/components/database/pokemon/movepool/MovepoolLevelLearnableTable.tsx
+++ b/src/views/components/database/pokemon/movepool/MovepoolLevelLearnableTable.tsx
@@ -128,9 +128,12 @@ const deleteMove = (
   pokemonIdentifier: PokemonIdentifierType,
   currentEditedPokemon: StudioCreature
 ) => {
-  const currentEditedForm = currentEditedPokemon.forms[pokemonIdentifier.form];
-  movePool.splice(index, 1);
-  currentEditedForm.moveSet = [...movePool, ...currentEditedForm.moveSet.filter((m) => m.klass !== 'LevelLearnableMove')];
+  const currentEditedForm = currentEditedPokemon.forms.find((f) => f.form === pokemonIdentifier.form);
+  if (!currentEditedForm) return;
+
+  const movePoolEdited = cloneEntity(movePool);
+  movePoolEdited.splice(index, 1);
+  currentEditedForm.moveSet = [...movePoolEdited, ...currentEditedForm.moveSet.filter((m) => m.klass !== 'LevelLearnableMove')];
   return currentEditedPokemon;
 };
 

--- a/src/views/components/database/pokemon/movepool/MovepoolTable.tsx
+++ b/src/views/components/database/pokemon/movepool/MovepoolTable.tsx
@@ -126,10 +126,13 @@ const deleteMove = (
   currentEditedPokemon: StudioCreature,
   type: MovepoolTableType
 ) => {
-  moveSet.splice(index, 1);
-  const form = currentEditedPokemon.forms[pokemonIdentifier.form];
+  const currentEditedForm = currentEditedPokemon.forms.find((f) => f.form === pokemonIdentifier.form);
+  if (!currentEditedForm) return;
+
+  const moveSetEdited = cloneEntity(moveSet);
   const klass = getMoveKlass(type);
-  form.moveSet = [...form.moveSet.filter((m) => m.klass !== klass), ...moveSet];
+  moveSetEdited.splice(index, 1);
+  currentEditedForm.moveSet = [...currentEditedForm.moveSet.filter((m) => m.klass !== klass), ...moveSetEdited];
   return currentEditedPokemon;
 };
 


### PR DESCRIPTION
## Description

This PR fixes a crash in movepool page if we try to delete a move from the movepool with a creature form other than 0 because there has been confusion between the id of the form and its index. (the usual bug...)

In practice, it's with mega evolutions that have form equal to or greater than 30 that the problem occurs. (because the index is different to the form id)

## Tests to perform

- [x] The user can delete a move in the movepool page

## Error

![image](https://github.com/PokemonWorkshop/PokemonStudio/assets/7809685/cf011199-fffa-456d-9183-1bd341d04b31)

Discord: https://discord.com/channels/143824995867557888/1255523750078713979
