### PR TITLE
Make sure that the user can use the Showdown import even if there is no trainer in the database

### DIFF
--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -74,5 +74,6 @@
   "victory_music": "Victory music of the trainer",
   "defeat_music": "Defeat music of the trainer",
   "bgm_music": "Battle music",
-  "character_v3_message": "The character will be used from version 3.0 of the application."
+  "character_v3_message": "The character will be used from version 3.0 of the application.",
+  "no_trainers_available": "No trainers available for import !"
 }

--- a/assets/i18n/fr/database_trainers.json
+++ b/assets/i18n/fr/database_trainers.json
@@ -74,5 +74,6 @@
   "victory_music": "Musique de victoire du dresseur",
   "defeat_music": "Musique de défaite du dresseur",
   "bgm_music": "Musique de combat",
-  "character_v3_message": "Le character sera utilisé à partir de la version 3.0 de l'application."
+  "character_v3_message": "Le character sera utilisé à partir de la version 3.0 de l'application.",
+  "no_trainers_available": "Aucun dresseur n'est disponible à l'import !"
 }

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
@@ -54,15 +54,26 @@ const getFirstDbSymbol = (
   groups: ProjectData['groups'],
   trainers: ProjectData['trainers'],
   group: StudioGroup,
-  trainer: StudioTrainer
+  trainer: StudioTrainer | null
 ) => {
-  const getFirstSymbol = (entities: ProjectData['groups'] | ProjectData['trainers'], currentSymbol: DbSymbol) =>
-    Object.entries(entities)
-      .map(([value, data]) => ({ value, index: data.id }))
-      .filter(({ value }) => value !== currentSymbol)
-      .sort((a, b) => a.index - b.index)[0].value;
+  const getFirstSymbol = (entities: ProjectData['groups'] | ProjectData['trainers'], currentSymbol: DbSymbol) => {
+    if (!entities) return '__undef__';
 
-  return from === 'group' ? getFirstSymbol(groups, group.dbSymbol) : from === 'trainer' ? getFirstSymbol(trainers, trainer.dbSymbol) : '__undef__';
+    const entries = Object.entries(entities)
+      .map(([value, data]) => ({ value, index: data.id }))
+      .filter(({ value }) => value !== currentSymbol);
+    if (entries.length === 0) return '__undef__';
+
+    return entries.sort((a, b) => a.index - b.index)[0].value;
+  };
+
+  if (from === 'group') {
+    return getFirstSymbol(groups, group.dbSymbol);
+  } else if (from === 'trainer' && trainer) {
+    return getFirstSymbol(trainers, trainer.dbSymbol);
+  } else {
+    return '__undef__';
+  }
 };
 
 export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattlerImportProps>(({ closeDialog, from }, ref) => {
@@ -77,12 +88,12 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
   const { group } = useGroupPage();
 
   const updateTrainer = useUpdateTrainer(trainer);
-  const currentTrainer = useMemo(() => cloneEntity(trainer), []);
+  const currentTrainer = useMemo(() => (trainer ? cloneEntity(trainer) : null), [trainer]);
   const updateGroup = useUpdateGroup(group);
 
   const [selectedEntity, setSelectedEntity] = useState(getFirstDbSymbol(from, groups, trainers, group, currentTrainer));
   const [showdownEncounter, setShowdownEncounter] = useState<StudioGroupEncounter[]>([]);
-  const [dropDownSelection, setDropDownSelection] = useState<string>('default');
+  const [dropDownSelection, setDropDownSelection] = useState<string>(selectedEntity !== '__undef__' ? 'default' : 'showdown');
   const [override, setOverride] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -101,7 +112,7 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
     if (convertedTeam.length === 0) {
       setShowdownEncounter([]);
       return setError(t('error_message'));
-    } else if (!isGroup && !override && convertedTeam.length + currentTrainer.party.length > 6) {
+    } else if (!isGroup && !override && currentTrainer && convertedTeam.length + currentTrainer.party.length > 6) {
       setError(tTrainer('party_length_limit'));
     } else {
       setError('');
@@ -111,10 +122,12 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
   };
 
   const handleImportTypeChange = (type: string) => {
+    if (type === 'default' && currentTrainer) return setError(t('no_trainers_available'));
+
     setDropDownSelection(type);
     if (type === 'default') {
       const lengthPartyToImport = trainers[selectedEntity].party.length;
-      setError(override || currentTrainer.party.length + lengthPartyToImport <= 6 ? '' : tTrainer('party_length_limit'));
+      setError(override || (currentTrainer && currentTrainer.party.length + lengthPartyToImport <= 6) ? '' : tTrainer('party_length_limit'));
     } else {
       setError('');
       setShowdownEncounter([]);
@@ -123,6 +136,7 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
 
   const canImport = (override: boolean) => {
     if (isGroup || (override && dropDownSelection === 'default')) return true;
+    if (!currentTrainer) return false;
 
     if (dropDownSelection === 'showdown') {
       const isInputValid = showdownEncounter.length > 0;
@@ -150,11 +164,11 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
     const handleImport = (entityType: string, newEntities: StudioGroupEncounter[]) => {
       const updateFunction = entityType === 'group' ? updateGroup : updateTrainer;
       const entityKey = entityType === 'group' ? 'encounters' : 'party';
-      const currentEntities = entityType === 'group' ? group.encounters : currentTrainer.party;
+      const currentEntities = entityType === 'group' ? group.encounters : currentTrainer?.party;
 
       if (override) {
         updateFunction({ [entityKey]: newEntities });
-      } else {
+      } else if (currentEntities) {
         const clonedEntities = cloneEntity(currentEntities);
         clonedEntities.push(...newEntities);
         updateFunction({ [entityKey]: clonedEntities });
@@ -191,7 +205,7 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
             <SelectComponent
               dbSymbol={selectedEntity}
               onChange={(dbSymbol) => setSelectedEntity(dbSymbol)}
-              filter={(dbSymbol) => dbSymbol !== (isGroup ? group.dbSymbol : currentTrainer.dbSymbol)}
+              filter={(dbSymbol) => dbSymbol !== (isGroup ? group.dbSymbol : currentTrainer?.dbSymbol)}
               noLabel
             />
           </InputWithTopLabelContainer>

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
@@ -123,7 +123,7 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
 
   const handleImportTypeChange = (type: string) => {
     setDropDownSelection(type);
-    if (type === 'default') {
+    if (type === 'default' && !isGroup) {
       const lengthPartyToImport = trainers[selectedEntity].party.length;
       setError(override || (currentTrainer && currentTrainer.party.length + lengthPartyToImport <= 6) ? '' : tTrainer('party_length_limit'));
     } else {

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
@@ -122,8 +122,6 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
   };
 
   const handleImportTypeChange = (type: string) => {
-    if (type === 'default' && selectedEntity === '__undef__') return setError(t('no_trainers_available'));
-
     setDropDownSelection(type);
     if (type === 'default') {
       const lengthPartyToImport = trainers[selectedEntity].party.length;
@@ -194,10 +192,12 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
           <ImportInfo>{t('battler_import_info')}</ImportInfo>
           {dropDownSelection === 'showdown' && <ImportInfo>{t('battler_import_details')}</ImportInfo>}
         </ImportInfoContainer>
-        <InputWithTopLabelContainer>
-          <Label htmlFor={from}>{t('import_battler')}</Label>
-          <StudioDropDown value={dropDownSelection} options={dropDownOptions} onChange={handleImportTypeChange} />
-        </InputWithTopLabelContainer>
+        {selectedEntity !== '__undef__' && (
+          <InputWithTopLabelContainer>
+            <Label htmlFor={from}>{t('import_battler')}</Label>
+            <StudioDropDown value={dropDownSelection} options={dropDownOptions} onChange={handleImportTypeChange} />
+          </InputWithTopLabelContainer>
+        )}
 
         {dropDownSelection === 'default' && (
           <InputWithTopLabelContainer>

--- a/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
+++ b/src/views/components/pokemonBattler/editors/PokemonBattlerImport.tsx
@@ -122,7 +122,7 @@ export const PokemonBattlerImport = forwardRef<EditorHandlingClose, PokemonBattl
   };
 
   const handleImportTypeChange = (type: string) => {
-    if (type === 'default' && currentTrainer) return setError(t('no_trainers_available'));
+    if (type === 'default' && selectedEntity === '__undef__') return setError(t('no_trainers_available'));
 
     setDropDownSelection(type);
     if (type === 'default') {

--- a/src/views/pages/database/Trainer.page.tsx
+++ b/src/views/pages/database/Trainer.page.tsx
@@ -37,12 +37,7 @@ export const TrainerPage = () => {
             <TrainerDialog trainer={trainer} dialogsRef={dialogsRef} />
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <PokemonBattlerList
-              title={t('trainer_party', { name: trainerName })}
-              encounters={trainer.party}
-              disabledImport={cannotDelete}
-              from="trainer"
-            />
+            <PokemonBattlerList title={t('trainer_party', { name: trainerName })} encounters={trainer.party} disabledImport={false} from="trainer" />
             <BagEntryList
               title={t('trainer_bag', { name: trainerName })}
               bagEntries={trainer.bagEntries}


### PR DESCRIPTION
## Description

When you have only one trainer in Studio, it is now possible to use the import only in Showdown mode.

## Tests to perform

- Having only one trainer
- [x] It is not possible to change mode
- [x] An error message appears when you try to change modes when you have no trainers to import.
- [x] Import when at least two trainers are working as intended
