### PR TITLE
Fix a possible softlock when saving, fix creatures creation and change the limits for the height and weight of the creatures

### DIFF
--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -122,7 +122,7 @@ export const CREATURE_FORM_VALIDATOR = z.object({
   baseExperience: POSITIVE_OR_ZERO_INT.max(1000),
   baseLoyalty: POSITIVE_OR_ZERO_INT.max(255),
   catchRate: POSITIVE_OR_ZERO_INT.max(255),
-  femaleRate: z.union([POSITIVE_OR_ZERO_FLOAT.step(0.1).max(100), z.literal(-1)]),
+  femaleRate: z.union([POSITIVE_OR_ZERO_FLOAT.step(0.01).max(100), z.literal(-1)]),
   breedGroups: z.array(POSITIVE_OR_ZERO_INT),
   hatchSteps: POSITIVE_INT.max(99999),
   babyDbSymbol: DB_SYMBOL_VALIDATOR,

--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -101,8 +101,8 @@ export type StudioCreatureResources = z.infer<typeof CREATURE_RESOURCES_VALIDATO
 
 export const CREATURE_FORM_VALIDATOR = z.object({
   form: POSITIVE_OR_ZERO_INT,
-  height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(100).step(0.01),
-  weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(1000).step(0.01),
+  height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(999).step(0.01),
+  weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(9999).step(0.01),
   type1: DB_SYMBOL_VALIDATOR,
   type2: DB_SYMBOL_VALIDATOR,
   baseHp: POSITIVE_INT.max(255),

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -88,8 +88,8 @@ export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbS
     forms: [
       {
         form: 0,
-        height: 0,
-        weight: 0,
+        height: 0.01,
+        weight: 0.01,
         type1,
         type2,
         baseHp: 100,

--- a/src/views/components/save/MapModificationWarningDialog.tsx
+++ b/src/views/components/save/MapModificationWarningDialog.tsx
@@ -48,10 +48,15 @@ export const MapModificationWarningDialog = forwardRef<EditorHandlingClose, MapM
       // Hide the message box so that it is not visible when the loader is closed
       if (messageBoxRef.current) messageBoxRef.current.style.display = 'none';
       save(
-        () => loaderRef.current.close(),
-        ({ errorMessage }) => loaderRef.current.setError('saving_project_error', errorMessage)
+        () => {
+          loaderRef.current.close();
+          closeDialog();
+        },
+        ({ errorMessage }) => {
+          loaderRef.current.setError('saving_project_error', errorMessage);
+          closeDialog();
+        }
       );
-      closeDialog();
     };
 
     useEditorHandlingClose(ref, undefined, () => {


### PR DESCRIPTION
## Description

This PR fixes the issues follows:
- Fix a possible softlock when saving: I cannot reproduce the problem, but 2 users has been reported the issue. The dialog to advertised the user that RMXP should be closed before Studio saving is responsable of the issue. The dialog is closed while the process saving, so the process can be interrupted and blocked. The fix ensures that the dialog is now closed after the save process.
- Fix the creatures creation, the default values of the height and weight has been changed to 0 to 0.01.

Changes:

Early feedback from users shows that the limits we have set on certain creature property values are too restrictive. The following changes modify certain limits.

- The maximum limits for the height and weight of the creatures has been increased. (999 for the height, 9999 for the weight)
- The step for the femaleRate has been changed to 0.1 to 0.01.

## Tests to perform

- [x] The user can save their project: to display the dialogue, you need to change a map data (or the map name etc.). Then save (no need to tick the box) and check that there is no softlock.
- [x] The user can create a creature that can pass the zod check.
- [x] The maximum limits for the height and weight works correctly
- [x] The step for the femaleRate works correctly

Issues reported:
- https://discord.com/channels/143824995867557888/1257270539248996455
- https://discord.com/channels/143824995867557888/1257170238600904775
