### PR TITLE
Fix false positives in error detection during project compilation

### DIFF
--- a/src/views/components/compilation/CompilationLogs.tsx
+++ b/src/views/components/compilation/CompilationLogs.tsx
@@ -26,9 +26,9 @@ export const CompilationLogs = ({ configuration }: CompilationLogsProps) => {
   const logsRef = useRef<HTMLTextAreaElement>(null);
   const progressBarRef = useRef<HTMLProgressElement>(null);
   const loaderRef = useLoaderRef();
-  const [exitCode, setExitCode] = useState<number | undefined>(undefined);
+  const [exitCode, setExitCode] = useState<number | undefined | null>(undefined);
   const showItemInFolder = useShowItemInFolder();
-  const isError = exitCode !== undefined && exitCode > 0;
+  const isError = exitCode !== undefined && (exitCode === null || exitCode > 0);
 
   const onClickClipboard = () => {
     if (!logsRef.current) return;
@@ -89,7 +89,7 @@ export const CompilationLogs = ({ configuration }: CompilationLogsProps) => {
           </span>
         </div>
       )}
-      {(exitCode === undefined || exitCode > 0) && (
+      {(exitCode === undefined || exitCode === null || exitCode > 0) && (
         <ProgressBarCompilationContainer isError={isError}>
           <span className="progress-message">
             {isError ? t('error_occurred') : t('creating_executable_for')}


### PR DESCRIPTION
## Description

This PR changes the way errors are detected during project compilation.

Studio checked if a message arrived in stderr, and if it did, it considered that there was an error in the process. However, a warning uses stderr and therefore gives a false positive.
With the change made, Studio no longer uses stderr but the exit code to determine whether there has been an error.

To improve the reliability of the exit code, a change has been made to PSDK:
https://gitlab.com/pokemonsdk/pokemonsdk/-/merge_requests/1427

## Note before testing

Use the following branch of PSDK (https://gitlab.com/TheRey/pokemonsdk/-/tree/fix/compilation) before to test the project compilation.

## Tests to perform

- [x] The user can compile his project ;
- [x] Studio doesn't send a false positive error during the project compilation ;
