### PR TITLE
Select research should work even if there are accents

### DIFF
--- a/src/designSystem/Select/useSelect.ts
+++ b/src/designSystem/Select/useSelect.ts
@@ -12,6 +12,7 @@ import {
 import { RenderOptionRef, SelectOption } from './types';
 import { getNotFoundExclusionPattern, getSelectDefaultLabel, positionAndShowPopover } from './utils';
 import type { List } from 'react-virtualized/dist/es/List';
+import { normalize } from '@utils/normalize';
 
 export type SelectProps<Value extends string, ChooseValue extends string> = {
   options: Readonly<SelectOption<Value>[]>;
@@ -129,8 +130,8 @@ export const useSelect = <Value extends string, ChooseValue extends string>({
   const onInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     if (disabled) return;
 
-    const value = event.currentTarget.value.toLowerCase();
-    const newOptions = options.filter((o) => o.value.toLowerCase().includes(value) || o.label.toLowerCase().includes(value));
+    const value = normalize(event.currentTarget.value);
+    const newOptions = options.filter((o) => normalize(o.value).includes(value) || normalize(o.label).includes(value));
     optionsUtilsRef.current?.refine(newOptions);
   };
 

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,0 +1,6 @@
+export const normalize = (str: string) => {
+  return str
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+};

--- a/src/views/components/StudioDropDown.tsx
+++ b/src/views/components/StudioDropDown.tsx
@@ -165,9 +165,9 @@ const applyFilter = (options: DropDownOption[], filter?: StudioDropDownFilter) =
 const research = (options: DropDownOption[], entry: string) => {
   if (!entry) return options;
 
-  const entryLowerCase = entry.toLowerCase();
+  const entryLowerCase = normalize(entry.toLowerCase());
   return options.filter(
-    (option) => normalize(option.value).indexOf(entry) !== -1 || normalize(option.label).toLowerCase().indexOf(entryLowerCase) !== -1
+    (option) => normalize(option.value).indexOf(normalize(entry)) !== -1 || normalize(option.label).toLowerCase().indexOf(entryLowerCase) !== -1
   );
 };
 

--- a/src/views/components/StudioDropDown.tsx
+++ b/src/views/components/StudioDropDown.tsx
@@ -4,6 +4,7 @@ import { AutoSizer, List } from 'react-virtualized';
 import { ReactComponent as DownIcon } from '@assets/icons/global/down-icon.svg';
 import { Input } from './inputs';
 import { useTranslation } from 'react-i18next';
+import { normalize } from '@utils/normalize';
 
 export type StudioDropDownFilter = (value: string) => boolean;
 type DropDownOptionsProps = {
@@ -165,7 +166,9 @@ const research = (options: DropDownOption[], entry: string) => {
   if (!entry) return options;
 
   const entryLowerCase = entry.toLowerCase();
-  return options.filter((option) => option.value.indexOf(entry) !== -1 || option.label.toLowerCase().indexOf(entryLowerCase) !== -1);
+  return options.filter(
+    (option) => normalize(option.value).indexOf(entry) !== -1 || normalize(option.label).toLowerCase().indexOf(entryLowerCase) !== -1
+  );
 };
 
 const getHeight = (options: DropDownOption[], isOpen: boolean) => {

--- a/src/views/components/StudioDropDown.tsx
+++ b/src/views/components/StudioDropDown.tsx
@@ -164,10 +164,8 @@ const applyFilter = (options: DropDownOption[], filter?: StudioDropDownFilter) =
 
 const research = (options: DropDownOption[], entry: string) => {
   if (!entry) return options;
-
-  const entryLowerCase = normalize(entry.toLowerCase());
   return options.filter(
-    (option) => normalize(option.value).indexOf(normalize(entry)) !== -1 || normalize(option.label).toLowerCase().indexOf(entryLowerCase) !== -1
+    (option) => normalize(option.value).indexOf(normalize(entry)) !== -1 || normalize(option.label).toLowerCase().indexOf(normalize(entry)) !== -1
   );
 };
 


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [ x] Your code builds clean without any errors or warnings
- [ x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x ] You tested your code to make sure it does what it is supposed to do

## Description

Ne pas rendre obligatoire les accents dans les selects par exemple pour chercher pokédex -> on devait taper le "é" alors que pokedex devrait marché.

## Tests to perform

Les selects de controlbar pour la section base de donnée par exemple. Malgré les différents select j'ai remarqué que seulement le composant StudioDropDown avait ce bug.