### PR TITLE
Typing in an input should not trigger the CTRL LEFT / RIGHT shortcuts

### DIFF
--- a/src/views/components/textmanagement/TextControlBar.tsx
+++ b/src/views/components/textmanagement/TextControlBar.tsx
@@ -31,7 +31,14 @@ export const TextControlBar = ({ dialogsRef }: TextControlBarProps) => {
   // Definition of the control bar shortcuts
   const shortcutMap = useMemo<StudioShortcutActions>(() => {
     // No shortcut if an editor is opened
-    const isShortcutEnabled = () => dialogsRef?.current?.currentDialog === undefined;
+    const isShortcutEnabled = () => {
+      const activeElement = document.activeElement;
+      if (activeElement && activeElement.tagName === 'INPUT') return false;
+      if (dialogsRef?.current?.currentDialog !== undefined) return false;
+
+      return true;
+    };
+
     return {
       db_previous: () => isShortcutEnabled() && setSelectedDataIdentifier({ textInfo: getPreviousFileId() }),
       db_next: () => isShortcutEnabled() && setSelectedDataIdentifier({ textInfo: getNextFileId() }),

--- a/src/views/components/textmanagement/TextControlBar.tsx
+++ b/src/views/components/textmanagement/TextControlBar.tsx
@@ -33,7 +33,7 @@ export const TextControlBar = ({ dialogsRef }: TextControlBarProps) => {
     // No shortcut if an editor is opened
     const isShortcutEnabled = () => {
       const activeElement = document.activeElement;
-      if (activeElement && activeElement.tagName === 'INPUT') return false;
+      if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) return false;
       if (dialogsRef?.current?.currentDialog !== undefined) return false;
 
       return true;


### PR DESCRIPTION
## Description

If you're in an input, whether it's a search or an input to modify text, you won't be able to use shortcuts.

## Tests to perform

- Put yourself in the text change input, make a shortcut, it won't happen
- Put yourself in the research input, make a shortcut, it won't happen
- Be on the page, make a shortcut, it will happen
