### PR TITLE
Creature select should be ordered by following the national dex order

### DIFF
--- a/src/hooks/useProjectData.ts
+++ b/src/hooks/useProjectData.ts
@@ -97,8 +97,15 @@ export const useProjectData = <Key extends keyof ProjectData, SelectedIdentifier
           savingData: new SavingMap(currentState.savingData.set({ key, id }, 'UPDATE')),
           savingText: new SavingTextMap(currentState.savingText.setMultiple(fileIdUpdatedTexts, 'UPDATE')),
         };
+        if (key === 'mapLinks') return newState;
+
         // Add the new text
-        if (key !== 'mapLinks') addSelectOption(key === 'pokemon' ? 'creatures' : key, newState);
+        if (key === 'dex') {
+          addSelectOption('dex', newState);
+          addSelectOption('creatures', newState);
+        } else {
+          addSelectOption(key === 'pokemon' ? 'creatures' : key, newState);
+        }
         return newState;
       } else {
         return {

--- a/src/hooks/useProjectData.ts
+++ b/src/hooks/useProjectData.ts
@@ -4,6 +4,7 @@ import { getEntityNameText, getEntityNameTextUsingTextId } from '@utils/ReadingP
 import { SavingMap, SavingTextMap } from '@utils/SavingUtils';
 import { buildTextUpdate, TextUpdate } from './updateProjectText';
 import { addSelectOption, removeSelectOption } from './useSelectOptions';
+import { buildCreaturesListByDexOrder } from '@utils/buildCreaturesListByDexOrder';
 
 const getPreviousDbSymbolById = (values: { id: number; dbSymbol: DbSymbol }[], currentId: number) => {
   const sortedValues = values.sort((a, b) => b.id - a.id);
@@ -38,6 +39,18 @@ const getNextDbSymbolByName = (values: (EntityTextIdWithDbSymbol | EntityIdWithD
         )
       : (values as EntityIdWithDbSymbol[]).sort((a, b) => getEntityNameText(a, state).localeCompare(getEntityNameText(b, state)));
   const keys = sortedValues.map(({ dbSymbol }) => dbSymbol);
+  return keys[keys.indexOf(currentDbSymbol as DbSymbol) + 1] || keys[0];
+};
+
+export const getPreviousDbSymbolByDexOrder = (currentDbSymbol: string, state: State) => {
+  const creaturesList = buildCreaturesListByDexOrder(state);
+  const keys = creaturesList.map(({ dbSymbol }) => dbSymbol);
+  return keys[keys.indexOf(currentDbSymbol as DbSymbol) - 1] || keys[keys.length - 1];
+};
+
+export const getNextDbSymbolByDexOrder = (currentDbSymbol: string, state: State) => {
+  const creaturesList = buildCreaturesListByDexOrder(state);
+  const keys = creaturesList.map(({ dbSymbol }) => dbSymbol);
   return keys[keys.indexOf(currentDbSymbol as DbSymbol) + 1] || keys[0];
 };
 

--- a/src/hooks/useSelectOptions.ts
+++ b/src/hooks/useSelectOptions.ts
@@ -12,9 +12,10 @@ import { State } from '@src/GlobalStateProvider';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { cloneEntity } from '@utils/cloneEntity';
 import { getText, pocketMapping } from '@utils/ReadingProjectText';
-import { DEX_DEFAULT_NAME_TEXT_ID, StudioDexCreature } from '@modelEntities/dex';
+import { DEX_DEFAULT_NAME_TEXT_ID } from '@modelEntities/dex';
 import { MAP_NAME_TEXT_ID } from '@modelEntities/map';
 import { TRAINER_CLASS_TEXT_ID, TRAINER_NAME_TEXT_ID } from '@modelEntities/trainer';
+import { buildCreaturesListByDexOrder } from '@utils/buildCreaturesListByDexOrder';
 
 // Note: Regexp to search all options in the code: (\{ value:|\{ label:)
 
@@ -280,20 +281,10 @@ const buildSelectOptionsFromKey = (key: OptionSourceKey, state: State) => {
       return Object.values(state.projectData.groups)
         .sort((a, b) => a.id - b.id)
         .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
-    case 'creatures': {
-      const allPokemon = state.projectData.pokemon;
-      const creaturesFromDex = cloneEntity(state.projectData.dex['national'].creatures)
-        .filter(({ dbSymbol }) => allPokemon[dbSymbol] !== undefined)
-        .map((creature) => ({ ...creature, id: allPokemon[creature.dbSymbol].id }));
-      const creatures = Object.values(allPokemon)
-        .sort((a, b) => a.id - b.id)
-        .reduce<({ id: number } & StudioDexCreature)[]>((prev, creature) => {
-          if (prev.find(({ dbSymbol }) => dbSymbol === creature.dbSymbol)) return prev;
-
-          return [...prev, { dbSymbol: creature.dbSymbol, form: 0, id: allPokemon[creature.dbSymbol].id }];
-        }, creaturesFromDex);
-      return creatures.map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
-    }
+    case 'creatures':
+      return buildCreaturesListByDexOrder(state).map((data) =>
+        adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol)
+      );
     case 'quests':
       return Object.values(state.projectData.quests)
         .sort((a, b) => a.id - b.id)

--- a/src/hooks/useSelectOptions.ts
+++ b/src/hooks/useSelectOptions.ts
@@ -12,7 +12,7 @@ import { State } from '@src/GlobalStateProvider';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import { cloneEntity } from '@utils/cloneEntity';
 import { getText, pocketMapping } from '@utils/ReadingProjectText';
-import { DEX_DEFAULT_NAME_TEXT_ID } from '@modelEntities/dex';
+import { DEX_DEFAULT_NAME_TEXT_ID, StudioDexCreature } from '@modelEntities/dex';
 import { MAP_NAME_TEXT_ID } from '@modelEntities/map';
 import { TRAINER_CLASS_TEXT_ID, TRAINER_NAME_TEXT_ID } from '@modelEntities/trainer';
 
@@ -280,10 +280,20 @@ const buildSelectOptionsFromKey = (key: OptionSourceKey, state: State) => {
       return Object.values(state.projectData.groups)
         .sort((a, b) => a.id - b.id)
         .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
-    case 'creatures':
-      return Object.values(state.projectData.pokemon)
+    case 'creatures': {
+      const allPokemon = state.projectData.pokemon;
+      const creaturesFromDex = cloneEntity(state.projectData.dex['national'].creatures)
+        .filter(({ dbSymbol }) => allPokemon[dbSymbol] !== undefined)
+        .map((creature) => ({ ...creature, id: allPokemon[creature.dbSymbol].id }));
+      const creatures = Object.values(allPokemon)
         .sort((a, b) => a.id - b.id)
-        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+        .reduce<({ id: number } & StudioDexCreature)[]>((prev, creature) => {
+          if (prev.find(({ dbSymbol }) => dbSymbol === creature.dbSymbol)) return prev;
+
+          return [...prev, { dbSymbol: creature.dbSymbol, form: 0, id: allPokemon[creature.dbSymbol].id }];
+        }, creaturesFromDex);
+      return creatures.map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    }
     case 'quests':
       return Object.values(state.projectData.quests)
         .sort((a, b) => a.id - b.id)

--- a/src/utils/buildCreaturesListByDexOrder.ts
+++ b/src/utils/buildCreaturesListByDexOrder.ts
@@ -1,0 +1,17 @@
+import { State } from '@src/GlobalStateProvider';
+import { cloneEntity } from './cloneEntity';
+
+export const buildCreaturesListByDexOrder = (state: State) => {
+  const allPokemon = state.projectData.pokemon;
+  const creaturesFromDex = cloneEntity(state.projectData.dex['national'].creatures)
+    .filter(({ dbSymbol }) => allPokemon[dbSymbol] !== undefined)
+    .map((creature) => ({ dbSymbol: creature.dbSymbol, id: allPokemon[creature.dbSymbol].id }));
+  return Object.values(allPokemon)
+    .sort((a, b) => a.id - b.id)
+    .reduce((prev, creature) => {
+      // If the creature doesn't exist in the national dex, it is added at the end of the list
+      if (prev.find(({ dbSymbol }) => dbSymbol === creature.dbSymbol)) return prev;
+
+      return [...prev, { dbSymbol: creature.dbSymbol, id: allPokemon[creature.dbSymbol].id }];
+    }, creaturesFromDex);
+};

--- a/src/utils/buildCreaturesListByDexOrder.ts
+++ b/src/utils/buildCreaturesListByDexOrder.ts
@@ -3,7 +3,12 @@ import { cloneEntity } from './cloneEntity';
 
 export const buildCreaturesListByDexOrder = (state: State) => {
   const allPokemon = state.projectData.pokemon;
-  const creaturesFromDex = cloneEntity(state.projectData.dex['national'].creatures)
+  const nationalDex = state.projectData.dex['national'];
+  if (!nationalDex) {
+    return Object.values(allPokemon).sort((a, b) => a.id - b.id);
+  }
+
+  const creaturesFromDex = cloneEntity(nationalDex.creatures)
     .filter(({ dbSymbol }) => allPokemon[dbSymbol] !== undefined)
     .map((creature) => ({ dbSymbol: creature.dbSymbol, id: allPokemon[creature.dbSymbol].id }));
   return Object.values(allPokemon)

--- a/src/views/components/database/pokemon/PokemonControlBar.tsx
+++ b/src/views/components/database/pokemon/PokemonControlBar.tsx
@@ -5,7 +5,7 @@ import { ControlBar, ControlBarButtonContainer, ControlBarLabelContainer } from 
 import { useTranslation } from 'react-i18next';
 import { useSetCurrentDatabasePath } from '@hooks/useSetCurrentDatabasePage';
 import { PokemonDialogRef } from './editors/PokemonEditorOverlay';
-import { useProjectPokemon } from '@hooks/useProjectData';
+import { getNextDbSymbolByDexOrder, getPreviousDbSymbolByDexOrder, useProjectPokemon } from '@hooks/useProjectData';
 import { StudioShortcutActions, useShortcut } from '@hooks/useShortcuts';
 import { SelectPokemon } from '@components/selects/SelectPokemon';
 import { SelectPokemonForm } from '@components/selects/SelectPokemonForm';
@@ -22,7 +22,7 @@ type Props = {
 export const PokemonControlBar = ({ dialogsRef, setEvolutionIndex }: Props) => {
   useSetCurrentDatabasePath();
   const { t } = useTranslation(['database_pokemon']);
-  const { selectedDataIdentifier: currentPokemon, setSelectedDataIdentifier, getPreviousDbSymbol, getNextDbSymbol } = useProjectPokemon();
+  const { selectedDataIdentifier: currentPokemon, setSelectedDataIdentifier, state } = useProjectPokemon();
   const shortcutMap = useMemo<StudioShortcutActions>(() => {
     const isShortcutEnabled = () => dialogsRef?.current?.currentDialog === undefined;
 
@@ -30,12 +30,12 @@ export const PokemonControlBar = ({ dialogsRef, setEvolutionIndex }: Props) => {
       db_previous: () => {
         if (!isShortcutEnabled()) return;
         if (setEvolutionIndex) setEvolutionIndex(0);
-        setSelectedDataIdentifier({ pokemon: { specie: getPreviousDbSymbol('id'), form: 0 } });
+        setSelectedDataIdentifier({ pokemon: { specie: getPreviousDbSymbolByDexOrder(currentPokemon.specie, state), form: 0 } });
       },
       db_next: () => {
         if (!isShortcutEnabled()) return;
         if (setEvolutionIndex) setEvolutionIndex(0);
-        setSelectedDataIdentifier({ pokemon: { specie: getNextDbSymbol('id'), form: 0 } });
+        setSelectedDataIdentifier({ pokemon: { specie: getNextDbSymbolByDexOrder(currentPokemon.specie, state), form: 0 } });
       },
       db_new: () => isShortcutEnabled() && dialogsRef?.current?.openDialog('new'),
     };


### PR DESCRIPTION
## Description

This PR changes the creature select for following the national dex order.
If the creature doesn't exist in the national dex, it is added to the end of the list so all the creatures are available.
The shortcut has also been updated to follow the new order.

Closes #320 

## Tests to perform

- [x] Check that the creature select follows the national dex order
- [x] Check that if you edit the national dex, the creature select is updated.
- [x] Check that the shortchut works correctly