### PR TITLE
Fix item held editor which cannot be closed if the chance is out of range and the item selected is 'None'

### DIFF
--- a/assets/i18n/de/database_groups.json
+++ b/assets/i18n/de/database_groups.json
@@ -20,7 +20,7 @@
   "example_name": "Alabastia - Gras 1",
   "pokemon_group": "Pokémon der Gruppe",
   "fields_asterisk_required": "Die mit einem Sternchen versehenen Felder sind erforderlich.",
-  "battler_deletion_of": "Löschung von {{pokemon}}",
+  "battler_deletion_of": "Löschen eines Pokémon",
   "battler_deletion_message": "Du bist dabei, « {{battler}} » dauerhaft aus der Gruppe « {{group}} » zu löschen.",
   "import": "Importieren",
   "battler_import_info": "Du kannst Pokémon aus einer anderen Gruppe importieren.",

--- a/assets/i18n/de/database_trainers.json
+++ b/assets/i18n/de/database_trainers.json
@@ -8,7 +8,7 @@
   "delete_this_trainer": "Diesen Trainer löschen",
   "trainer_deletion_of": "Löschen des Trainers",
   "trainer_deletion_message": "Du bist dabei, den Trainer « {{trainer}} » endgültig zu löschen.",
-  "battler_deletion_of": "Löschen von {{pokemon}}",
+  "battler_deletion_of": "Löschen eines Pokémon",
   "battler_deletion_message": "Du bist dabei, « {{battler}} » dauerhaft aus « {{trainer}} » Trainer zu löschen.",
   "create_trainer": "Trainer hinzufügen",
   "cancel": "Abbrechen",

--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -25,7 +25,7 @@
   "pokemon_group": "Pokémon of the group",
   "fields_asterisk_required": "Fields with an asterisk are required.",
   "battler_deletion_of": "Deletion of Pokémon",
-  "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the «\u00a0{{group}}\u00a0» group.",
+  "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the group «\u00a0{{group}}\u00a0».",
   "import": "Importation",
   "default_option_label": "From another group",
   "showdown_option_label": "In Showdown format",

--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -24,7 +24,7 @@
   "example_name": "Pallet Town - Grass 1",
   "pokemon_group": "Pokémon of the group",
   "fields_asterisk_required": "Fields with an asterisk are required.",
-  "battler_deletion_of": "Deletion of {{pokemon}}",
+  "battler_deletion_of": "Deletion of Pokémon",
   "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the «\u00a0{{group}}\u00a0» group.",
   "import": "Importation",
   "default_option_label": "From another group",

--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -9,7 +9,7 @@
   "trainer_deletion_of": "Deletion of the trainer",
   "trainer_deletion_message": "You are about to permanently delete the trainer «\u00a0{{trainer}}\u00a0».",
   "battler_deletion_of": "Deletion of Pokémon",
-  "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the «\u00a0{{trainer}}\u00a0» trainer.",
+  "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the trainer «\u00a0{{trainer}}\u00a0».",
   "create_trainer": "Add the trainer",
   "cancel": "Cancel",
   "fields_asterisk_required": "Fields with an asterisk are required.",

--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -8,7 +8,7 @@
   "delete_this_trainer": "Delete this trainer",
   "trainer_deletion_of": "Deletion of the trainer",
   "trainer_deletion_message": "You are about to permanently delete the trainer «\u00a0{{trainer}}\u00a0».",
-  "battler_deletion_of": "Deletion of {{pokemon}}",
+  "battler_deletion_of": "Deletion of Pokémon",
   "battler_deletion_message": "You are about to permanently delete «\u00a0{{battler}}\u00a0» from the «\u00a0{{trainer}}\u00a0» trainer.",
   "create_trainer": "Add the trainer",
   "cancel": "Cancel",

--- a/assets/i18n/es/database_groups.json
+++ b/assets/i18n/es/database_groups.json
@@ -21,7 +21,7 @@
   "example_name": "Pueblo Paleta - Hierba 1",
   "pokemon_group": "Pokémon del grupo",
   "fields_asterisk_required": "Los campos con asterisco son obligatorios.",
-  "battler_deletion_of": "Eliminar a {{pokemon}}",
+  "battler_deletion_of": "Eliminar un Pokémon",
   "battler_deletion_message": "Estás a punto de eliminar a «\u00a0{{battler}}\u00a0» del grupo «\u00a0{{group}}\u00a0».",
   "import": "Importar",
   "battler_import_info": "Puedes importar Pokémon desde otro grupo.",

--- a/assets/i18n/es/database_trainers.json
+++ b/assets/i18n/es/database_trainers.json
@@ -8,7 +8,7 @@
   "delete_this_trainer": "Borrar este entrenador",
   "trainer_deletion_of": "Borrado del entrenador",
   "trainer_deletion_message": "Estás a punto de eliminar permanentemente el entrenador « {{trainer}} »",
-  "battler_deletion_of": "Borrado de {{pokemon}}",
+  "battler_deletion_of": "Eliminar un Pokémon",
   "battler_deletion_message": "Estás a punto de eliminar permanentemente a «\u00a0{{battler}}\u00a0» del entrenador «\u00a0{{trainer}}\u00a0»",
   "create_trainer": "Añadir el entrenador",
   "cancel": "Cancelar",

--- a/assets/i18n/it/database_groups.json
+++ b/assets/i18n/it/database_groups.json
@@ -23,7 +23,7 @@
   "example_name": "Biancavilla - Erba 1",
   "pokemon_group": "Pokémon del gruppo",
   "fields_asterisk_required": "I campi con l'asterisco sono obbligatori.",
-  "battler_deletion_of": "Rimozione di {{pokemon}}",
+  "battler_deletion_of": "Rimozione di un Pokémon",
   "battler_deletion_message": "Stai per rimuovere per sempre «\u00a0{{battler}}\u00a0» dal gruppo «\u00a0{{group}}\u00a0».",
   "import": "Importazione",
   "battler_import_info": "Puoi importare Pokémon da un altro gruppo.",

--- a/assets/i18n/it/database_trainers.json
+++ b/assets/i18n/it/database_trainers.json
@@ -8,7 +8,7 @@
   "delete_this_trainer": "Rimuovi questo allenatore",
   "trainer_deletion_of": "Rimozione dell'allenatore",
   "trainer_deletion_message": "Stai per rimuovere per sempre l'allenatore «\u00a0{{trainer}}\u00a0».",
-  "battler_deletion_of": "Rimozione di {{pokemon}}",
+  "battler_deletion_of": "Rimozione di un Pokémon",
   "battler_deletion_message": "Stai per rimuovere per sempre «\u00a0{{battler}}\u00a0» dall'allenatore «\u00a0{{trainer}}\u00a0».",
   "create_trainer": "Aggiungi allenatore",
   "cancel": "Annulla",

--- a/assets/i18n/pt/database_groups.json
+++ b/assets/i18n/pt/database_groups.json
@@ -23,7 +23,7 @@
   "example_name": "Pallet Town - Relva 1",
   "pokemon_group": "Pokémon do grupo",
   "fields_asterisk_required": "Os campos com asterisco são obrigatórios.",
-  "battler_deletion_of": "Eliminação do {{Pokemon}}",
+  "battler_deletion_of": "Eliminação do Pokémon",
   "battler_deletion_message": "Você está no ponto de eliminar definitivamente «\u00a0{{battler}}\u00a0» do grupo «\u00a0{{group}}\u00a0»",
   "import": "Importação",
   "battler_import_info": "Você pode importar Pokémon de um outro grupo.",

--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -101,8 +101,8 @@ export type StudioCreatureResources = z.infer<typeof CREATURE_RESOURCES_VALIDATO
 
 export const CREATURE_FORM_VALIDATOR = z.object({
   form: POSITIVE_OR_ZERO_INT,
-  height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(999).step(0.01),
-  weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(9999).step(0.01),
+  height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(999.99).step(0.01),
+  weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(9999.99).step(0.01),
   type1: DB_SYMBOL_VALIDATOR,
   type2: DB_SYMBOL_VALIDATOR,
   baseHp: POSITIVE_INT.max(255),

--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -47,8 +47,8 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       <InputFormContainer ref={formRef}>
         <Input name="catchRate" label={t('catch_rate')} labelLeft onInput={onTouched} />
         <GenderEditor getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} formRef={formRef} />
-        <ItemHeldEditor index={0} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />
-        <ItemHeldEditor index={1} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} />
+        <ItemHeldEditor index={0} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} formRef={formRef} />
+        <ItemHeldEditor index={1} options={options} getRawFormData={getRawFormData} defaults={defaults} onTouched={onTouched} formRef={formRef} />
       </InputFormContainer>
     </Editor>
   );

--- a/src/views/components/database/pokemon/editors/EncounterEditor/ItemHeldEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor/ItemHeldEditor.tsx
@@ -17,9 +17,10 @@ type ItemHeldEditorProps = {
   getRawFormData: () => Record<string, unknown>;
   onTouched: React.FormEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   defaults: Record<string, unknown>;
+  formRef: React.RefObject<HTMLFormElement>;
 };
 
-export const ItemHeldEditor = ({ index, options, getRawFormData, onTouched, defaults }: ItemHeldEditorProps) => {
+export const ItemHeldEditor = ({ index, options, getRawFormData, onTouched, defaults, formRef }: ItemHeldEditorProps) => {
   const { t } = useTranslation('database_pokemon');
   const divRef = useRef<HTMLDivElement>(null);
   const { Select, EmbeddedUnitInput } = useInputAttrsWithLabel(ENCOUNTER_EDITOR_SCHEMA, defaults);
@@ -29,6 +30,11 @@ export const ItemHeldEditor = ({ index, options, getRawFormData, onTouched, defa
   const label = t(index === 0 ? 'common_item_held' : 'rare_item_held');
   const onChange = (value: string) => {
     if (divRef.current) divRef.current.style.display = value === 'none' ? 'none' : 'block';
+
+    const chanceElement = formRef.current?.elements.namedItem(`itemHeld.${index}.chance`);
+    if (!(chanceElement instanceof HTMLInputElement) || value !== 'none') return;
+
+    chanceElement.value = '0';
   };
 
   return (


### PR DESCRIPTION
## Description

Fix:
- The item held editor which cannot be closed if the chance is out of range and the item selected is 'None' ;
- Deletion message variable error when deleting the Pokémon of a trainer (#342)

Changes: 
- Adjust height and weight limit (creature)

Closes #342 

## Tests to perform

- [x] The user can close the encounted editor if it set an out of range value for the item chance and then selected "None" for the item held.
- [x] The height and weight limit are correct
- [x] The translation is correct
