### PR TITLE
Fix editor cannot be closed when genderless toggle is checked in encounter editor

### DIFF
--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -45,6 +45,10 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const isGenderless = Boolean(getRawFormData().isGenderLess ?? defaults.isGenderLess === 'true');
 
   const onStateChange: React.ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
+    const femaleRateElement = formRef.current?.elements.namedItem('femaleRate');
+    if (!(femaleRateElement instanceof HTMLInputElement)) return;
+
+    femaleRateElement.value = '0';
     const isGenderless = currentTarget.checked;
     if (divRef.current) divRef.current.style.display = isGenderless ? 'none' : 'block';
   };

--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -2,7 +2,7 @@ import { Editor } from '@components/editor/Editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useCreaturePage } from '@hooks/usePage';
 import { useSelectOptions } from '@hooks/useSelectOptions';
-import React, { forwardRef, useMemo, useRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUpdateForm } from './useUpdateForm';
 import { useZodForm } from '@hooks/useZodForm';
@@ -11,6 +11,7 @@ import { InputFormContainer } from '@components/inputs/InputContainer';
 import { ENCOUNTER_EDITOR_SCHEMA } from './EncounterEditor/EncounterEditorSchema';
 import { ItemHeldEditor } from './EncounterEditor/ItemHeldEditor';
 import { StudioCreatureForm } from '@modelEntities/creature';
+import { GenderEditor } from './EncounterEditor/GenderEditor';
 
 const initForm = (form: StudioCreatureForm) => {
   return {
@@ -27,9 +28,8 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const updateForm = useUpdateForm(creature, form);
   const itemOptions = useSelectOptions('itemHeld');
   const options = useMemo(() => [{ value: 'none', label: tSelect('none') }, ...itemOptions], []);
-  const divRef = useRef<HTMLDivElement>(null);
   const { canClose, getFormData, getRawFormData, onInputTouched: onTouched, defaults, formRef } = useZodForm(ENCOUNTER_EDITOR_SCHEMA, initForm(form));
-  const { Input, EmbeddedUnitInput, Toggle } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
+  const { Input } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
 
   const onClose = () => {
     const result = canClose() && getFormData();
@@ -42,25 +42,11 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
   useEditorHandlingClose(ref, onClose, canClose);
 
-  const isGenderless = Boolean(getRawFormData().isGenderLess ?? defaults.isGenderLess === 'true');
-
-  const onStateChange: React.ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
-    const femaleRateElement = formRef.current?.elements.namedItem('femaleRate');
-    if (!(femaleRateElement instanceof HTMLInputElement)) return;
-
-    femaleRateElement.value = '0';
-    const isGenderless = currentTarget.checked;
-    if (divRef.current) divRef.current.style.display = isGenderless ? 'none' : 'block';
-  };
-
   return (
     <Editor type="edit" title={t('encounter')}>
       <InputFormContainer ref={formRef}>
         <Input name="catchRate" label={t('catch_rate')} labelLeft onInput={onTouched} />
-        <Toggle name="isGenderLess" label={t('genderless')} onChange={onStateChange} onInput={onTouched} />
-        <div style={{ display: isGenderless ? 'none' : undefined }} ref={divRef}>
-          <EmbeddedUnitInput name="femaleRate" unit="%" type="number" label={t('female_rate')} labelLeft onInput={onTouched} />
-        </div>
+        <GenderEditor getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} formRef={formRef} />
         <ItemHeldEditor index={0} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />
         <ItemHeldEditor index={1} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />
       </InputFormContainer>

--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -1,6 +1,5 @@
 import { Editor } from '@components/editor/Editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
-import { InputWithLeftLabelContainer, Label, Toggle } from '@components/inputs';
 import { useCreaturePage } from '@hooks/usePage';
 import { useSelectOptions } from '@hooks/useSelectOptions';
 import React, { forwardRef, useMemo, useRef } from 'react';
@@ -11,6 +10,15 @@ import { useInputAttrsWithLabel } from '@hooks/useInputAttrs';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { ENCOUNTER_EDITOR_SCHEMA } from './EncounterEditor/EncounterEditorSchema';
 import { ItemHeldEditor } from './EncounterEditor/ItemHeldEditor';
+import { StudioCreatureForm } from '@modelEntities/creature';
+
+const initForm = (form: StudioCreatureForm) => {
+  return {
+    ...form,
+    isGenderLess: form.femaleRate === -1,
+    femaleRate: form.femaleRate === -1 ? 0 : form.femaleRate,
+  };
+};
 
 export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_pokemon');
@@ -20,29 +28,24 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const itemOptions = useSelectOptions('itemHeld');
   const options = useMemo(() => [{ value: 'none', label: tSelect('none') }, ...itemOptions], []);
   const divRef = useRef<HTMLDivElement>(null);
-  const genderlessRef = useRef<HTMLInputElement>(null);
-  const { canClose, getFormData, getRawFormData, onInputTouched: onTouched, defaults, formRef } = useZodForm(ENCOUNTER_EDITOR_SCHEMA, form);
-  const { Input, EmbeddedUnitInput } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
+  const { canClose, getFormData, getRawFormData, onInputTouched: onTouched, defaults, formRef } = useZodForm(ENCOUNTER_EDITOR_SCHEMA, initForm(form));
+  const { Input, EmbeddedUnitInput, Toggle } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
 
   const onClose = () => {
     const result = canClose() && getFormData();
     if (result && result.success) {
-      const femaleRate = result.data.femaleRate;
+      const { isGenderLess, ...data } = result.data;
+      const femaleRate = isGenderLess ? -1 : data.femaleRate;
       const hasFemale = femaleRate <= 0 || femaleRate === 100 ? femaleRate === 100 : form.resources.hasFemale;
-      updateForm({ ...result.data, resources: { ...form.resources, hasFemale } });
+      updateForm({ ...data, femaleRate, resources: { ...form.resources, hasFemale } });
     }
   };
   useEditorHandlingClose(ref, onClose, canClose);
 
-  const isGenderless = Number(getRawFormData().femaleRate ?? defaults.femaleRate) === -1;
-  const onStateChange: React.ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
-    const isFemaleRate = currentTarget.name === 'femaleRate';
-    const femaleRateElement = isFemaleRate ? currentTarget : formRef.current?.elements.namedItem('femaleRate');
-    if (!(femaleRateElement instanceof HTMLInputElement) || !genderlessRef.current) return;
+  const isGenderless = Boolean(getRawFormData().isGenderLess ?? defaults.isGenderLess === 'true');
 
-    const isGenderless = isFemaleRate ? currentTarget.valueAsNumber === -1 : currentTarget.checked;
-    if (isFemaleRate && genderlessRef.current) genderlessRef.current.checked = isGenderless;
-    if (!isFemaleRate) femaleRateElement.value = `${isGenderless ? -1 : Math.max(0, form.femaleRate)}`;
+  const onStateChange: React.ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
+    const isGenderless = currentTarget.checked;
     if (divRef.current) divRef.current.style.display = isGenderless ? 'none' : 'block';
   };
 
@@ -50,12 +53,9 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     <Editor type="edit" title={t('encounter')}>
       <InputFormContainer ref={formRef}>
         <Input name="catchRate" label={t('catch_rate')} labelLeft onInput={onTouched} />
-        <InputWithLeftLabelContainer>
-          <Label>{t('genderless')}</Label>
-          <Toggle defaultChecked={isGenderless} onChange={onStateChange} ref={genderlessRef} />
-        </InputWithLeftLabelContainer>
+        <Toggle name="isGenderLess" label={t('genderless')} onChange={onStateChange} onInput={onTouched} />
         <div style={{ display: isGenderless ? 'none' : undefined }} ref={divRef}>
-          <EmbeddedUnitInput name="femaleRate" unit="%" type="number" label={t('female_rate')} labelLeft onInput={onTouched} onBlur={onStateChange} />
+          <EmbeddedUnitInput name="femaleRate" unit="%" type="number" label={t('female_rate')} labelLeft onInput={onTouched} />
         </div>
         <ItemHeldEditor index={0} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />
         <ItemHeldEditor index={1} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />

--- a/src/views/components/database/pokemon/editors/EncounterEditor/EncounterEditorSchema.ts
+++ b/src/views/components/database/pokemon/editors/EncounterEditor/EncounterEditorSchema.ts
@@ -1,3 +1,6 @@
 import { CREATURE_FORM_VALIDATOR } from '@modelEntities/creature';
+import { z } from 'zod';
 
-export const ENCOUNTER_EDITOR_SCHEMA = CREATURE_FORM_VALIDATOR.pick({ catchRate: true, femaleRate: true, itemHeld: true });
+export const ENCOUNTER_EDITOR_SCHEMA = CREATURE_FORM_VALIDATOR.pick({ catchRate: true, femaleRate: true, itemHeld: true }).merge(
+  z.object({ isGenderLess: z.boolean() })
+);

--- a/src/views/components/database/pokemon/editors/EncounterEditor/GenderEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor/GenderEditor.tsx
@@ -1,0 +1,36 @@
+import { useInputAttrsWithLabel } from '@src/hooks/useInputAttrs';
+import React, { useRef } from 'react';
+import { ENCOUNTER_EDITOR_SCHEMA } from './EncounterEditorSchema';
+import { useTranslation } from 'react-i18next';
+
+type GenderEditorProps = {
+  getRawFormData: () => Record<string, unknown>;
+  onTouched: React.FormEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  defaults: Record<string, unknown>;
+  formRef: React.RefObject<HTMLFormElement>;
+};
+
+export const GenderEditor = ({ getRawFormData, onTouched, defaults, formRef }: GenderEditorProps) => {
+  const { t } = useTranslation('database_pokemon');
+  const { EmbeddedUnitInput, Toggle } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
+  const divRef = useRef<HTMLDivElement>(null);
+  const isGenderless = Boolean(getRawFormData().isGenderLess ?? defaults.isGenderLess === 'true');
+
+  const onStateChange: React.ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
+    const femaleRateElement = formRef.current?.elements.namedItem('femaleRate');
+    if (!(femaleRateElement instanceof HTMLInputElement)) return;
+
+    femaleRateElement.value = '0';
+    const isGenderless = currentTarget.checked;
+    if (divRef.current) divRef.current.style.display = isGenderless ? 'none' : 'block';
+  };
+
+  return (
+    <>
+      <Toggle name="isGenderLess" label={t('genderless')} onChange={onStateChange} onInput={onTouched} />
+      <div style={{ display: isGenderless ? 'none' : undefined }} ref={divRef}>
+        <EmbeddedUnitInput name="femaleRate" unit="%" type="number" label={t('female_rate')} labelLeft onInput={onTouched} />
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## Description

This PR fixes an issue in the encounter editor which cannot be closed when the genderless toggle is checked.

## Tests to perform

- [x] The user can close the editor when the genderless toggle is checked ;
- [x] The editor doesn't close when the value of the femaleRate is out of range ;
- [x] Test this specific case: set a out of range value for the femaleRate, tick the toggle and try to close the editor. If the editor closes, it's OK.

## Issues report
Discord: 
https://discord.com/channels/143824995867557888/1257465408265392270
https://discord.com/channels/143824995867557888/1257684673274970142
