### PR TITLE
Fix the baby form id when we create a new creature form

### DIFF
--- a/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
@@ -59,8 +59,7 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
     if (data.success == false) return;
 
     const newForm = cloneEntity({ ...form, ...data.data, form: newFormId });
-    // TODO: Make a better implementation of that, it's overwriting the original value!
-    if (newFormId <= 29 && creatures[form.babyDbSymbol]?.forms.find((f) => f.form === newFormId)) form.babyForm = newFormId;
+    if (newFormId <= 29 && creatures[form.babyDbSymbol]?.forms.find((f) => f.form === newFormId)) newForm.babyForm = newFormId;
 
     const updatedCreature = cloneEntity(creature);
     updatedCreature.forms = [...updatedCreature.forms, newForm];


### PR DESCRIPTION
## Description

This PR fixes the baby form id when we create a new form. The id has been applied on the wrong creature form.

## Tests to perform

- [x] Check that only the babyFormId of the new form is modified

Example to check: 
- Create a new form for Weedle (Aspicot)
- Create a new form for Kakuna (Coconfort)
- Check the baby form for the form 0 for Kakuna : it must be 0
- Check the baby form for the form 1 for Kakuna : it must be 1

## Bug report

https://discord.com/channels/143824995867557888/1253264471984443472