### PR TITLE
Update to Tiled Opening Method

### DIFF
--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -40,12 +40,9 @@ const openTiled = async (payload: OpenTiledPayload) => {
     const linuxMapFilename = path.basename(mapFilename);
     const defaultDir = process.cwd();
     process.chdir(path.dirname(mapFilename));
-    if (payload.tiledPath.endsWith('AppImage') && linuxMapFilename.indexOf(' ') !== -1) {
-      throw new Error("Tiled's AppImage doesn't support spaces in map names.");
-    }
     try {
       await executeCommand(payload.tiledPath, [linuxMapFilename]);
-    } catch (error: unknown) {
+    } catch (error) {
       log.error(error);
     }
     process.chdir(defaultDir);

--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -18,11 +18,11 @@ const openTiled = async (payload: OpenTiledPayload) => {
       const child = spawn(command, args || [], { detached: true });
 
       child.stdout.on('data', (data) => {
-        log.info(`stdout: ${data}`);
+        log.info(`[Tiled] ${data}`);
       });
 
       child.stderr.on('data', (data) => {
-        log.error(`stderr: ${data}`);
+        log.error(`[Tiled] ${data}`);
       });
 
       child.on('error', (error) => {

--- a/src/backendTasks/openTiled.ts
+++ b/src/backendTasks/openTiled.ts
@@ -1,7 +1,6 @@
 import log from 'electron-log';
-import { execFile } from 'child_process';
+import { spawn } from 'child_process';
 import path from 'path';
-import util from 'util';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 
 export type OpenTiledPayload = {
@@ -13,8 +12,30 @@ export type OpenTiledPayload = {
 const openTiled = async (payload: OpenTiledPayload) => {
   log.info('open-tiled', payload);
   const mapFilename = path.join(payload.projectPath, 'Data', 'Tiled', 'Maps', payload.tiledMapFilename + '.tmx');
+
+  const executeCommand = (command: string, args?: readonly string[]) => {
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn(command, args || [], { detached: true });
+
+      child.stdout.on('data', (data) => {
+        log.info(`stdout: ${data}`);
+      });
+
+      child.stderr.on('data', (data) => {
+        log.error(`stderr: ${data}`);
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+
+      child.unref();
+      resolve();
+    });
+  };
+
   if (process.platform === 'darwin') {
-    await util.promisify(execFile)('open', [payload.tiledPath, mapFilename]);
+    await executeCommand('open', [payload.tiledPath, mapFilename]);
   } else if (process.platform === 'linux') {
     const linuxMapFilename = path.basename(mapFilename);
     const defaultDir = process.cwd();
@@ -22,11 +43,14 @@ const openTiled = async (payload: OpenTiledPayload) => {
     if (payload.tiledPath.endsWith('AppImage') && linuxMapFilename.indexOf(' ') !== -1) {
       throw new Error("Tiled's AppImage doesn't support spaces in map names.");
     }
-    const result = await util.promisify(execFile)(payload.tiledPath, [`"${linuxMapFilename}"`]);
-    if (result.stderr) log.error(result.stderr);
+    try {
+      await executeCommand(payload.tiledPath, [linuxMapFilename]);
+    } catch (error: unknown) {
+      log.error(error);
+    }
     process.chdir(defaultDir);
   } else {
-    await util.promisify(execFile)(payload.tiledPath, [mapFilename]);
+    await executeCommand(payload.tiledPath, [mapFilename]);
   }
   return {};
 };


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

This update ensures that the Tiled process is now independent of the Studio process. As a result, if Studio is closed, the Tiled window will no longer close and will remain active. Here are the key changes:

- **Detached Tiled process**: The Tiled process now runs independently from Studio, allowing Tiled to remain active even if Studio is closed.
- **Tiled can open the maps (tmx files) with spaces in the filename with the AppImage**: the last version of Tiled (1.11) has fixed a bug with the AppImage that prevented a map from being opened if there was a space in the filename. Only for Linux.

## Tests Performed

The following tests were conducted to ensure the new functionality works as expected:

1. **Launching Tiled**:
   - Tiled was successfully launched from Studio.
   - Verified that closing Studio does not close the Tiled window.
   - Confirmed that both processes (Studio and Tiled) are now independent.
2. **A map (tmx file) opens correctly with AppImage if there is a space in the filename** (only for Linux)

All tests confirmed that the changes work as intended, ensuring the independence of the Studio and Tiled processes.
