### PR TITLE
Update the PSDK binaries link to the GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ The PSDK binaries are important, they let Studio start PSDK projects and perform
 
 To install them follow those steps:
 
-1. Download the binary archive from
-
-- https://download.psdk.pokemonworkshop.com/binaries/ (Windows, Linux & MacOS M1+)
+1. Download the [Pokémon SDK binary archive](https://github.com/PokemonWorkshop/PokemonSDKBinaries/releases) (Windows, Linux & MacOS M1+).
 
 2. Extract the content of the archive to the psdk-binaries folder.
 


### PR DESCRIPTION
## Description
This MR update the PSDK binaries link to point the GitHub repository one.
Close #331.

## Tests to perform
- [x] Test the PSDK Binaries link in the [README](https://github.com/PokemonWorkshop/PokemonStudio/tree/update-the-psdk-binaries-link?tab=readme-ov-file#get-the-psdk-binaries) (first point) to check if it's working properly.
