### PR TITLE
Implement migration to fix values in the creatures + update Studio to 2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-studio",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-studio",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@electron-forge/publisher-github": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/backendTasks/migrateData.ts
+++ b/src/backendTasks/migrateData.ts
@@ -12,28 +12,32 @@ import { migrationV2 } from '@src/migrations/migrationV2';
 import { migrationPreV2 } from '@src/migrations/migrationPreV2';
 import { migrationPreV2_1 } from '@src/migrations/migrationPreV2_1';
 import { addOtherLanguages } from '@src/migrations/addOtherLanguages';
+import { fixCreatureValuesAfterZodChange } from '@src/migrations/fixCreatureValuesAfterZodChange';
 
 export type MigrationTask = (event: IpcMainEvent, projectPath: string, studioSettings?: StudioSettings) => Promise<void>;
 
 // Don't forget to extend those array with the new tasks that gets added by the time!
 const MIGRATIONS: Record<string, MigrationTask[]> = {
-  '1.0.0': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.0.1': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.0.2': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.1.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.1.1': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.2.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.3.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.4.0': [migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.4.1': [migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.4.2': [migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.4.3': [migrationV2, migrationPreV2_1, addOtherLanguages],
-  '1.4.4': [migrationV2, migrationPreV2_1, addOtherLanguages],
-  '2.0.0': [migrationPreV2_1, addOtherLanguages],
-  '2.0.1': [migrationPreV2_1, addOtherLanguages],
-  '2.0.2': [migrationPreV2_1, addOtherLanguages],
-  '2.0.3': [migrationPreV2_1, addOtherLanguages],
-  '2.1.0': [addOtherLanguages], // Don't forget to add the official version coming up
+  '1.0.0': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.0.1': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.0.2': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.1.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.1.1': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.2.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.3.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.4.0': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.4.1': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.4.2': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.4.3': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '1.4.4': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.0.0': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.0.1': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.0.2': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.0.3': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.1.0': [addOtherLanguages, fixCreatureValuesAfterZodChange],
+  '2.2.0': [fixCreatureValuesAfterZodChange],
+  '2.2.1': [fixCreatureValuesAfterZodChange],
+  '2.2.2': [fixCreatureValuesAfterZodChange], // Don't forget to add the official version coming up
 };
 
 // Don't forget to extend those array with the new tasks that gets added by the time!
@@ -48,6 +52,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.0.1': [
     'Migrate MapLinks',
@@ -59,6 +64,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.0.2': [
     'Migrate MapLinks',
@@ -70,6 +76,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.1.0': [
     'Link the resources to the Pokémon',
@@ -80,6 +87,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.1.1': [
     'Link the resources to the Pokémon',
@@ -90,6 +98,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.2.0': [
     'Link the resources to the Pokémon',
@@ -100,6 +109,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.3.0': [
     'Link the resources to the Pokémon',
@@ -110,6 +120,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.4.0': [
     'Migration to version 2.0',
@@ -117,6 +128,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.4.1': [
     'Migration to version 2.0',
@@ -124,6 +136,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.4.2': [
     'Migration to version 2.0',
@@ -131,6 +144,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.4.3': [
     'Migration to version 2.0',
@@ -138,6 +152,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
   '1.4.4': [
     'Migration to version 2.0',
@@ -145,12 +160,40 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Add the volume and the pitch in the maps',
     'Generating map overviews',
     'Add basic languages',
+    'Update creatures values after change in the values authorized',
   ],
-  '2.0.0': ['Add available languages for translation', 'Add the volume and the pitch in the maps', 'Generating map overviews', 'Add basic languages'],
-  '2.0.1': ['Add available languages for translation', 'Add the volume and the pitch in the maps', 'Generating map overviews', 'Add basic languages'],
-  '2.0.2': ['Add available languages for translation', 'Add the volume and the pitch in the maps', 'Generating map overviews', 'Add basic languages'],
-  '2.0.3': ['Add available languages for translation', 'Add the volume and the pitch in the maps', 'Generating map overviews', 'Add basic languages'],
-  '2.1.0': ['Add basic languages'], // Don't forget to add the official version coming up
+  '2.0.0': [
+    'Add available languages for translation',
+    'Add the volume and the pitch in the maps',
+    'Generating map overviews',
+    'Add basic languages',
+    'Update creatures values after change in the values authorized',
+  ],
+  '2.0.1': [
+    'Add available languages for translation',
+    'Add the volume and the pitch in the maps',
+    'Generating map overviews',
+    'Add basic languages',
+    'Update creatures values after change in the values authorized',
+  ],
+  '2.0.2': [
+    'Add available languages for translation',
+    'Add the volume and the pitch in the maps',
+    'Generating map overviews',
+    'Add basic languages',
+    'Update creatures values after change in the values authorized',
+  ],
+  '2.0.3': [
+    'Add available languages for translation',
+    'Add the volume and the pitch in the maps',
+    'Generating map overviews',
+    'Add basic languages',
+    'Update creatures values after change in the values authorized',
+  ],
+  '2.1.0': ['Add basic languages', 'Update creatures values after change in the values authorized'],
+  '2.2.0': ['Update creatures values after change in the values authorized'],
+  '2.2.1': ['Update creatures values after change in the values authorized'],
+  '2.2.2': ['Update creatures values after change in the values authorized'], // Don't forget to add the official version coming up
 };
 
 export type MigrateDataInput = { projectPath: string; projectVersion: string; studioSettings: StudioSettings };

--- a/src/migrations/fixCreatureValuesAfterZodChange.ts
+++ b/src/migrations/fixCreatureValuesAfterZodChange.ts
@@ -1,0 +1,57 @@
+import { IpcMainEvent } from 'electron';
+import path from 'path';
+import { readProjectFolder } from '@src/backendTasks/readProjectData';
+import fsPromise from 'fs/promises';
+import { CREATURE_FORM_VALIDATOR, CREATURE_VALIDATOR } from '@modelEntities/creature';
+import { z } from 'zod';
+import { deletePSDKDatFile } from './migrateUtils';
+import { parseJSON } from '@utils/json/parse';
+import { POSITIVE_OR_ZERO_FLOAT } from '@modelEntities/common';
+import { DbSymbol } from '@modelEntities/dbSymbol';
+
+const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({
+  forms: z.array(CREATURE_FORM_VALIDATOR.extend({ height: POSITIVE_OR_ZERO_FLOAT, weight: POSITIVE_OR_ZERO_FLOAT })).nonempty(),
+});
+type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;
+
+const fixHeightAndWeightValues = (creature: StudioCreatureDataBeforeMigration) => {
+  creature.forms.forEach((form) => {
+    form.weight = form.weight === 0 ? 0.01 : form.weight;
+    form.height = form.height === 0 ? 0.01 : form.height;
+  });
+};
+
+const fixItemHeld = (creature: StudioCreatureDataBeforeMigration) => {
+  creature.forms.forEach((form) => {
+    if (form.itemHeld.length === 0) {
+      form.itemHeld = [
+        {
+          dbSymbol: 'none' as DbSymbol,
+          chance: 0,
+        },
+        {
+          dbSymbol: 'none' as DbSymbol,
+          chance: 0,
+        },
+      ];
+    }
+  });
+};
+
+export const fixCreatureValuesAfterZodChange = async (_: IpcMainEvent, projectPath: string) => {
+  deletePSDKDatFile(projectPath);
+
+  const creatureData = await readProjectFolder(projectPath, 'pokemon');
+  await creatureData.reduce(async (lastPromise, creature) => {
+    await lastPromise;
+    const creatureParsed = PRE_MIGRATION_CREATURE_VALIDATOR.safeParse(parseJSON(creature.data, creature.filename));
+    if (creatureParsed.success) {
+      fixHeightAndWeightValues(creatureParsed.data);
+      fixItemHeld(creatureParsed.data);
+      return fsPromise.writeFile(
+        path.join(projectPath, 'Data/Studio/pokemon', `${creatureParsed.data.dbSymbol}.json`),
+        JSON.stringify(creatureParsed.data, null, 2)
+      );
+    }
+  }, Promise.resolve());
+};


### PR DESCRIPTION
## Description

This PR fixes the values of the creatures (using migration) to be correct for the validator or prevent malfunction in the editors.

Fix:
- Fix itemHeld props which should be not be an empty array.
- Fix the minimum values for the height and weight (change 0 to 0.01)

Change:
- Update Studio version 2.2.2 to 2.2.3

## Tests to perform

- [x] The migration fixes the itemHeld and height and weight values

After the migration, the project.studio file of the project is updated to write 2.2.3. If you want make several tests, change this value to 2.2.2.