### PR TITLE
Fix the ItemHealDataEditor which could introduce ALL in the status list

### DIFF
--- a/src/views/components/database/item/editors/ItemHealDataEditor.tsx
+++ b/src/views/components/database/item/editors/ItemHealDataEditor.tsx
@@ -77,6 +77,11 @@ export const ItemHealDataEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       ...item,
       ...filteredFormData,
     };
+
+    if (newItem.statusList && newItem.statusList.includes('ALL')) {
+      newItem.statusList = Statuses.slice(0, -2);
+    }
+
     setProjectItem({ [item.dbSymbol]: newItem as StudioItem });
   };
 
@@ -181,7 +186,7 @@ export const ItemHealDataEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               options={statusesOptions}
               value={healChanges.statusList[0] || '???'}
               onChange={(value) => {
-                const newValue = (item.statusList = (value === 'ALL' ? Statuses.slice(0, -3) : [value]) as [
+                const newValue = (item.statusList = (value === 'ALL' ? Statuses.slice(0, -2) : [value]) as [
                   StudioItemStatusCondition,
                   ...StudioItemStatusCondition[]
                 ]);


### PR DESCRIPTION
## Description

- For the heal item, we can configure the heal settings.
- In the case of using statuses, if the care applies to all statuses, an incorrect value may be entered in a particular circumstance: opening and closing the editor will add ALL to the data if nothing is edited and "All statuses" was already selected before opening the editor.

=> statusList should be contains : "POISONED", "PARALYZED", "BURN", "ASLEEP", "FROZEN", "TOXIC", "CONFUSION" now.

- I also changed the -3 to -2 to include the confusion.

## Tests to perform

1. Go on the Lum Berry item
2. Open the heal editor
3. Close the heal editor
4. Save
5. Open the json lum_berry.json and see the issue
6. Try to open the project after modification
