### PR TITLE
Add the custom creature form names and descriptions

### DIFF
--- a/assets/i18n/en/database_pokemon.json
+++ b/assets/i18n/en/database_pokemon.json
@@ -221,5 +221,9 @@
   "icons": "Icons",
   "show_female_sprites": "Show different sprites for females",
   "offset": "Sprite offset",
-  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift."
+  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift.",
+  "form_name": "Form name",
+  "example_form_name": "Unown A",
+  "form_description": "Form description",
+  "use_default_description": "Use the default description"
 }

--- a/assets/i18n/en/database_pokemon.json
+++ b/assets/i18n/en/database_pokemon.json
@@ -221,5 +221,6 @@
   "icons": "Icons",
   "show_female_sprites": "Show different sprites for females",
   "offset": "Sprite offset",
-  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift."
+  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift.",
+  "basic_form": "Basic form"
 }

--- a/assets/i18n/en/database_pokemon.json
+++ b/assets/i18n/en/database_pokemon.json
@@ -221,6 +221,5 @@
   "icons": "Icons",
   "show_female_sprites": "Show different sprites for females",
   "offset": "Sprite offset",
-  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift.",
-  "basic_form": "Basic form"
+  "offset_info": "The offset is expressed in pixels. A positive value suggests a downward shift."
 }

--- a/assets/i18n/en/editor.json
+++ b/assets/i18n/en/editor.json
@@ -19,5 +19,7 @@
   "translation_class": "Class of {{name}}",
   "translation_victory": "Victory of {{name}}",
   "translation_defeat": "Defeat of {{name}}",
-  "translation_name_plural": "Plural name of {{name}}"
+  "translation_name_plural": "Plural name of {{name}}",
+  "translation_form_name": "Form name of {{name}}",
+  "translation_form_description": "Form description of {{name}}"
 }

--- a/assets/i18n/fr/database_pokemon.json
+++ b/assets/i18n/fr/database_pokemon.json
@@ -221,6 +221,5 @@
   "icons": "Icônes",
   "show_female_sprites": "Afficher des sprites différents pour les femelles",
   "offset": "Décalage du sprite",
-  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas.",
-  "basic_form": "Forme de base"
+  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas."
 }

--- a/assets/i18n/fr/database_pokemon.json
+++ b/assets/i18n/fr/database_pokemon.json
@@ -221,5 +221,6 @@
   "icons": "Icônes",
   "show_female_sprites": "Afficher des sprites différents pour les femelles",
   "offset": "Décalage du sprite",
-  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas."
+  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas.",
+  "basic_form": "Forme de base"
 }

--- a/assets/i18n/fr/database_pokemon.json
+++ b/assets/i18n/fr/database_pokemon.json
@@ -221,5 +221,9 @@
   "icons": "Icônes",
   "show_female_sprites": "Afficher des sprites différents pour les femelles",
   "offset": "Décalage du sprite",
-  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas."
+  "offset_info": "Le décalage est exprimé en pixels. Une valeur positive suggère un décalage vers le bas.",
+  "form_name": "Nom de la forme",
+  "example_form_name": "Zarbi A",
+  "form_description": "Description de la forme",
+  "use_default_description": "Utiliser la description par défaut"
 }

--- a/assets/i18n/fr/editor.json
+++ b/assets/i18n/fr/editor.json
@@ -19,5 +19,7 @@
   "translation_class": "Classe de {{name}}",
   "translation_victory": "Victoire de {{name}}",
   "translation_defeat": "Défaite de {{name}}",
-  "translation_name_plural": "Nom au pluriel de {{name}}"
+  "translation_name_plural": "Nom au pluriel de {{name}}",
+  "translation_form_name": "Nom de la forme de {{name}}",
+  "translation_form_description": "Description de la forme de {{name}}"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-studio",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-studio",
-      "version": "2.2.4",
+      "version": "2.3.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@electron-forge/publisher-github": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/backendTasks/migrateData.ts
+++ b/src/backendTasks/migrateData.ts
@@ -11,33 +11,36 @@ import { migrateMapLinks } from '@src/migrations/migrateMapLinks';
 import { migrationV2 } from '@src/migrations/migrationV2';
 import { migrationPreV2 } from '@src/migrations/migrationPreV2';
 import { migrationPreV2_1 } from '@src/migrations/migrationPreV2_1';
-import { addOtherLanguages } from '@src/migrations/addOtherLanguages';
 import { fixCreatureValuesAfterZodChange } from '@src/migrations/fixCreatureValuesAfterZodChange';
+import { addFormNamesDescriptions } from '@src/migrations/addFormNamesDescriptions';
+import { migrationPreV2_3 } from '@src/migrations/migrationPreV2_3';
 
 export type MigrationTask = (event: IpcMainEvent, projectPath: string, studioSettings?: StudioSettings) => Promise<void>;
 
 // Don't forget to extend those array with the new tasks that gets added by the time!
 const MIGRATIONS: Record<string, MigrationTask[]> = {
-  '1.0.0': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.0.1': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.0.2': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.1.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.1.1': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.2.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.3.0': [migrationPreV2, migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.4.0': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.4.1': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.4.2': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.4.3': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '1.4.4': [migrationV2, migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.0.0': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.0.1': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.0.2': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.0.3': [migrationPreV2_1, addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.1.0': [addOtherLanguages, fixCreatureValuesAfterZodChange],
-  '2.2.0': [fixCreatureValuesAfterZodChange],
-  '2.2.1': [fixCreatureValuesAfterZodChange],
-  '2.2.2': [fixCreatureValuesAfterZodChange], // Don't forget to add the official version coming up
+  '1.0.0': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.0.1': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.0.2': [migrateMapLinks, migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.1.0': [migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.1.1': [migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.2.0': [migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.3.0': [migrationPreV2, migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.4.0': [migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.4.1': [migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.4.2': [migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.4.3': [migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '1.4.4': [migrationV2, migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '2.0.0': [migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '2.0.1': [migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '2.0.2': [migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '2.0.3': [migrationPreV2_1, migrationPreV2_3, addFormNamesDescriptions],
+  '2.1.0': [migrationPreV2_3, addFormNamesDescriptions],
+  '2.2.0': [fixCreatureValuesAfterZodChange, addFormNamesDescriptions],
+  '2.2.1': [fixCreatureValuesAfterZodChange, addFormNamesDescriptions],
+  '2.2.2': [fixCreatureValuesAfterZodChange, addFormNamesDescriptions],
+  '2.2.3': [addFormNamesDescriptions],
+  '2.2.4': [addFormNamesDescriptions], // Don't forget to add the official version coming up
 };
 
 // Don't forget to extend those array with the new tasks that gets added by the time!
@@ -53,6 +56,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.0.1': [
     'Migrate MapLinks',
@@ -65,6 +69,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.0.2': [
     'Migrate MapLinks',
@@ -77,6 +82,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.1.0': [
     'Link the resources to the Pokémon',
@@ -88,6 +94,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.1.1': [
     'Link the resources to the Pokémon',
@@ -99,6 +106,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.2.0': [
     'Link the resources to the Pokémon',
@@ -110,6 +118,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.3.0': [
     'Link the resources to the Pokémon',
@@ -121,6 +130,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.4.0': [
     'Migration to version 2.0',
@@ -129,6 +139,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.4.1': [
     'Migration to version 2.0',
@@ -137,6 +148,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.4.2': [
     'Migration to version 2.0',
@@ -145,6 +157,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.4.3': [
     'Migration to version 2.0',
@@ -153,6 +166,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '1.4.4': [
     'Migration to version 2.0',
@@ -161,6 +175,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '2.0.0': [
     'Add available languages for translation',
@@ -168,6 +183,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '2.0.1': [
     'Add available languages for translation',
@@ -175,6 +191,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '2.0.2': [
     'Add available languages for translation',
@@ -182,6 +199,7 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
   '2.0.3': [
     'Add available languages for translation',
@@ -189,11 +207,27 @@ const MIGRATION_STEP_TEXTS: Record<string, string[]> = {
     'Generating map overviews',
     'Add basic languages',
     'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
   ],
-  '2.1.0': ['Add basic languages', 'Update creatures values after change in the values authorized'],
-  '2.2.0': ['Update creatures values after change in the values authorized'],
-  '2.2.1': ['Update creatures values after change in the values authorized'],
-  '2.2.2': ['Update creatures values after change in the values authorized'], // Don't forget to add the official version coming up
+  '2.1.0': [
+    'Add basic languages',
+    'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
+  ],
+  '2.2.0': [
+    'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
+  ],
+  '2.2.1': [
+    'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
+  ],
+  '2.2.2': [
+    'Update creatures values after change in the values authorized',
+    'Update creatures and create CSV files to manage form names and descriptions',
+  ],
+  '2.2.3': ['Update creatures and create CSV files to manage form names and descriptions'],
+  '2.2.4': ['Update creatures and create CSV files to manage form names and descriptions'], // Don't forget to add the official version coming up
 };
 
 export type MigrateDataInput = { projectPath: string; projectVersion: string; studioSettings: StudioSettings };

--- a/src/migrations/addFormNamesDescriptions.ts
+++ b/src/migrations/addFormNamesDescriptions.ts
@@ -47,12 +47,15 @@ const initCSVForm = (creatureTexts: string[][], csvPath: string, csvTextId: numb
   return formTexts;
 };
 
-const updateCSVFormTexts = (creatureTexts: string[][], formTexts: string[][], creature: StudioCreature) => {
+const updateCSVFormTexts = (creatureTexts: string[][], formTexts: string[][], creature: StudioCreature, type: 'name' | 'description') => {
   const id = creature.id;
   const texts = creatureTexts[id + 1];
-  for (let i = 0; i < creature.forms.length - 1; i++) {
-    formTexts.push(texts);
-  }
+  creature.forms.forEach((form) => {
+    if (form.form === 0) return;
+
+    if (type === 'name') return formTexts.push(texts.map((text) => `${text} (${form.form})`));
+    return formTexts.push(texts);
+  });
 };
 
 export const addFormNamesDescriptions = async (_: IpcMainEvent, projectPath: string) => {
@@ -70,8 +73,8 @@ export const addFormNamesDescriptions = async (_: IpcMainEvent, projectPath: str
     const creatureParsed = PRE_MIGRATION_CREATURE_VALIDATOR.safeParse(parseJSON<StudioCreature>(creature.data, creature.filename));
     if (creatureParsed.success) {
       const newCreature = addTextId(creatureParsed.data);
-      updateCSVFormTexts(creatureNames, formNames, newCreature);
-      updateCSVFormTexts(creatureDescriptions, formDescriptions, newCreature);
+      updateCSVFormTexts(creatureNames, formNames, newCreature, 'name');
+      updateCSVFormTexts(creatureDescriptions, formDescriptions, newCreature, 'description');
 
       return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/pokemon', `${newCreature.dbSymbol}.json`), JSON.stringify(newCreature, null, 2));
     }

--- a/src/migrations/addFormNamesDescriptions.ts
+++ b/src/migrations/addFormNamesDescriptions.ts
@@ -57,8 +57,7 @@ const updateCSVFormTexts = (creatureTexts: string[][], formTexts: string[][], cr
   creature.forms.forEach((form) => {
     if (form.form === 0 && type === 'description') return;
 
-    if (type === 'name') return formTexts.push(texts.map((text) => `${text} (${form.form})`));
-    return formTexts.push(texts);
+    formTexts.push(texts);
   });
 };
 

--- a/src/migrations/fixCreatureValuesAfterZodChange.ts
+++ b/src/migrations/fixCreatureValuesAfterZodChange.ts
@@ -12,7 +12,7 @@ import { cloneEntity } from '@utils/cloneEntity';
 
 const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({
   forms: z
-    .array(CREATURE_FORM_VALIDATOR.extend({ height: POSITIVE_OR_ZERO_FLOAT, weight: POSITIVE_OR_ZERO_FLOAT }).omit({ textId: true }))
+    .array(CREATURE_FORM_VALIDATOR.extend({ height: POSITIVE_OR_ZERO_FLOAT, weight: POSITIVE_OR_ZERO_FLOAT }).omit({ formTextId: true }))
     .nonempty(),
 });
 type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;

--- a/src/migrations/fixCreatureValuesAfterZodChange.ts
+++ b/src/migrations/fixCreatureValuesAfterZodChange.ts
@@ -11,7 +11,9 @@ import { DbSymbol } from '@modelEntities/dbSymbol';
 import { cloneEntity } from '@utils/cloneEntity';
 
 const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({
-  forms: z.array(CREATURE_FORM_VALIDATOR.extend({ height: POSITIVE_OR_ZERO_FLOAT, weight: POSITIVE_OR_ZERO_FLOAT })).nonempty(),
+  forms: z
+    .array(CREATURE_FORM_VALIDATOR.extend({ height: POSITIVE_OR_ZERO_FLOAT, weight: POSITIVE_OR_ZERO_FLOAT }).omit({ textId: true }))
+    .nonempty(),
 });
 type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;
 

--- a/src/migrations/linkResourcesToCreatures.ts
+++ b/src/migrations/linkResourcesToCreatures.ts
@@ -16,7 +16,7 @@ import { deletePSDKDatFile } from './migrateUtils';
 import { parseJSON } from '@utils/json/parse';
 
 const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({
-  forms: z.array(CREATURE_FORM_VALIDATOR.omit({ resources: true })).nonempty(),
+  forms: z.array(CREATURE_FORM_VALIDATOR.omit({ resources: true, textId: true })).nonempty(),
 });
 type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;
 type ComputedCreatureResources = Partial<Omit<Exclude<StudioCreatureResources, { hasFemale: false }>, 'hasFemale'>>;

--- a/src/migrations/migrationPreV2_3.ts
+++ b/src/migrations/migrationPreV2_3.ts
@@ -1,0 +1,12 @@
+import { IpcMainEvent } from 'electron';
+import { addOtherLanguages } from './addOtherLanguages';
+import { fixCreatureValuesAfterZodChange } from './fixCreatureValuesAfterZodChange';
+
+const MIGRATION_PRE_V2_3 = [addOtherLanguages, fixCreatureValuesAfterZodChange];
+
+export const migrationPreV2_3 = async (event: IpcMainEvent, projectPath: string) => {
+  await MIGRATION_PRE_V2_3.reduce(async (prev, curr) => {
+    await prev;
+    await curr(event, projectPath);
+  }, Promise.resolve());
+};

--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -101,6 +101,7 @@ export type StudioCreatureResources = z.infer<typeof CREATURE_RESOURCES_VALIDATO
 
 export const CREATURE_FORM_VALIDATOR = z.object({
   form: POSITIVE_OR_ZERO_INT,
+  textId: POSITIVE_OR_ZERO_INT,
   height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(999.99).step(0.01),
   weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(9999.99).step(0.01),
   type1: DB_SYMBOL_VALIDATOR,
@@ -146,3 +147,5 @@ export type StudioCreature = z.infer<typeof CREATURE_VALIDATOR>;
 export const CREATURE_DESCRIPTION_TEXT_ID = 100002;
 export const CREATURE_NAME_TEXT_ID = 100000;
 export const CREATURE_SPECIE_TEXT_ID = 100001;
+export const CREATURE_FORM_NAME_TEXT_ID = 100066;
+export const CREATURE_FORM_DESCRIPTION_TEXT_ID = 100067;

--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -101,7 +101,10 @@ export type StudioCreatureResources = z.infer<typeof CREATURE_RESOURCES_VALIDATO
 
 export const CREATURE_FORM_VALIDATOR = z.object({
   form: POSITIVE_OR_ZERO_INT,
-  textId: POSITIVE_OR_ZERO_INT,
+  formTextId: z.object({
+    name: POSITIVE_OR_ZERO_INT,
+    description: POSITIVE_OR_ZERO_INT,
+  }),
   height: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(999.99).step(0.01),
   weight: POSITIVE_OR_ZERO_FLOAT.min(0.01).max(9999.99).step(0.01),
   type1: DB_SYMBOL_VALIDATOR,

--- a/src/utils/ModelUtils.ts
+++ b/src/utils/ModelUtils.ts
@@ -54,3 +54,25 @@ export const findFirstAndSecondAvailableId = (allData: Record<string, { id: numb
   const secondId = findFirstAvailableId(newAllData, startId, excludeIds);
   return { firstId, secondId };
 };
+
+export const findFirstAvailableFormTextId = (allPokemon: ProjectData['pokemon'], startId: number, type: 'name' | 'description') => {
+  const pokemon = Object.values(allPokemon);
+  if (pokemon.length === 0) return startId;
+
+  // Fetch all form text ids
+  const fetchValues = pokemon.reduce<number[]>((prev, current) => {
+    prev.push(...current.forms.map(({ formTextId }) => (type === 'name' ? formTextId.name : formTextId.description)));
+    return prev;
+  }, []);
+
+  const textIdSet = fetchValues
+    .filter((textId, index, array) => index === array.indexOf(textId)) // reject all duplicates
+    .sort((a, b) => a - b); // sort id by ascending order
+  // Since ids are ordered, if the first isn't the startId that means we need to fill the beginning of the list ;)
+  if (textIdSet[0] > startId) return startId;
+
+  const holeIndex = textIdSet.findIndex((textId, index) => textId !== index + startId);
+  if (holeIndex === -1) return textIdSet[textIdSet.length - 1] + 1;
+
+  return textIdSet[holeIndex - 1] + 1;
+};

--- a/src/utils/ReadingProjectText.ts
+++ b/src/utils/ReadingProjectText.ts
@@ -22,7 +22,6 @@ import { SavingTextMap } from './SavingUtils';
 import { MAP_DESCRIPTION_TEXT_ID, MAP_NAME_TEXT_ID } from '@modelEntities/map';
 import { MAP_INFO_FOLDER_NAME_TEXT_ID } from '@modelEntities/mapInfo';
 import { cloneEntity } from './cloneEntity';
-import { useTranslation } from 'react-i18next';
 
 type KeyProjectText = keyof ProjectText;
 

--- a/src/utils/ReadingProjectText.ts
+++ b/src/utils/ReadingProjectText.ts
@@ -1,5 +1,11 @@
 import { ABILITY_DESCRIPTION_TEXT_ID, ABILITY_NAME_TEXT_ID } from '@modelEntities/ability';
-import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_NAME_TEXT_ID } from '@modelEntities/creature';
+import {
+  CREATURE_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_NAME_TEXT_ID,
+  CREATURE_NAME_TEXT_ID,
+  StudioCreatureForm,
+} from '@modelEntities/creature';
 import { StudioDex } from '@modelEntities/dex';
 import { GROUP_NAME_TEXT_ID } from '@modelEntities/group';
 import { ITEM_DESCRIPTION_TEXT_ID, ITEM_NAME_TEXT_ID, ITEM_PLURAL_NAME_TEXT_ID, ITEM_POCKET_NAME_TEXT_ID, StudioItem } from '@modelEntities/item';
@@ -376,4 +382,16 @@ export const useCopyProjectText = () => {
       return newState;
     });
   };
+};
+
+export const useGetCreatureFormNameText = () => {
+  const getEntityText = useGetProjectText();
+
+  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_NAME_TEXT_ID, form.textId);
+};
+
+export const useGetCreatureFormDescriptionText = () => {
+  const getEntityText = useGetProjectText();
+
+  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.textId);
 };

--- a/src/utils/ReadingProjectText.ts
+++ b/src/utils/ReadingProjectText.ts
@@ -386,18 +386,13 @@ export const useCopyProjectText = () => {
 };
 
 export const useGetCreatureFormNameText = () => {
-  const { t } = useTranslation('database_pokemon');
   const getEntityText = useGetProjectText();
 
-  return (form: StudioCreatureForm) => {
-    if (form.form === 0) return t('basic_form');
-
-    return getEntityText(CREATURE_FORM_NAME_TEXT_ID, form.textId);
-  };
+  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_NAME_TEXT_ID, form.formTextId.name);
 };
 
 export const useGetCreatureFormDescriptionText = () => {
   const getEntityText = useGetProjectText();
 
-  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.textId);
+  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.formTextId.description);
 };

--- a/src/utils/ReadingProjectText.ts
+++ b/src/utils/ReadingProjectText.ts
@@ -22,6 +22,7 @@ import { SavingTextMap } from './SavingUtils';
 import { MAP_DESCRIPTION_TEXT_ID, MAP_NAME_TEXT_ID } from '@modelEntities/map';
 import { MAP_INFO_FOLDER_NAME_TEXT_ID } from '@modelEntities/mapInfo';
 import { cloneEntity } from './cloneEntity';
+import { useTranslation } from 'react-i18next';
 
 type KeyProjectText = keyof ProjectText;
 
@@ -385,9 +386,14 @@ export const useCopyProjectText = () => {
 };
 
 export const useGetCreatureFormNameText = () => {
+  const { t } = useTranslation('database_pokemon');
   const getEntityText = useGetProjectText();
 
-  return (form: StudioCreatureForm) => getEntityText(CREATURE_FORM_NAME_TEXT_ID, form.textId);
+  return (form: StudioCreatureForm) => {
+    if (form.form === 0) return t('basic_form');
+
+    return getEntityText(CREATURE_FORM_NAME_TEXT_ID, form.textId);
+  };
 };
 
 export const useGetCreatureFormDescriptionText = () => {

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -83,7 +83,6 @@ export const createDex = (allDex: ProjectData['dex'], dbSymbol: DbSymbol, startI
 export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbSymbol, type1: DbSymbol, type2: DbSymbol): StudioCreature => {
   const id = findFirstAvailableId(allPokemon, 1);
   const formTextIdName = findFirstAvailableFormTextId(allPokemon, 0, 'name');
-  const formTextIdDescription = findFirstAvailableFormTextId(allPokemon, 0, 'description');
   return {
     klass: 'Specie',
     id,
@@ -93,7 +92,7 @@ export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbS
         form: 0,
         formTextId: {
           name: formTextIdName,
-          description: formTextIdDescription,
+          description: 0,
         },
         height: 0.01,
         weight: 0.01,

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -1,5 +1,5 @@
 import { StudioAbility } from '@modelEntities/ability';
-import { StudioCreature } from '@modelEntities/creature';
+import { StudioCreature, StudioCreatureForm } from '@modelEntities/creature';
 import { DbSymbol } from '@modelEntities/dbSymbol';
 import { DEX_DEFAULT_NAME_TEXT_ID, StudioDex, StudioDexCreature } from '@modelEntities/dex';
 import { StudioCustomGroupCondition, StudioGroup, StudioGroupSystemTag, StudioGroupTool } from '@modelEntities/group';
@@ -28,6 +28,7 @@ import { StudioTextInfo } from '@modelEntities/textInfo';
 import { StudioMap, StudioMapAudio } from '@modelEntities/map';
 import { StudioMapInfo, StudioMapInfoMap } from '@modelEntities/mapInfo';
 import { mapInfoFindFirstAvailableId, mapInfoFindFirstAvailableTextId } from './MapInfoUtils';
+import { cloneEntity } from './cloneEntity';
 
 /**
  * Create a new ability with default values
@@ -149,6 +150,20 @@ export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbS
       },
     ],
   };
+};
+
+/**
+ * Create a creature form
+ */
+export const createCreatureForm = (
+  allPokemon: ProjectData['pokemon'],
+  form: StudioCreatureForm,
+  types: { type1: DbSymbol; type2: DbSymbol },
+  newFormId: number
+) => {
+  const formTextIdName = findFirstAvailableFormTextId(allPokemon, 0, 'name');
+  const formTextIdDescription = findFirstAvailableFormTextId(allPokemon, 0, 'description');
+  return cloneEntity({ ...form, ...types, form: newFormId, formTextId: { name: formTextIdName, description: formTextIdDescription } });
 };
 
 /**

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -22,7 +22,7 @@ import { StudioType } from '@modelEntities/type';
 import { StudioZone } from '@modelEntities/zone';
 import { ProjectData } from '@src/GlobalStateProvider';
 import { assertUnreachable } from './assertUnreachable';
-import { findFirstAvailableId, findFirstAvailableTextId } from './ModelUtils';
+import { findFirstAvailableFormTextId, findFirstAvailableId, findFirstAvailableTextId } from './ModelUtils';
 import { padStr } from './PadStr';
 import { StudioTextInfo } from '@modelEntities/textInfo';
 import { StudioMap, StudioMapAudio } from '@modelEntities/map';
@@ -81,6 +81,8 @@ export const createDex = (allDex: ProjectData['dex'], dbSymbol: DbSymbol, startI
  */
 export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbSymbol, type1: DbSymbol, type2: DbSymbol): StudioCreature => {
   const id = findFirstAvailableId(allPokemon, 1);
+  const formTextIdName = findFirstAvailableFormTextId(allPokemon, 0, 'name');
+  const formTextIdDescription = findFirstAvailableFormTextId(allPokemon, 0, 'description');
   return {
     klass: 'Specie',
     id,
@@ -88,6 +90,10 @@ export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbS
     forms: [
       {
         form: 0,
+        formTextId: {
+          name: formTextIdName,
+          description: formTextIdDescription,
+        },
         height: 0.01,
         weight: 0.01,
         type1,

--- a/src/views/components/database/pokemon/PokemonFrame.tsx
+++ b/src/views/components/database/pokemon/PokemonFrame.tsx
@@ -5,7 +5,7 @@ import { useGlobalState } from '@src/GlobalStateProvider';
 import { getNameType } from '@utils/getNameType';
 import { padStr } from '@utils/PadStr';
 import { pokemonSpritePath } from '@utils/path';
-import { useGetEntityDescriptionText, useGetEntityNameText } from '@utils/ReadingProjectText';
+import { useGetEntityDescriptionText, useGetEntityNameText, useGetCreatureFormDescriptionText } from '@utils/ReadingProjectText';
 import React from 'react';
 import {
   DataBlockContainer,
@@ -23,6 +23,7 @@ export const PokemonFrame = ({ pokemonWithForm, dialogsRef }: PokemonDataProps) 
   const [state] = useGlobalState();
   const getCreatureName = useGetEntityNameText();
   const getCreatureDescription = useGetEntityDescriptionText();
+  const getCreatureFormDescription = useGetCreatureFormDescriptionText();
   const types = state.projectData.types;
 
   return (
@@ -45,7 +46,7 @@ export const PokemonFrame = ({ pokemonWithForm, dialogsRef }: PokemonDataProps) 
               {form.type2 !== '__undef__' && <TypeCategory type={form.type2}>{getNameType(types, form.type2, state)}</TypeCategory>}
             </DataInfoContainerHeaderBadges>
           </DataInfoContainerHeader>
-          <p>{getCreatureDescription(species)}</p>
+          <p>{form.form === 0 ? getCreatureDescription(species) : getCreatureFormDescription(form)}</p>
         </DataInfoContainer>
       </DataGrid>
     </DataBlockContainer>

--- a/src/views/components/database/pokemon/PokemonFrame.tsx
+++ b/src/views/components/database/pokemon/PokemonFrame.tsx
@@ -5,7 +5,12 @@ import { useGlobalState } from '@src/GlobalStateProvider';
 import { getNameType } from '@utils/getNameType';
 import { padStr } from '@utils/PadStr';
 import { pokemonSpritePath } from '@utils/path';
-import { useGetEntityDescriptionText, useGetEntityNameText, useGetCreatureFormDescriptionText } from '@utils/ReadingProjectText';
+import {
+  useGetEntityDescriptionText,
+  useGetEntityNameText,
+  useGetCreatureFormDescriptionText,
+  useGetCreatureFormNameText,
+} from '@utils/ReadingProjectText';
 import React from 'react';
 import {
   DataBlockContainer,
@@ -17,14 +22,29 @@ import {
   DataSpriteContainer,
 } from '../dataBlocks';
 import { PokemonDataProps } from './PokemonDataPropsInterface';
+import styled from 'styled-components';
+
+const CreatureNameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  .specie {
+    ${({ theme }) => theme.fonts.normalMedium}
+    font-size: 20px;
+    color: ${({ theme }) => theme.colors.text400};
+  }
+`;
 
 export const PokemonFrame = ({ pokemonWithForm, dialogsRef }: PokemonDataProps) => {
   const { species, form } = pokemonWithForm;
   const [state] = useGlobalState();
   const getCreatureName = useGetEntityNameText();
+  const getCreatureFormName = useGetCreatureFormNameText();
   const getCreatureDescription = useGetEntityDescriptionText();
   const getCreatureFormDescription = useGetCreatureFormDescriptionText();
   const types = state.projectData.types;
+  const creatureName = species ? getCreatureName(species) : '';
+  const creatureFormName = form ? getCreatureFormName(form) : '';
 
   return (
     <DataBlockContainer size="full" onClick={() => dialogsRef.current?.openDialog('information')}>
@@ -34,13 +54,16 @@ export const PokemonFrame = ({ pokemonWithForm, dialogsRef }: PokemonDataProps) 
         </DataSpriteContainer>
         <DataInfoContainer>
           <DataInfoContainerHeader>
-            <DataInfoContainerHeaderTitle>
-              <h1>
-                {species && getCreatureName(species)}
-                <span className="data-id">#{padStr(species?.id, 3)}</span>
-              </h1>
-              <CopyIdentifier dataToCopy={species.dbSymbol} />
-            </DataInfoContainerHeaderTitle>
+            <CreatureNameContainer>
+              {creatureName !== creatureFormName && <span className="specie">{creatureName}</span>}
+              <DataInfoContainerHeaderTitle>
+                <h1>
+                  {creatureFormName}
+                  <span className="data-id">#{padStr(species?.id, 3)}</span>
+                </h1>
+                <CopyIdentifier dataToCopy={species.dbSymbol} />
+              </DataInfoContainerHeaderTitle>
+            </CreatureNameContainer>
             <DataInfoContainerHeaderBadges>
               <TypeCategory type={form.type1}>{getNameType(types, form.type1, state)}</TypeCategory>
               {form.type2 !== '__undef__' && <TypeCategory type={form.type2}>{getNameType(types, form.type2, state)}</TypeCategory>}

--- a/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
+++ b/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
@@ -58,6 +58,7 @@ export const CreatureTranslationOverlay = defineEditorOverlay<TranslationEditorT
           <TranslationEditorWithCloseHandling
             title={dialogToShow}
             nameTextId={CREATURE_FORM_NAME_TEXT_ID}
+            nameTextIndex={form.formTextId.name}
             fileId={fileIds[dialogToShow]}
             textIndex={dialogToShow === 'translation_form_name' ? form.formTextId.name : form.formTextId.description}
             isMultiline={dialogToShow === 'translation_form_description'}

--- a/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
+++ b/src/views/components/database/pokemon/editors/CreatureTranslationOverlay.tsx
@@ -1,25 +1,41 @@
 import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
 import { TranslationEditorWithCloseHandling } from '@components/editor/TranslationEditorWithCloseHandling';
-import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_NAME_TEXT_ID, CREATURE_SPECIE_TEXT_ID, StudioCreature } from '@modelEntities/creature';
+import {
+  CREATURE_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_NAME_TEXT_ID,
+  CREATURE_NAME_TEXT_ID,
+  CREATURE_SPECIE_TEXT_ID,
+  StudioCreature,
+  StudioCreatureForm,
+} from '@modelEntities/creature';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import React from 'react';
 
-export type TranslationEditorTitle = 'translation_name' | 'translation_description' | 'translation_species';
+export type TranslationEditorTitle =
+  | 'translation_name'
+  | 'translation_description'
+  | 'translation_species'
+  | 'translation_form_name'
+  | 'translation_form_description';
 
 type Props = {
   onClose: () => void;
   creature: StudioCreature;
+  form: StudioCreatureForm;
 };
 
 const fileIds: Record<TranslationEditorTitle, number> = {
   translation_species: CREATURE_SPECIE_TEXT_ID,
   translation_description: CREATURE_DESCRIPTION_TEXT_ID,
   translation_name: CREATURE_NAME_TEXT_ID,
+  translation_form_name: CREATURE_FORM_NAME_TEXT_ID,
+  translation_form_description: CREATURE_FORM_DESCRIPTION_TEXT_ID,
 };
 
 export const CreatureTranslationOverlay = defineEditorOverlay<TranslationEditorTitle, Props>(
   'CreatureTranslationOverlay',
-  (dialogToShow, handleCloseRef, closeDialog, { onClose, creature }) => {
+  (dialogToShow, handleCloseRef, closeDialog, { onClose, creature, form }) => {
     switch (dialogToShow) {
       case 'translation_name':
       case 'translation_description':
@@ -31,6 +47,20 @@ export const CreatureTranslationOverlay = defineEditorOverlay<TranslationEditorT
             fileId={fileIds[dialogToShow]}
             textIndex={creature.id}
             isMultiline={dialogToShow === 'translation_description'}
+            closeDialog={closeDialog}
+            onClose={onClose}
+            ref={handleCloseRef}
+          />
+        );
+      case 'translation_form_name':
+      case 'translation_form_description':
+        return (
+          <TranslationEditorWithCloseHandling
+            title={dialogToShow}
+            nameTextId={CREATURE_FORM_NAME_TEXT_ID}
+            fileId={fileIds[dialogToShow]}
+            textIndex={dialogToShow === 'translation_form_name' ? form.formTextId.name : form.formTextId.description}
+            isMultiline={dialogToShow === 'translation_form_description'}
             closeDialog={closeDialog}
             onClose={onClose}
             ref={handleCloseRef}

--- a/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
+++ b/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
@@ -18,7 +18,7 @@ import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TranslationEditorTitle } from '../CreatureTranslationOverlay';
 import { useTranslation } from 'react-i18next';
 import { TranslatableTextFieldsRef } from './TranslatableTextFields';
-import { SecondaryNoBackground } from '@components/buttons';
+import { SecondaryButton } from '@components/buttons';
 
 type TranslatableFormTextFieldsProps = {
   creature: StudioCreature;
@@ -84,9 +84,7 @@ export const TranslatableFormTextFields = forwardRef<TranslatableTextFieldsRef, 
           <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_form_description')}>
             <MultiLineInput defaultValue={getCreatureFormDescription(form)} ref={descriptionRef} />
           </TranslateInputContainer>
-          <SecondaryNoBackground style={{ justifyContent: 'left' }} onClick={onClickUseBaseDescription}>
-            {t('use_default_description')}
-          </SecondaryNoBackground>
+          <SecondaryButton onClick={onClickUseBaseDescription}>{t('use_default_description')}</SecondaryButton>
         </InputWithTopLabelContainer>
       </>
     );

--- a/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
+++ b/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
@@ -1,0 +1,95 @@
+import { Input, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
+import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
+import {
+  CREATURE_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_NAME_TEXT_ID,
+  StudioCreature,
+  StudioCreatureForm,
+} from '@modelEntities/creature';
+import {
+  useCopyProjectText,
+  useGetCreatureFormDescriptionText,
+  useGetCreatureFormNameText,
+  useGetEntityDescriptionText,
+  useSetProjectText,
+} from '@utils/ReadingProjectText';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { TranslationEditorTitle } from '../CreatureTranslationOverlay';
+import { useTranslation } from 'react-i18next';
+import { TranslatableTextFieldsRef } from './TranslatableTextFields';
+import { SecondaryNoBackground } from '@components/buttons';
+
+type TranslatableFormTextFieldsProps = {
+  creature: StudioCreature;
+  form: StudioCreatureForm;
+  handleTranslateClick: (editorTitle: TranslationEditorTitle) => () => void;
+};
+
+export const TranslatableFormTextFields = forwardRef<TranslatableTextFieldsRef, TranslatableFormTextFieldsProps>(
+  ({ creature, form, handleTranslateClick }, ref) => {
+    const { t } = useTranslation('database_pokemon');
+    const nameRef = useRef<HTMLInputElement>(null);
+    const descriptionRef = useRef<HTMLTextAreaElement>(null);
+    const getCreatureDescription = useGetEntityDescriptionText();
+    const getCreatureFormName = useGetCreatureFormNameText();
+    const getCreatureFormDescription = useGetCreatureFormDescriptionText();
+    const setText = useSetProjectText();
+    const copyProjectText = useCopyProjectText();
+
+    const saveTexts = () => {
+      if (!nameRef.current || !descriptionRef.current) return;
+
+      setText(CREATURE_FORM_NAME_TEXT_ID, form.formTextId.name, nameRef.current.value);
+      setText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.formTextId.description, descriptionRef.current.value);
+    };
+    const onTranslationOverlayClose = () => {
+      if (!nameRef.current || !descriptionRef.current) return;
+      // Since translation Editor sets the texts we can rely on default value that is recomputed on state changes
+      nameRef.current.value = nameRef.current.defaultValue;
+      descriptionRef.current.value = descriptionRef.current.defaultValue;
+    };
+    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [form]);
+
+    const onClickUseBaseDescription = () => {
+      const defaultForm = creature.forms.find((form) => form.form === 0);
+      if (!defaultForm || !descriptionRef.current) return;
+
+      const srcDescriptionTextId = creature.id + 1;
+      const destDescriptionTextId = form.formTextId.description + 1;
+      copyProjectText(
+        { fileId: CREATURE_DESCRIPTION_TEXT_ID, textId: srcDescriptionTextId },
+        { fileId: CREATURE_FORM_DESCRIPTION_TEXT_ID, textId: destDescriptionTextId }
+      );
+      descriptionRef.current.value = getCreatureDescription(creature);
+    };
+
+    return (
+      <>
+        <InputWithTopLabelContainer>
+          <Label required>{t('form_name')}</Label>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_form_name')}>
+            <Input
+              type="text"
+              name="form_name"
+              defaultValue={getCreatureFormName(form)}
+              ref={nameRef}
+              placeholder={t('example_form_name')}
+              required
+            />
+          </TranslateInputContainer>
+        </InputWithTopLabelContainer>
+        <InputWithTopLabelContainer style={{ display: form.form !== 0 ? 'flex' : 'none' }}>
+          <Label>{t('form_description')}</Label>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_form_description')}>
+            <MultiLineInput defaultValue={getCreatureFormDescription(form)} ref={descriptionRef} />
+          </TranslateInputContainer>
+          <SecondaryNoBackground style={{ justifyContent: 'left' }} onClick={onClickUseBaseDescription}>
+            {t('use_default_description')}
+          </SecondaryNoBackground>
+        </InputWithTopLabelContainer>
+      </>
+    );
+  }
+);
+TranslatableFormTextFields.displayName = 'TranslatableFormTextFields';

--- a/src/views/components/database/pokemon/editors/InformationEditor/TranslatableTextFields.tsx
+++ b/src/views/components/database/pokemon/editors/InformationEditor/TranslatableTextFields.tsx
@@ -2,20 +2,8 @@
 
 import { Input, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
-import {
-  CREATURE_DESCRIPTION_TEXT_ID,
-  CREATURE_FORM_DESCRIPTION_TEXT_ID,
-  CREATURE_FORM_NAME_TEXT_ID,
-  CREATURE_NAME_TEXT_ID,
-  StudioCreature,
-  StudioCreatureForm,
-} from '@modelEntities/creature';
-import {
-  useGetCreatureFormDescriptionText,
-  useGetCreatureFormNameText,
-  useGetEntityDescriptionText,
-  useSetProjectText,
-} from '@utils/ReadingProjectText';
+import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_NAME_TEXT_ID, StudioCreature } from '@modelEntities/creature';
+import { useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TranslationEditorTitle } from '../CreatureTranslationOverlay';
 import { useTranslation } from 'react-i18next';
@@ -27,31 +15,22 @@ export type TranslatableTextFieldsRef = {
 type TranslatableTextFieldsProps = {
   creatureName: string;
   creature: StudioCreature;
-  form: StudioCreatureForm;
-  type: 'base' | 'form';
   handleTranslateClick: (editorTitle: TranslationEditorTitle) => () => void;
 };
 
 export const TranslatableTextFields = forwardRef<TranslatableTextFieldsRef, TranslatableTextFieldsProps>(
-  ({ creatureName, creature, form, type, handleTranslateClick }, ref) => {
+  ({ creatureName, creature, handleTranslateClick }, ref) => {
     const { t } = useTranslation('database_pokemon');
     const nameRef = useRef<HTMLInputElement>(null);
     const descriptionRef = useRef<HTMLTextAreaElement>(null);
     const getCreatureDescription = useGetEntityDescriptionText();
-    const getCreatureFormName = useGetCreatureFormNameText();
-    const getCreatureFormDescription = useGetCreatureFormDescriptionText();
     const setText = useSetProjectText();
 
     const saveTexts = () => {
       if (!nameRef.current || !descriptionRef.current) return;
 
-      if (type === 'base') {
-        setText(CREATURE_NAME_TEXT_ID, creature.id, nameRef.current.value);
-        setText(CREATURE_DESCRIPTION_TEXT_ID, creature.id, descriptionRef.current.value);
-      } else {
-        setText(CREATURE_FORM_NAME_TEXT_ID, form.formTextId.name, nameRef.current.value);
-        setText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.formTextId.description, descriptionRef.current.value);
-      }
+      setText(CREATURE_NAME_TEXT_ID, creature.id, nameRef.current.value);
+      setText(CREATURE_DESCRIPTION_TEXT_ID, creature.id, descriptionRef.current.value);
     };
     const onTranslationOverlayClose = () => {
       if (!nameRef.current || !descriptionRef.current) return;
@@ -59,32 +38,20 @@ export const TranslatableTextFields = forwardRef<TranslatableTextFieldsRef, Tran
       nameRef.current.value = nameRef.current.defaultValue;
       descriptionRef.current.value = descriptionRef.current.defaultValue;
     };
-    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [creatureName, creature, form]);
+    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [creatureName, creature]);
 
     return (
       <>
         <InputWithTopLabelContainer>
-          <Label required={type === 'base'}>{t('name')}</Label>
-          <TranslateInputContainer onTranslateClick={handleTranslateClick(type === 'base' ? 'translation_name' : 'translation_form_name')}>
-            <Input
-              type="text"
-              name="name"
-              defaultValue={type === 'base' ? creatureName : getCreatureFormName(form)}
-              ref={nameRef}
-              placeholder={t('example_name')}
-              required
-            />
+          <Label required>{t('name')}</Label>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_name')}>
+            <Input type="text" name="name" defaultValue={creatureName} ref={nameRef} placeholder={t('example_name')} required />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
-        <InputWithTopLabelContainer style={{ display: type === 'base' || (type === 'form' && form.form !== 0) ? 'flex' : 'none' }}>
+        <InputWithTopLabelContainer>
           <Label>{t('description')}</Label>
-          <TranslateInputContainer
-            onTranslateClick={handleTranslateClick(type === 'base' ? 'translation_description' : 'translation_form_description')}
-          >
-            <MultiLineInput
-              defaultValue={type === 'base' ? getCreatureDescription(creature) : getCreatureFormDescription(form)}
-              ref={descriptionRef}
-            />
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_description')}>
+            <MultiLineInput defaultValue={getCreatureDescription(creature)} ref={descriptionRef} />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
       </>

--- a/src/views/components/database/pokemon/editors/InformationEditor/TranslatableTextFields.tsx
+++ b/src/views/components/database/pokemon/editors/InformationEditor/TranslatableTextFields.tsx
@@ -2,8 +2,20 @@
 
 import { Input, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
-import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_NAME_TEXT_ID, StudioCreature } from '@modelEntities/creature';
-import { useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
+import {
+  CREATURE_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_NAME_TEXT_ID,
+  CREATURE_NAME_TEXT_ID,
+  StudioCreature,
+  StudioCreatureForm,
+} from '@modelEntities/creature';
+import {
+  useGetCreatureFormDescriptionText,
+  useGetCreatureFormNameText,
+  useGetEntityDescriptionText,
+  useSetProjectText,
+} from '@utils/ReadingProjectText';
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TranslationEditorTitle } from '../CreatureTranslationOverlay';
 import { useTranslation } from 'react-i18next';
@@ -15,22 +27,31 @@ export type TranslatableTextFieldsRef = {
 type TranslatableTextFieldsProps = {
   creatureName: string;
   creature: StudioCreature;
+  form: StudioCreatureForm;
+  type: 'base' | 'form';
   handleTranslateClick: (editorTitle: TranslationEditorTitle) => () => void;
 };
 
 export const TranslatableTextFields = forwardRef<TranslatableTextFieldsRef, TranslatableTextFieldsProps>(
-  ({ creatureName, creature, handleTranslateClick }, ref) => {
+  ({ creatureName, creature, form, type, handleTranslateClick }, ref) => {
     const { t } = useTranslation('database_pokemon');
     const nameRef = useRef<HTMLInputElement>(null);
     const descriptionRef = useRef<HTMLTextAreaElement>(null);
     const getCreatureDescription = useGetEntityDescriptionText();
+    const getCreatureFormName = useGetCreatureFormNameText();
+    const getCreatureFormDescription = useGetCreatureFormDescriptionText();
     const setText = useSetProjectText();
 
     const saveTexts = () => {
       if (!nameRef.current || !descriptionRef.current) return;
 
-      setText(CREATURE_NAME_TEXT_ID, creature.id, nameRef.current.value);
-      setText(CREATURE_DESCRIPTION_TEXT_ID, creature.id, descriptionRef.current.value);
+      if (type === 'base') {
+        setText(CREATURE_NAME_TEXT_ID, creature.id, nameRef.current.value);
+        setText(CREATURE_DESCRIPTION_TEXT_ID, creature.id, descriptionRef.current.value);
+      } else {
+        setText(CREATURE_FORM_NAME_TEXT_ID, form.formTextId.name, nameRef.current.value);
+        setText(CREATURE_FORM_DESCRIPTION_TEXT_ID, form.formTextId.description, descriptionRef.current.value);
+      }
     };
     const onTranslationOverlayClose = () => {
       if (!nameRef.current || !descriptionRef.current) return;
@@ -38,20 +59,32 @@ export const TranslatableTextFields = forwardRef<TranslatableTextFieldsRef, Tran
       nameRef.current.value = nameRef.current.defaultValue;
       descriptionRef.current.value = descriptionRef.current.defaultValue;
     };
-    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [creatureName, creature]);
+    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [creatureName, creature, form]);
 
     return (
       <>
         <InputWithTopLabelContainer>
-          <Label required>{t('name')}</Label>
-          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_name')}>
-            <Input type="text" name="name" defaultValue={creatureName} ref={nameRef} placeholder={t('example_name')} required />
+          <Label required={type === 'base'}>{t('name')}</Label>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick(type === 'base' ? 'translation_name' : 'translation_form_name')}>
+            <Input
+              type="text"
+              name="name"
+              defaultValue={type === 'base' ? creatureName : getCreatureFormName(form)}
+              ref={nameRef}
+              placeholder={t('example_name')}
+              required
+            />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
-        <InputWithTopLabelContainer>
+        <InputWithTopLabelContainer style={{ display: type === 'base' || (type === 'form' && form.form !== 0) ? 'flex' : 'none' }}>
           <Label>{t('description')}</Label>
-          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_description')}>
-            <MultiLineInput defaultValue={getCreatureDescription(creature)} ref={descriptionRef} />
+          <TranslateInputContainer
+            onTranslateClick={handleTranslateClick(type === 'base' ? 'translation_description' : 'translation_form_description')}
+          >
+            <MultiLineInput
+              defaultValue={type === 'base' ? getCreatureDescription(creature) : getCreatureFormDescription(form)}
+              ref={descriptionRef}
+            />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
       </>

--- a/src/views/components/database/pokemon/editors/InformationsEditor.tsx
+++ b/src/views/components/database/pokemon/editors/InformationsEditor.tsx
@@ -12,6 +12,7 @@ import { useInputAttrsWithLabel } from '@hooks/useInputAttrs';
 import { useZodForm } from '@hooks/useZodForm';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { TranslatableTextFields, TranslatableTextFieldsRef } from './InformationEditor/TranslatableTextFields';
+import { TranslatableFormTextFields } from './InformationEditor/TranslatableFormTextFields';
 import { INFORMATION_EDITOR_SCHEMA } from './InformationEditor/InformationEditorSchema';
 import { TypeFields } from './InformationEditor/TypeFields';
 
@@ -58,27 +59,15 @@ export const InformationsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   return (
     <Editor type="edit" title={t('information')}>
       <InputFormContainer ref={formRef}>
-        <TranslatableTextFields
-          ref={tTFR}
-          handleTranslateClick={handleTranslateClick}
-          creature={creature}
-          form={form}
-          creatureName={creatureName}
-          type="base"
-        />
+        {form.form === 0 && (
+          <TranslatableTextFields ref={tTFR} handleTranslateClick={handleTranslateClick} creature={creature} creatureName={creatureName} />
+        )}
+        <TranslatableFormTextFields ref={formTTFR} handleTranslateClick={handleTranslateClick} creature={creature} form={form} />
         <TypeFields form={form} defaults={defaults} />
         <InputWithTopLabelContainer>
           <Input name="frontOffsetY" label={t('offset')} labelLeft onInput={onInputTouched} />
           <OffsetInfo>{t('offset_info')}</OffsetInfo>
         </InputWithTopLabelContainer>
-        <TranslatableTextFields
-          ref={formTTFR}
-          handleTranslateClick={handleTranslateClick}
-          creature={creature}
-          form={form}
-          creatureName={creatureName}
-          type="form"
-        />
       </InputFormContainer>
       <CreatureTranslationOverlay creature={creature} form={form} onClose={onTranslationOverlayClose} ref={dialogsRef} />
     </Editor>

--- a/src/views/components/database/pokemon/editors/InformationsEditor.tsx
+++ b/src/views/components/database/pokemon/editors/InformationsEditor.tsx
@@ -27,6 +27,7 @@ export const InformationsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { creature, form, creatureName } = useCreaturePage();
   const updateForm = useUpdateForm(creature, form);
   const tTFR = useRef<TranslatableTextFieldsRef>(null);
+  const formTTFR = useRef<TranslatableTextFieldsRef>(null);
   const { canClose, getFormData, onInputTouched, defaults, formRef } = useZodForm(INFORMATION_EDITOR_SCHEMA, form);
   const { Input } = useInputAttrsWithLabel(INFORMATION_EDITOR_SCHEMA, defaults);
 
@@ -39,27 +40,47 @@ export const InformationsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     if (!result || !result.success) return;
 
     tTFR.current?.saveTexts();
+    formTTFR.current?.saveTexts();
     updateForm(result.data);
   };
   useEditorHandlingClose(ref, onClose, canCloseEditor);
 
   const handleTranslateClick = (editorTitle: TranslationEditorTitle) => () => {
     tTFR.current?.saveTexts();
+    formTTFR.current?.saveTexts();
     setTimeout(() => dialogsRef.current?.openDialog(editorTitle), 0);
   };
-  const onTranslationOverlayClose = () => tTFR.current?.onTranslationOverlayClose();
+  const onTranslationOverlayClose = () => {
+    tTFR.current?.onTranslationOverlayClose();
+    formTTFR.current?.onTranslationOverlayClose();
+  };
 
   return (
     <Editor type="edit" title={t('information')}>
       <InputFormContainer ref={formRef}>
-        <TranslatableTextFields ref={tTFR} handleTranslateClick={handleTranslateClick} creature={creature} creatureName={creatureName} />
+        <TranslatableTextFields
+          ref={tTFR}
+          handleTranslateClick={handleTranslateClick}
+          creature={creature}
+          form={form}
+          creatureName={creatureName}
+          type="base"
+        />
         <TypeFields form={form} defaults={defaults} />
         <InputWithTopLabelContainer>
           <Input name="frontOffsetY" label={t('offset')} labelLeft onInput={onInputTouched} />
           <OffsetInfo>{t('offset_info')}</OffsetInfo>
         </InputWithTopLabelContainer>
+        <TranslatableTextFields
+          ref={formTTFR}
+          handleTranslateClick={handleTranslateClick}
+          creature={creature}
+          form={form}
+          creatureName={creatureName}
+          type="form"
+        />
       </InputFormContainer>
-      <CreatureTranslationOverlay creature={creature} onClose={onTranslationOverlayClose} ref={dialogsRef} />
+      <CreatureTranslationOverlay creature={creature} form={form} onClose={onTranslationOverlayClose} ref={dialogsRef} />
     </Editor>
   );
 });

--- a/src/views/components/database/pokemon/editors/PokedexEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokedexEditor.tsx
@@ -64,7 +64,7 @@ export const PokedexEditor = forwardRef<EditorHandlingClose>((_, ref) => {
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
       </InputFormContainer>
-      <CreatureTranslationOverlay creature={creature} onClose={onTranslationOverlayClose} ref={dialogsRef} />
+      <CreatureTranslationOverlay creature={creature} form={form} onClose={onTranslationOverlayClose} ref={dialogsRef} />
     </Editor>
   );
 });

--- a/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
@@ -56,7 +56,7 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
   const { getFormData, defaults, formRef } = useZodForm(CREATURE_FORM_NEW_EDITOR_SCHEMA, form);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const newFormId = findFirstFormNotUsed(creature, formCategory);
-  const [formName, setFormName] = useState(`${creatureName} (${newFormId})`);
+  const [formName, setFormName] = useState(creatureName);
 
   useEditorHandlingClose(ref);
 

--- a/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
@@ -1,19 +1,21 @@
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
 import { Editor } from '@components/editor';
 import { InputWithTopLabelContainer, Label } from '@components/inputs';
 import styled from 'styled-components';
 import { DarkButton, PrimaryButton } from '@components/buttons';
-import { TextInputError } from '@components/inputs/Input';
+import { Input, MultiLineInput, TextInputError } from '@components/inputs/Input';
 import { useProjectPokemon } from '@hooks/useProjectData';
 import { cloneEntity } from '@utils/cloneEntity';
-import { CREATURE_FORM_VALIDATOR, StudioCreature } from '@modelEntities/creature';
+import { CREATURE_FORM_DESCRIPTION_TEXT_ID, CREATURE_FORM_NAME_TEXT_ID, CREATURE_FORM_VALIDATOR, StudioCreature } from '@modelEntities/creature';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useCreaturePage } from '@hooks/usePage';
 import { useZodForm } from '@hooks/useZodForm';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { TypeFields } from './InformationEditor/TypeFields';
 import { Select } from '@ds/Select';
+import { useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
+import { createCreatureForm } from '@utils/entityCreation';
 
 export const FormCategories = ['classic', 'mega-evolution'] as const;
 export type FormCategory = (typeof FormCategories)[number];
@@ -45,33 +47,51 @@ const CREATURE_FORM_NEW_EDITOR_SCHEMA = CREATURE_FORM_VALIDATOR.pick({ type1: tr
 export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeDialog, setEvolutionIndex }, ref) => {
   const { t } = useTranslation('database_pokemon');
   const { t: tMove } = useTranslation('database_moves');
-  const { creature, form } = useCreaturePage();
+  const { creature, form, creatureName } = useCreaturePage();
   const { projectDataValues: creatures, setProjectDataValues: setCreature } = useProjectPokemon();
+  const setText = useSetProjectText();
+  const getCreatureDescription = useGetEntityDescriptionText();
   const formCategoryOptions = useMemo(() => formCategoryEntries(t), []);
   const [formCategory, setFormCategory] = useState<FormCategory>('classic');
   const { getFormData, defaults, formRef } = useZodForm(CREATURE_FORM_NEW_EDITOR_SCHEMA, form);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const newFormId = findFirstFormNotUsed(creature, formCategory);
+  const [formName, setFormName] = useState(`${creatureName} (${newFormId})`);
 
   useEditorHandlingClose(ref);
 
   const onClickNew = () => {
     const data = getFormData();
-    if (data.success == false) return;
+    if (data.success == false || !descriptionRef.current) return;
 
-    const newForm = cloneEntity({ ...form, ...data.data, form: newFormId });
+    const newForm = createCreatureForm(creatures, form, data.data, newFormId);
     if (newFormId <= 29 && creatures[form.babyDbSymbol]?.forms.find((f) => f.form === newFormId)) newForm.babyForm = newFormId;
 
     const updatedCreature = cloneEntity(creature);
     updatedCreature.forms = [...updatedCreature.forms, newForm];
     updatedCreature.forms.sort((a, b) => a.form - b.form);
+
+    setText(CREATURE_FORM_NAME_TEXT_ID, newForm.formTextId.name, formName);
+    setText(CREATURE_FORM_DESCRIPTION_TEXT_ID, newForm.formTextId.description, descriptionRef.current.value);
+
     setEvolutionIndex(0);
     setCreature({ [updatedCreature.dbSymbol]: updatedCreature }, { pokemon: { specie: updatedCreature.dbSymbol, form: newFormId } });
     closeDialog();
   };
 
+  const isDisabled = newFormId === -1 || !formName;
+
   return (
     <Editor type="creation" title={t('new_form')}>
       <InputFormContainer ref={formRef}>
+        <InputWithTopLabelContainer>
+          <Label required>{t('form_name')}</Label>
+          <Input value={formName} onChange={(event) => setFormName(event.currentTarget.value)} placeholder={t('example_form_name')} />
+        </InputWithTopLabelContainer>
+        <InputWithTopLabelContainer>
+          <Label>{t('form_description')}</Label>
+          <MultiLineInput ref={descriptionRef} defaultValue={getCreatureDescription(creature)} />
+        </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
           <Label>{t('form_type')}</Label>
           <Select value={formCategory} options={formCategoryOptions} onChange={setFormCategory} />
@@ -81,7 +101,7 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
         </InputWithTopLabelContainer>
         <TypeFields form={form} defaults={defaults} />
         <ButtonContainer>
-          <PrimaryButton onClick={onClickNew} disabled={newFormId === -1}>
+          <PrimaryButton onClick={onClickNew} disabled={isDisabled}>
             {t('create_form')}
           </PrimaryButton>
           <DarkButton onClick={closeDialog}>{tMove('cancel')}</DarkButton>

--- a/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
@@ -46,7 +46,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
   const { t: tMove } = useTranslation('database_moves');
   const setText = useSetProjectText();
   const [name, setName] = useState(''); // We use a state because synchronizing dbSymbol is easier with a state
-  const [formName, setFormName] = useState('');
+  const formNameRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const dbSymbolRef = useRef<HTMLInputElement>(null);
   const [dbSymbolErrorType, setDbSymbolErrorType] = useState<'value' | 'duplicate' | undefined>(undefined);
@@ -57,7 +57,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
 
   const onClickNew = () => {
     const result = getFormData();
-    if (!dbSymbolRef.current || !name || !descriptionRef.current || !result.success) return;
+    if (!dbSymbolRef.current || !name || !descriptionRef.current || !formNameRef.current || !result.success) return;
 
     const dbSymbol = dbSymbolRef.current.value as DbSymbol;
     const { type1, type2 } = result.data;
@@ -65,7 +65,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
     setText(CREATURE_NAME_TEXT_ID, newCreature.id, name);
     setText(CREATURE_DESCRIPTION_TEXT_ID, newCreature.id, descriptionRef.current.value);
     setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, '-');
-    setText(CREATURE_FORM_NAME_TEXT_ID, newCreature.forms[0].formTextId.name, formName);
+    setText(CREATURE_FORM_NAME_TEXT_ID, newCreature.forms[0].formTextId.name, formNameRef.current.value || name);
 
     setCreature({ [dbSymbol]: newCreature }, { pokemon: { specie: dbSymbol, form: 0 } });
     const editedDex = cloneEntity(dex.national);
@@ -105,7 +105,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
   /**
    * Check if the entity cannot be created because of any validation error
    */
-  const isDisabled = !name || !formName || !!dbSymbolErrorType;
+  const isDisabled = !name || !!dbSymbolErrorType;
 
   return (
     <Editor type="creation" title={t('new')}>
@@ -119,8 +119,8 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
           <MultiLineInput ref={descriptionRef} placeholder={t('example_description')} />
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
-          <Label required>{t('form_name')}</Label>
-          <Input value={formName} onChange={(event) => setFormName(event.currentTarget.value)} placeholder={t('example_form_name')} />
+          <Label>{t('form_name')}</Label>
+          <Input ref={formNameRef} placeholder={t('example_form_name')} />
         </InputWithTopLabelContainer>
         <TypeFields form={form} defaults={defaults} />
         <InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
@@ -9,7 +9,13 @@ import { checkDbSymbolExist, generateDefaultDbSymbol, wrongDbSymbol } from '@uti
 import { useProjectPokemon, useProjectDex } from '@hooks/useProjectData';
 import { createCreature } from '@utils/entityCreation';
 import { useSetProjectText } from '@utils/ReadingProjectText';
-import { CREATURE_DESCRIPTION_TEXT_ID, CREATURE_FORM_VALIDATOR, CREATURE_NAME_TEXT_ID, CREATURE_SPECIE_TEXT_ID } from '@modelEntities/creature';
+import {
+  CREATURE_DESCRIPTION_TEXT_ID,
+  CREATURE_FORM_NAME_TEXT_ID,
+  CREATURE_FORM_VALIDATOR,
+  CREATURE_NAME_TEXT_ID,
+  CREATURE_SPECIE_TEXT_ID,
+} from '@modelEntities/creature';
 import { DbSymbol } from '@modelEntities/dbSymbol';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { cloneEntity } from '@utils/cloneEntity';
@@ -40,6 +46,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
   const { t: tMove } = useTranslation('database_moves');
   const setText = useSetProjectText();
   const [name, setName] = useState(''); // We use a state because synchronizing dbSymbol is easier with a state
+  const [formName, setFormName] = useState('');
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const dbSymbolRef = useRef<HTMLInputElement>(null);
   const [dbSymbolErrorType, setDbSymbolErrorType] = useState<'value' | 'duplicate' | undefined>(undefined);
@@ -58,6 +65,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
     setText(CREATURE_NAME_TEXT_ID, newCreature.id, name);
     setText(CREATURE_DESCRIPTION_TEXT_ID, newCreature.id, descriptionRef.current.value);
     setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, '-');
+    setText(CREATURE_FORM_NAME_TEXT_ID, newCreature.forms[0].formTextId.name, formName);
 
     setCreature({ [dbSymbol]: newCreature }, { pokemon: { specie: dbSymbol, form: 0 } });
     const editedDex = cloneEntity(dex.national);
@@ -97,7 +105,7 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
   /**
    * Check if the entity cannot be created because of any validation error
    */
-  const isDisabled = !name || !!dbSymbolErrorType;
+  const isDisabled = !name || !formName || !!dbSymbolErrorType;
 
   return (
     <Editor type="creation" title={t('new')}>
@@ -109,6 +117,10 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
         <InputWithTopLabelContainer>
           <Label>{t('description')}</Label>
           <MultiLineInput ref={descriptionRef} placeholder={t('example_description')} />
+        </InputWithTopLabelContainer>
+        <InputWithTopLabelContainer>
+          <Label required>{t('form_name')}</Label>
+          <Input value={formName} onChange={(event) => setFormName(event.currentTarget.value)} placeholder={t('example_form_name')} />
         </InputWithTopLabelContainer>
         <TypeFields form={form} defaults={defaults} />
         <InputWithTopLabelContainer>

--- a/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
+++ b/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
@@ -78,7 +78,9 @@ export type TranslationEditorTitle =
   | 'translation_species'
   | 'translation_class'
   | 'translation_victory'
-  | 'translation_defeat';
+  | 'translation_defeat'
+  | 'translation_form_name'
+  | 'translation_form_description';
 
 type InputRefsType = Record<string, HTMLInputElement | HTMLTextAreaElement | null>;
 

--- a/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
+++ b/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
@@ -170,18 +170,19 @@ type TranslationEditorWithCloseHandlingProps = {
   fileId: number;
   textIndex: number;
   isMultiline: boolean;
+  nameTextIndex?: number;
   closeDialog: () => void;
   onClose: () => void;
 };
 
 /** Wrapper allowing the TranslationEditor to be used with EditorOverlayV2 */
 export const TranslationEditorWithCloseHandling = forwardRef<EditorHandlingClose, TranslationEditorWithCloseHandlingProps>(
-  ({ title, closeDialog, onClose, fileId, nameTextId, textIndex, isMultiline }, ref) => {
+  ({ title, closeDialog, onClose, fileId, nameTextId, textIndex, isMultiline, nameTextIndex }, ref) => {
     const [{ projectText: texts, projectConfig, projectStudio }, setState] = useGlobalState();
     const getNameText = useGetProjectText();
     const inputRefs = useRef<InputRefsType>({});
     // Save the name in state to prevent the re-render to change the title when saving new name
-    const [name] = useState(getNameText(nameTextId, textIndex));
+    const [name] = useState(getNameText(nameTextId, nameTextIndex ?? textIndex));
 
     const onDialogClose = () => {
       setState((currentState) => {

--- a/src/views/components/selects/SelectPokemonForm.tsx
+++ b/src/views/components/selects/SelectPokemonForm.tsx
@@ -9,7 +9,7 @@ import { Select } from '@ds/Select';
 import { useGetCreatureFormNameText } from '@utils/ReadingProjectText';
 
 const getFormOptions = (getCreatureFormName: (form: StudioCreatureForm) => string, forms: StudioCreatureForm[]) =>
-  forms.map((formData) => ({ value: formData.form.toString(), label: getCreatureFormName(formData) }));
+  forms.map((formData) => ({ value: formData.form.toString(), label: `${getCreatureFormName(formData)} (n°${formData.form})` }));
 
 type SelectPokemonFormProps = {
   dbSymbol: string;

--- a/src/views/components/selects/SelectPokemonForm.tsx
+++ b/src/views/components/selects/SelectPokemonForm.tsx
@@ -28,7 +28,7 @@ export const SelectPokemonForm = ({ dbSymbol, form, onChange, noLabel, breakpoin
     const formOptions = getFormOptions(getCreatureFormName, state.projectData.pokemon[dbSymbol]?.forms || []);
     if (undefValueOption) return [{ value: '__undef__', label: undefValueOption }, ...formOptions];
     return formOptions;
-  }, [dbSymbol, undefValueOption, form, state]);
+  }, [dbSymbol, undefValueOption, getCreatureFormName, state]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const optionals = useMemo(() => ({ deletedOption: t('form_deleted') }), []);
 

--- a/src/views/components/selects/SelectPokemonForm.tsx
+++ b/src/views/components/selects/SelectPokemonForm.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useMemo } from 'react';
-import { TFunction, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useGlobalState } from '@src/GlobalStateProvider';
 import { StudioCreatureForm } from '@modelEntities/creature';
 import { StudioDropDown } from '@components/StudioDropDown';
 import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 import { BreakableSpan } from './SelectPokemon';
 import { Select } from '@ds/Select';
+import { useGetCreatureFormNameText } from '@utils/ReadingProjectText';
 
-const getFormOptions = (t: TFunction<'database_pokemon'>, forms: StudioCreatureForm[]) =>
-  forms.map((formData) => ({ value: formData.form.toString(), label: t('form#') + formData.form }));
+const getFormOptions = (getCreatureFormName: (form: StudioCreatureForm) => string, forms: StudioCreatureForm[]) =>
+  forms.map((formData) => ({ value: formData.form.toString(), label: getCreatureFormName(formData) }));
 
 type SelectPokemonFormProps = {
   dbSymbol: string;
@@ -22,8 +23,9 @@ type SelectPokemonFormProps = {
 export const SelectPokemonForm = ({ dbSymbol, form, onChange, noLabel, breakpoint, undefValueOption }: SelectPokemonFormProps) => {
   const { t } = useTranslation('database_pokemon');
   const [state] = useGlobalState();
+  const getCreatureFormName = useGetCreatureFormNameText();
   const options = useMemo(() => {
-    const formOptions = getFormOptions(t, state.projectData.pokemon[dbSymbol]?.forms || []);
+    const formOptions = getFormOptions(getCreatureFormName, state.projectData.pokemon[dbSymbol]?.forms || []);
     if (undefValueOption) return [{ value: '__undef__', label: undefValueOption }, ...formOptions];
     return formOptions;
   }, [dbSymbol, undefValueOption, form, state]);
@@ -50,7 +52,8 @@ type SelectCreatureFormProps = {
 export const SelectCreatureForm = ({ dbSymbol, onChange, ...props }: SelectCreatureFormProps) => {
   const { t } = useTranslation('database_pokemon');
   const [state] = useGlobalState();
-  const options = useMemo(() => getFormOptions(t, state.projectData.pokemon[dbSymbol]?.forms || []), [dbSymbol, state]);
+  const getCreatureFormName = useGetCreatureFormNameText();
+  const options = useMemo(() => getFormOptions(getCreatureFormName, state.projectData.pokemon[dbSymbol]?.forms || []), [dbSymbol, state]);
   const onValidatedChange = useCallback(
     (v: string) => {
       if (!onChange) return;


### PR DESCRIPTION
## Description

This PR adds the custom creature form names and descriptions to allow the user to choose a form name and description for each form.

CSV files 100066 and 100067 are now used to store form names and descriptions. If these files already exist, the migration will not run and will inform the user of the presence of the file.
During migration, the Pokémon names are used as the names for the form (same for the descriptions).

Issue: https://github.com/PokemonWorkshop/PokemonStudio/issues/323

## Tests to perform

- [x] If the CSV files 100066 and 100067 exists before the migration, the migration should be not run ;
- [x] The user can manage the name of the form ;
- [x] The user can manage the description of the form (for the form 0, it's the global description of the creature which is used) ;
- [x] TextIds are freed if a form is deleted ;
- [x] The creature creation works correctly ;
- [x] The form creation works correctly ;

## Screenshots

![image](https://github.com/user-attachments/assets/3c63b827-f711-4f10-8c78-087878c392b3)
