### PR TITLE
feat(pokemonBattlresList): add a percent after title

### DIFF
--- a/src/views/components/pokemonBattler/PokemonBattlerList.tsx
+++ b/src/views/components/pokemonBattler/PokemonBattlerList.tsx
@@ -11,6 +11,7 @@ import { PokemonBattlerEditorOverlay } from './editors';
 import type { CurrentBattlerType, PokemonBattlerEditorAndDeletionKeys, PokemonBattlerFrom } from './editors/PokemonBattlerEditorOverlay';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { useTrainerPage } from '@hooks/usePage';
+import { Tag } from '@components/Tag';
 
 type PokemonBattlerListProps = {
   title: string;
@@ -42,7 +43,7 @@ export const PokemonBattlerListHeader = styled.div`
     ${({ theme }) => theme.fonts.titlesHeadline6}
   }
 
-  .buttons {
+  .header {
     display: flex;
     gap: 12px;
 
@@ -56,7 +57,7 @@ export const PokemonBattlerListHeader = styled.div`
   }
 
   @media ${({ theme }) => theme.breakpoints.dataBox422} {
-    .buttons {
+    .header {
       .button-import-full {
         display: none;
       }
@@ -99,11 +100,16 @@ export const PokemonBattlerList = ({ title, encounters, disabledImport, from }: 
     return '';
   };
 
+  const totalEncounterChance = encounters.map((encounter) => encounter.randomEncounterChance).reduce((a, b) => a + b, 0);
+
   return (
     <PokemonBattlerListComponent size="full" data-noactive>
       <PokemonBattlerListHeader>
-        <div className="title">{title}</div>
-        <div className="buttons">
+        <div className="header">
+          <div className="title">{title}</div>
+          {!!totalEncounterChance && <Tag className="chance">{`${totalEncounterChance}%`}</Tag>}
+        </div>
+        <div className="header">
           <div className="button-import-full">
             <DarkButton onClick={() => dialogsRef.current?.openDialog('import')} disabled={disabledImport}>
               {importText()}

--- a/src/views/components/pokemonBattler/PokemonBattlerList.tsx
+++ b/src/views/components/pokemonBattler/PokemonBattlerList.tsx
@@ -107,7 +107,7 @@ export const PokemonBattlerList = ({ title, encounters, disabledImport, from }: 
       <PokemonBattlerListHeader>
         <div className="header">
           <div className="title">{title}</div>
-          {!!totalEncounterChance && <Tag className="chance">{`${totalEncounterChance}%`}</Tag>}
+          {totalEncounterChance > 0 && <Tag className="chance">{`${totalEncounterChance}%`}</Tag>}
         </div>
         <div className="header">
           <div className="button-import-full">

--- a/src/views/components/pokemonBattler/PokemonBattlerList.tsx
+++ b/src/views/components/pokemonBattler/PokemonBattlerList.tsx
@@ -107,7 +107,7 @@ export const PokemonBattlerList = ({ title, encounters, disabledImport, from }: 
       <PokemonBattlerListHeader>
         <div className="header">
           <div className="title">{title}</div>
-          {totalEncounterChance > 0 && <Tag className="chance">{`${totalEncounterChance}%`}</Tag>}
+          {totalEncounterChance > 0 && from === 'group' && <Tag className="chance">{`${totalEncounterChance}%`}</Tag>}
         </div>
         <div className="header">
           <div className="button-import-full">


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

I would like to know the sum of the encounter percentages of wild Pokémon in a group
So that I don't have to manually calculate it

## Tests to perform
When no pokemon is present, tag should not be displayed
When some creatures are present, make sure tag is displayed

https://github.com/PokemonWorkshop/PokemonStudio/issues/218