### PR TITLE
Fix an issue with the translation of the creature form name

### DIFF
--- a/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
+++ b/src/views/components/database/pokemon/editors/InformationEditor/TranslatableFormTextFields.tsx
@@ -7,13 +7,7 @@ import {
   StudioCreature,
   StudioCreatureForm,
 } from '@modelEntities/creature';
-import {
-  useCopyProjectText,
-  useGetCreatureFormDescriptionText,
-  useGetCreatureFormNameText,
-  useGetEntityDescriptionText,
-  useSetProjectText,
-} from '@utils/ReadingProjectText';
+import { useCopyProjectText, useGetCreatureFormDescriptionText, useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TranslationEditorTitle } from '../CreatureTranslationOverlay';
 import { useTranslation } from 'react-i18next';
@@ -23,16 +17,16 @@ import { SecondaryButton } from '@components/buttons';
 type TranslatableFormTextFieldsProps = {
   creature: StudioCreature;
   form: StudioCreatureForm;
+  formName: string;
   handleTranslateClick: (editorTitle: TranslationEditorTitle) => () => void;
 };
 
 export const TranslatableFormTextFields = forwardRef<TranslatableTextFieldsRef, TranslatableFormTextFieldsProps>(
-  ({ creature, form, handleTranslateClick }, ref) => {
+  ({ creature, form, formName, handleTranslateClick }, ref) => {
     const { t } = useTranslation('database_pokemon');
     const nameRef = useRef<HTMLInputElement>(null);
     const descriptionRef = useRef<HTMLTextAreaElement>(null);
     const getCreatureDescription = useGetEntityDescriptionText();
-    const getCreatureFormName = useGetCreatureFormNameText();
     const getCreatureFormDescription = useGetCreatureFormDescriptionText();
     const setText = useSetProjectText();
     const copyProjectText = useCopyProjectText();
@@ -49,7 +43,7 @@ export const TranslatableFormTextFields = forwardRef<TranslatableTextFieldsRef, 
       nameRef.current.value = nameRef.current.defaultValue;
       descriptionRef.current.value = descriptionRef.current.defaultValue;
     };
-    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [form]);
+    useImperativeHandle(ref, () => ({ saveTexts, onTranslationOverlayClose }), [creature, form, formName]);
 
     const onClickUseBaseDescription = () => {
       const defaultForm = creature.forms.find((form) => form.form === 0);
@@ -69,14 +63,7 @@ export const TranslatableFormTextFields = forwardRef<TranslatableTextFieldsRef, 
         <InputWithTopLabelContainer>
           <Label required>{t('form_name')}</Label>
           <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_form_name')}>
-            <Input
-              type="text"
-              name="form_name"
-              defaultValue={getCreatureFormName(form)}
-              ref={nameRef}
-              placeholder={t('example_form_name')}
-              required
-            />
+            <Input type="text" name="form_name" defaultValue={formName} ref={nameRef} placeholder={t('example_form_name')} required />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer style={{ display: form.form !== 0 ? 'flex' : 'none' }}>

--- a/src/views/components/database/pokemon/editors/InformationsEditor.tsx
+++ b/src/views/components/database/pokemon/editors/InformationsEditor.tsx
@@ -25,7 +25,7 @@ const OffsetInfo = styled.div`
 export const InformationsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_pokemon');
   const dialogsRef = useDialogsRef<TranslationEditorTitle>();
-  const { creature, form, creatureName } = useCreaturePage();
+  const { creature, form, creatureName, formName } = useCreaturePage();
   const updateForm = useUpdateForm(creature, form);
   const tTFR = useRef<TranslatableTextFieldsRef>(null);
   const formTTFR = useRef<TranslatableTextFieldsRef>(null);
@@ -62,7 +62,7 @@ export const InformationsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
         {form.form === 0 && (
           <TranslatableTextFields ref={tTFR} handleTranslateClick={handleTranslateClick} creature={creature} creatureName={creatureName} />
         )}
-        <TranslatableFormTextFields ref={formTTFR} handleTranslateClick={handleTranslateClick} creature={creature} form={form} />
+        <TranslatableFormTextFields ref={formTTFR} handleTranslateClick={handleTranslateClick} creature={creature} form={form} formName={formName} />
         <TypeFields form={form} defaults={defaults} />
         <InputWithTopLabelContainer>
           <Input name="frontOffsetY" label={t('offset')} labelLeft onInput={onInputTouched} />


### PR DESCRIPTION
## Description

This PR fixes an issue with the translation of the creatures form name, which can not update correctly in particular circumstance.

## How reproduce

In Pokémon page :
- Open editor (click on PokemonFrame)
- Open the advanced translation editor for the form name
- Edit the French text
- Close the advanced translation editor
- Change the French text back to the value before opening the editor
- Close the editor

Note: Here I've tested with French language but it's not linked to any particular language.

## Tests to perform

- [x] The creature form name is correctly updated
