### PR TITLE
Fix the add evolutions Dex button that now properly fallback on an existing form

### DIFF
--- a/src/utils/dex.ts
+++ b/src/utils/dex.ts
@@ -53,8 +53,11 @@ export const searchUnderAndEvolutions = (
     return dexCreatures;
   }
 
+  // If the form is unavailable, the baby form take the last one form available
+  const formIsAvailable = allPokemon[pokemonForm.babyDbSymbol]?.forms.length === pokemonForm.babyForm + 1;
+  const babyForm = formIsAvailable ? pokemonForm.babyForm : allPokemon[pokemonForm.babyDbSymbol]?.forms.length - 1;
   // search the evolutions from the baby
-  const babyDexCreature = { dbSymbol: babyDbSymbol, form: pokemonForm.babyForm };
+  const babyDexCreature = { dbSymbol: babyDbSymbol, form: babyForm };
   const dexCreatures = searchEvolutionPokemon(babyDexCreature, allPokemon, []);
   const numberOfEvolutions = dexCreatures.length;
   dexCreatures.unshift(babyDexCreature);

--- a/src/utils/dex.ts
+++ b/src/utils/dex.ts
@@ -55,7 +55,7 @@ export const searchUnderAndEvolutions = (
 
   // If the form is unavailable, the baby form take the last one form available
   const formIsAvailable = allPokemon[pokemonForm.babyDbSymbol]?.forms.length === pokemonForm.babyForm + 1;
-  const babyForm = formIsAvailable ? pokemonForm.babyForm : allPokemon[pokemonForm.babyDbSymbol]?.forms.length - 1;
+  const babyForm = formIsAvailable ? pokemonForm.babyForm : allPokemon[pokemonForm.babyDbSymbol]?.forms[0].form;
   // search the evolutions from the baby
   const babyDexCreature = { dbSymbol: babyDbSymbol, form: babyForm };
   const dexCreatures = searchEvolutionPokemon(babyDexCreature, allPokemon, []);


### PR DESCRIPTION
[Ticket 404](https://github.com/PokemonWorkshop/PokemonStudio/issues/404)

Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Make Studio fallback to the lastest form is the evolution one does not exists.

## Note before testing

<!-- Optional but can be useful if the tester has to update a lib for example. -->

## Tests to perform

1. Make a new Pokédex
2. Add a form 1 Pokémon whose pre-evolution is a form 0. See Alolan Marowak on the Technical Demo. Enable the "add evolutions" toggle".
3. See the pre-evolution with no types. Editing the Pokémon's data shows "Deleted form", matching its evolution form 1.