### PR TITLE
Fix a bug with the project names that are too long in the Studio's home project card component

### DIFF
--- a/src/views/components/home/ProjectCard.tsx
+++ b/src/views/components/home/ProjectCard.tsx
@@ -30,10 +30,9 @@ const ProjectCardContainer = styled(ActiveContainer)`
     ${({ theme }) => theme.fonts.titlesHeadline6}
     color: ${({ theme }) => theme.colors.text400};
     height: 44px;
-    overflow-y: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow-x: hidden;
+    overflow: hidden;
     margin: 0 0 4px 0;
     padding: 0;
   }

--- a/src/views/components/home/ProjectCard.tsx
+++ b/src/views/components/home/ProjectCard.tsx
@@ -29,7 +29,12 @@ const ProjectCardContainer = styled(ActiveContainer)`
     display: inline-block;
     ${({ theme }) => theme.fonts.titlesHeadline6}
     color: ${({ theme }) => theme.colors.text400};
-    margin: 0;
+    height: 44px;
+    overflow-y: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: hidden;
+    margin: 0 0 4px 0;
     padding: 0;
   }
 
@@ -81,7 +86,7 @@ const ProjectCardContainer = styled(ActiveContainer)`
   ${Code} {
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow-x: hidden;
+    overflow: hidden;
     max-width: 171px;
   }
 `;

--- a/src/views/components/home/ProjectCard.tsx
+++ b/src/views/components/home/ProjectCard.tsx
@@ -29,10 +29,7 @@ const ProjectCardContainer = styled(ActiveContainer)`
     display: inline-block;
     ${({ theme }) => theme.fonts.titlesHeadline6}
     color: ${({ theme }) => theme.colors.text400};
-    height: 44px;
-    overflow-y: hidden;
-    text-overflow: ellipsis;
-    margin: 0 0 4px 0;
+    margin: 0;
     padding: 0;
   }
 
@@ -84,7 +81,7 @@ const ProjectCardContainer = styled(ActiveContainer)`
   ${Code} {
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden;
+    overflow-x: hidden;
     max-width: 171px;
   }
 `;


### PR DESCRIPTION
## Description

When the user is setting a project name that is too long, the name is not properly displayed in the recent project card component.

## Steps to reproduce
- Create a project
- Change the name for a long one like "my-super-monster-taming-game-project-for-real"
- Check the home's recent project component for this project