### PR TITLE
Implement the trainer additional dialogs

### DIFF
--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -77,5 +77,12 @@
   "bgm_music": "Battle music",
   "character_v3_message": "The character will be used from version 3.0 of the application.",
   "no_trainers_available": "No trainers available for import !",
-  "change_order_info": "You can change the order of the Pokémon in this trainer's party.\n\nThis action has an impact on the money given to the player by this trainer."
+  "change_order_info": "You can change the order of the Pokémon in this trainer's party.\n\nThis action has an impact on the money given to the player by this trainer.",
+  "condition": "Condition:",
+  "additional_dialog_before_creature_send": "Before creature send",
+  "additional_dialog_after_creature_send": "After creature send",
+  "additional_dialog_after_all_actions_choices": "After all actions choices",
+  "additional_dialog_after_attack_action": "After Attack action",
+  "additional_dialog_after_all_turn_actions": "After all turn actions",
+  "additional_dialog_end_of_battle_turn": "At the end of a battle turn"
 }

--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -89,5 +89,6 @@
   "condition_appearance": "Condition of appearance",
   "sentence_spoken": "Sentence spoken",
   "delete_dialog": "Delete this dialog",
-  "max_dialog": "You cannot create more dialogs"
+  "max_dialog": "You cannot create more dialogs",
+  "no_sentence": "No text provided"
 }

--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -87,5 +87,7 @@
   "additional_dialog_end_of_battle_turn": "At the end of a battle turn",
   "default_dialogs": "Default dialogs",
   "condition_appearance": "Condition of appearance",
-  "sentence_spoken": "Sentence spoken"
+  "sentence_spoken": "Sentence spoken",
+  "delete_dialog": "Delete this dialog",
+  "max_dialog": "You cannot create more dialogs"
 }

--- a/assets/i18n/en/database_trainers.json
+++ b/assets/i18n/en/database_trainers.json
@@ -84,5 +84,8 @@
   "additional_dialog_after_all_actions_choices": "After all actions choices",
   "additional_dialog_after_attack_action": "After Attack action",
   "additional_dialog_after_all_turn_actions": "After all turn actions",
-  "additional_dialog_end_of_battle_turn": "At the end of a battle turn"
+  "additional_dialog_end_of_battle_turn": "At the end of a battle turn",
+  "default_dialogs": "Default dialogs",
+  "condition_appearance": "Condition of appearance",
+  "sentence_spoken": "Sentence spoken"
 }

--- a/assets/i18n/en/editor.json
+++ b/assets/i18n/en/editor.json
@@ -20,6 +20,7 @@
   "translation_class": "Class of {{name}}",
   "translation_victory": "Victory of {{name}}",
   "translation_defeat": "Defeat of {{name}}",
+  "translation_additional_dialog": "Scripted dialog of {{name}}",
   "translation_name_plural": "Plural name of {{name}}",
   "translation_form_name": "Form name of {{name}}",
   "translation_form_description": "Form description of {{name}}"

--- a/assets/i18n/en/migration.json
+++ b/assets/i18n/en/migration.json
@@ -11,5 +11,6 @@
   "update_creatures_after_zod_change": "Update creatures values after change in the values authorized",
   "update_creatures_to_manage_form": "Update creatures and create CSV files to manage form names and descriptions",
   "migrate_natures": "Migrate natures config to nature entities",
-  "migrate_breeding_group": "Migrate undefined breeding group to unknown breeding group"
+  "migrate_breeding_group": "Migrate undefined breeding group to unknown breeding group",
+  "add_trainer_additional_dialogs": "Additional dialogue added for trainers"
 }

--- a/assets/i18n/fr/database_trainers.json
+++ b/assets/i18n/fr/database_trainers.json
@@ -87,5 +87,7 @@
   "additional_dialog_end_of_battle_turn": "À la fin du tour",
   "default_dialogs": "Dialogues par défaut",
   "condition_appearance": "Condition d'apparition",
-  "sentence_spoken": "Phrase prononcée"
+  "sentence_spoken": "Phrase prononcée",
+  "delete_dialog": "Supprimer ce dialogue",
+  "max_dialog": "Vous ne pouvez pas créer de dialogues supplémentaires"
 }

--- a/assets/i18n/fr/database_trainers.json
+++ b/assets/i18n/fr/database_trainers.json
@@ -77,5 +77,12 @@
   "bgm_music": "Musique de combat",
   "character_v3_message": "Le character sera utilisé à partir de la version 3.0 de l'application.",
   "no_trainers_available": "Aucun dresseur n'est disponible à l'import !",
-  "change_order_info": "Vous pouvez changer l’ordre des Pokémon de l‘équipe de ce dresseur.\n\nCette action a un impact sur l’argent donné au joueur par ce dresseur."
+  "change_order_info": "Vous pouvez changer l’ordre des Pokémon de l‘équipe de ce dresseur.\n\nCette action a un impact sur l’argent donné au joueur par ce dresseur.",
+  "condition": "Condition :",
+  "additional_dialog_before_creature_send": "Avant l’envoi des créatures",
+  "additional_dialog_after_creature_send": "Après l’envoi des créatures",
+  "additional_dialog_after_all_actions_choices": "Après la sélection de toutes les actions",
+  "additional_dialog_after_attack_action": "Après l’exécution d’une attaque",
+  "additional_dialog_after_all_turn_actions": "À la fin de toutes les actions d’un tour",
+  "additional_dialog_end_of_battle_turn": "À la fin du tour"
 }

--- a/assets/i18n/fr/database_trainers.json
+++ b/assets/i18n/fr/database_trainers.json
@@ -84,5 +84,8 @@
   "additional_dialog_after_all_actions_choices": "Après la sélection de toutes les actions",
   "additional_dialog_after_attack_action": "Après l’exécution d’une attaque",
   "additional_dialog_after_all_turn_actions": "À la fin de toutes les actions d’un tour",
-  "additional_dialog_end_of_battle_turn": "À la fin du tour"
+  "additional_dialog_end_of_battle_turn": "À la fin du tour",
+  "default_dialogs": "Dialogues par défaut",
+  "condition_appearance": "Condition d'apparition",
+  "sentence_spoken": "Phrase prononcée"
 }

--- a/assets/i18n/fr/database_trainers.json
+++ b/assets/i18n/fr/database_trainers.json
@@ -89,5 +89,6 @@
   "condition_appearance": "Condition d'apparition",
   "sentence_spoken": "Phrase prononcée",
   "delete_dialog": "Supprimer ce dialogue",
-  "max_dialog": "Vous ne pouvez pas créer de dialogues supplémentaires"
+  "max_dialog": "Vous ne pouvez pas créer de dialogues supplémentaires",
+  "no_sentence": "Aucun texte renseigné"
 }

--- a/assets/i18n/fr/editor.json
+++ b/assets/i18n/fr/editor.json
@@ -20,6 +20,7 @@
   "translation_class": "Classe de {{name}}",
   "translation_victory": "Victoire de {{name}}",
   "translation_defeat": "Défaite de {{name}}",
+  "translation_additional_dialog": "Dialogue scénarisé de {{name}}",
   "translation_name_plural": "Nom au pluriel de {{name}}",
   "translation_form_name": "Nom de la forme de {{name}}",
   "translation_form_description": "Description de la forme de {{name}}"

--- a/assets/i18n/fr/migration.json
+++ b/assets/i18n/fr/migration.json
@@ -11,5 +11,6 @@
   "update_creatures_after_zod_change": "Mise à jour des données des créatures après la mise à jour des valeurs autorisées",
   "update_creatures_to_manage_form": "Mise à jour des créatures et création de fichiers CSV pour gérer les noms et descriptions des formes des créatures",
   "migrate_natures": "Migration des natures",
-  "migrate_breeding_group": "Migration du groupe d'œuf «\u00a0Non défini\u00a0» en «\u00a0Inconnu\u00a0»"
+  "migrate_breeding_group": "Migration du groupe d'œuf «\u00a0Non défini\u00a0» en «\u00a0Inconnu\u00a0»",
+  "add_trainer_additional_dialogs": "Ajout des dialogues additionnels pour les dresseurs"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/backendTasks/migrateData.ts
+++ b/src/backendTasks/migrateData.ts
@@ -18,7 +18,7 @@ export type MigrateDataOutput = { projectStudio: StudioProject };
 const migrateData = async (payload: MigrateDataInput, event: IpcMainEvent, channels: ChannelNames) => {
   log.info('migrate-data', `Current project version: ${payload.projectVersion}`);
 
-  const migrationFound = MIGRATION_CONFIG.filter((migration) => migration.version.localeCompare(payload.projectVersion) === 1);
+  const migrationFound = MIGRATION_CONFIG.filter((migration) => migration.version.localeCompare(payload.projectVersion) !== -1);
   if (migrationFound.length > 0) {
     log.info('migrate-data', `Found ${migrationFound.length} migrations`);
     await migrationFound.reduce(async (prev, curr, index) => {

--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -167,6 +167,7 @@ export const useTrainerPage = () => {
   return {
     trainer,
     trainerName,
+    trainers,
     cannotDelete: Object.keys(trainers).length <= 1,
   };
 };

--- a/src/migrations/addTrainerAdditionalDialogs.ts
+++ b/src/migrations/addTrainerAdditionalDialogs.ts
@@ -1,0 +1,50 @@
+import { IpcMainEvent } from 'electron';
+import { deletePSDKDatFile } from './migrateUtils';
+import { TRAINER_VALIDATOR, StudioTrainer, TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, TRAINER_NAME_TEXT_ID } from '@modelEntities/trainer';
+import fsPromise from 'fs/promises';
+import path from 'path';
+import { z } from 'zod';
+import { readProjectFolder } from '@src/backendTasks/readProjectData';
+import { parseJSON } from '@utils/json/parse';
+import fs from 'fs';
+import { loadCSV, saveCSV } from '@utils/textManagement';
+
+const PRE_MIGRATION_TRAINER_VALIDATOR = TRAINER_VALIDATOR.omit({ additionalDialogs: true });
+type StudioTrainerDataBeforeMigration = z.infer<typeof PRE_MIGRATION_TRAINER_VALIDATOR>;
+
+const initCSVAdditionalDialogs = async (projectPath: string) => {
+  const csvPath = path.join(projectPath, 'Data/Text/Dialogs');
+  if (fs.existsSync(path.join(csvPath, `${TRAINER_ADDITIONAL_DIALOGS_TEXT_ID}.csv`))) {
+    throw new Error(`The file ${TRAINER_ADDITIONAL_DIALOGS_TEXT_ID}.csv already exists. Please rename your file.`);
+  }
+
+  const trainerNames = await loadCSV(path.join(csvPath, `${TRAINER_NAME_TEXT_ID}.csv`));
+  const header = trainerNames[0];
+  saveCSV(path.join(csvPath, `${TRAINER_ADDITIONAL_DIALOGS_TEXT_ID}.csv`), [header]);
+};
+
+const addAdditionalDialogs = (trainer: StudioTrainerDataBeforeMigration): StudioTrainer => {
+  return {
+    ...trainer,
+    additionalDialogs: [],
+  };
+};
+
+export const addTrainerAdditionalDialogs = async (_: IpcMainEvent, projectPath: string) => {
+  deletePSDKDatFile(projectPath);
+
+  await initCSVAdditionalDialogs(projectPath);
+
+  const trainers = await readProjectFolder(projectPath, 'trainers');
+  await trainers.reduce(async (lastPromise, trainer) => {
+    await lastPromise;
+    const trainerParsed = PRE_MIGRATION_TRAINER_VALIDATOR.safeParse(parseJSON(trainer.data, trainer.filename));
+    if (trainerParsed.success) {
+      const trainerUpdated = addAdditionalDialogs(trainerParsed.data);
+      return fsPromise.writeFile(
+        path.join(projectPath, 'Data/Studio/trainers', `${trainerUpdated.dbSymbol}.json`),
+        JSON.stringify(trainerUpdated, null, 2)
+      );
+    }
+  }, Promise.resolve());
+};

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -12,6 +12,7 @@ import { fixCreatureValuesAfterZodChange } from './fixCreatureValuesAfterZodChan
 import { addFormNamesDescriptions } from './addFormNamesDescriptions';
 import { migrateNaturesToEntities } from './migrateNaturesToEntities';
 import { migrateUndefinedBreedingGroupToUnknown } from './migrateUndefinedBreedingGroupToUnknown';
+import { addTrainerAdditionalDialogs } from './addTrainerAdditionalDialogs';
 
 type MigrateConfigType = {
   migration: MigrationTask;
@@ -100,5 +101,10 @@ export const MIGRATION_CONFIG: MigrateConfigType[] = [
     migration: migrateUndefinedBreedingGroupToUnknown,
     version: '2.3.0',
     message: 'migrate_breeding_group',
+  },
+  {
+    migration: addTrainerAdditionalDialogs,
+    version: '2.4.0',
+    message: 'add_trainer_additional_dialogs',
   },
 ];

--- a/src/models/entities/trainer.ts
+++ b/src/models/entities/trainer.ts
@@ -64,6 +64,18 @@ export const TRAINER_VICTORY_SENTENCE_TEXT_ID = 100047;
 export const TRAINER_DEFEAT_SENTENCE_TEXT_ID = 100048;
 export const TRAINER_ADDITIONAL_DIALOGS_TEXT_ID = 100069;
 
+export const TRAINER_AI_CATEGORIES = ['basic', 'regular', 'medium', 'hard', 'lieutenant', 'gym_leader', 'champion'] as const;
+export const TRAINER_VS_TYPE_CATEGORIES = [1, 2] as const;
+export const TRAINER_ADDITIONAL_DIALOGS_CONDITION = [
+  'before_creature_send',
+  'after_creature_send',
+  'after_all_actions_choices',
+  'after_attack_action',
+  'after_all_turn_actions',
+  'end_of_battle_turn',
+] as const;
+export type TrainerAdditionalDialogsCondition = (typeof TRAINER_ADDITIONAL_DIALOGS_CONDITION)[number];
+
 export const getTrainerMoney = (trainer: StudioTrainer) => {
   if (trainer.party.length === 0 || isNaN(trainer.baseMoney)) return 0;
 
@@ -72,9 +84,6 @@ export const getTrainerMoney = (trainer: StudioTrainer) => {
   if (lastLevel.kind === 'fixed') return trainer.baseMoney * lastLevel.level;
   return trainer.baseMoney * lastLevel.level.maximumLevel;
 };
-
-export const TRAINER_AI_CATEGORIES = ['basic', 'regular', 'medium', 'hard', 'lieutenant', 'gym_leader', 'champion'] as const;
-export const TRAINER_VS_TYPE_CATEGORIES = [1, 2] as const;
 
 export const updatePartyTrainerName = (trainer: StudioTrainer, name: string) => {
   trainer.party.forEach((encounter) => {

--- a/src/models/entities/trainer.ts
+++ b/src/models/entities/trainer.ts
@@ -29,6 +29,19 @@ export const TRAINER_RESOURCES_VALIDATOR = z.object({
 });
 export type StudioTrainerResources = z.infer<typeof TRAINER_RESOURCES_VALIDATOR>;
 
+export const TRAINER_ADDITIONAL_DIALOGS_VALIDATOR = z.object({
+  condition: z.union([
+    z.literal('before_creature_send'),
+    z.literal('after_creature_send'),
+    z.literal('after_all_actions_choices'),
+    z.literal('after_attack_action'),
+    z.literal('after_all_turn_actions'),
+    z.literal('end_of_battle_turn'),
+  ]),
+  textId: POSITIVE_OR_ZERO_INT,
+});
+export type StudioTrainerAdditionalDialogs = z.infer<typeof TRAINER_ADDITIONAL_DIALOGS_VALIDATOR>;
+
 export const TRAINER_VALIDATOR = z.object({
   klass: z.literal('TrainerBattleSetup'),
   id: POSITIVE_OR_ZERO_INT,
@@ -41,6 +54,7 @@ export const TRAINER_VALIDATOR = z.object({
   ai: POSITIVE_OR_ZERO_INT.default(1),
   party: z.array(ENCOUNTER_VALIDATOR),
   resources: TRAINER_RESOURCES_VALIDATOR,
+  additionalDialogs: z.array(TRAINER_ADDITIONAL_DIALOGS_VALIDATOR),
 });
 export type StudioTrainer = z.infer<typeof TRAINER_VALIDATOR>;
 
@@ -48,6 +62,8 @@ export const TRAINER_CLASS_TEXT_ID = 100029;
 export const TRAINER_NAME_TEXT_ID = 100062;
 export const TRAINER_VICTORY_SENTENCE_TEXT_ID = 100047;
 export const TRAINER_DEFEAT_SENTENCE_TEXT_ID = 100048;
+export const TRAINER_ADDITIONAL_DIALOGS_TEXT_ID = 100069;
+
 export const getTrainerMoney = (trainer: StudioTrainer) => {
   if (trainer.party.length === 0 || isNaN(trainer.baseMoney)) return 0;
 
@@ -56,8 +72,10 @@ export const getTrainerMoney = (trainer: StudioTrainer) => {
   if (lastLevel.kind === 'fixed') return trainer.baseMoney * lastLevel.level;
   return trainer.baseMoney * lastLevel.level.maximumLevel;
 };
+
 export const TRAINER_AI_CATEGORIES = ['basic', 'regular', 'medium', 'hard', 'lieutenant', 'gym_leader', 'champion'] as const;
 export const TRAINER_VS_TYPE_CATEGORIES = [1, 2] as const;
+
 export const updatePartyTrainerName = (trainer: StudioTrainer, name: string) => {
   trainer.party.forEach((encounter) => {
     encounter.expandPokemonSetup.forEach((expandPokemonSetup) => {
@@ -65,6 +83,7 @@ export const updatePartyTrainerName = (trainer: StudioTrainer, name: string) => 
     });
   });
 };
+
 export const reduceBagEntries = (trainerBagEntries: StudioTrainerBagEntry[]) => {
   const bagEntries: StudioTrainerBagEntry[] = [];
   trainerBagEntries.forEach((bagEntry) => {

--- a/src/utils/ModelUtils.ts
+++ b/src/utils/ModelUtils.ts
@@ -1,12 +1,15 @@
 import { StudioTextInfo } from '@modelEntities/textInfo';
+import { StudioTrainerAdditionalDialogs } from '@modelEntities/trainer';
 import { ProjectData } from '@src/GlobalStateProvider';
 
 /**
  * Find the first available text id
- * @param allData The project data containing the abilities or types
+ * @param allData The project data containing the abilities, types or a textId
  * @returns The text id
  */
-export const findFirstAvailableTextId = (allData: ProjectData['abilities'] | ProjectData['types'] | StudioTextInfo[]) => {
+export const findFirstAvailableTextId = (
+  allData: ProjectData['abilities'] | ProjectData['types'] | StudioTextInfo[] | StudioTrainerAdditionalDialogs[]
+) => {
   const textIdSet = Object.values(allData)
     .map(({ textId }) => textId) // Fetch all ids
     .filter((textId, index, array) => index === array.indexOf(textId)) // reject all duplicates

--- a/src/utils/ReadingProjectText.ts
+++ b/src/utils/ReadingProjectText.ts
@@ -23,6 +23,7 @@ import { MAP_DESCRIPTION_TEXT_ID, MAP_NAME_TEXT_ID } from '@modelEntities/map';
 import { MAP_INFO_FOLDER_NAME_TEXT_ID } from '@modelEntities/mapInfo';
 import { cloneEntity } from './cloneEntity';
 import { NATURE_NAME_TEXT_ID } from '@modelEntities/nature';
+import { useEffect } from 'react';
 
 type KeyProjectText = keyof ProjectText;
 
@@ -60,7 +61,13 @@ export const getText = (projectText: TextsWithLanguageConfig, fileId: number, te
 };
 
 export const useGetProjectText = () => {
-  const [{ projectText: texts, projectConfig, projectStudio }] = useGlobalState();
+  const [{ projectText: texts, projectConfig, projectStudio, textVersion }] = useGlobalState();
+
+  useEffect(() => {
+    // Force the hook to refresh the texts when a text is updated (witchcraft)
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    texts;
+  }, [textVersion, texts]);
 
   return (fileId: number, textId: number): string =>
     getText(

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -350,6 +350,7 @@ export const createTrainer = (
       },
       sprite: '',
     },
+    additionalDialogs: [],
   };
 };
 

--- a/src/views/components/PaginationWithTitle.tsx
+++ b/src/views/components/PaginationWithTitle.tsx
@@ -17,6 +17,8 @@ const PaginationWithTitleContainer = styled.div`
     max-width: 196px;
     overflow: hidden;
     color: ${({ theme }) => theme.colors.text100};
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   & svg:hover {

--- a/src/views/components/database/trainer/TrainerDialog.tsx
+++ b/src/views/components/database/trainer/TrainerDialog.tsx
@@ -15,6 +15,11 @@ const TrainerDialogContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
+
+  & .separator {
+    height: 1px;
+    background-color: ${({ theme }) => theme.colors.dark18};
+  }
 `;
 
 type TrainerDialogProps = {
@@ -41,11 +46,12 @@ export const TrainerDialog = ({ trainer, dialogsRef }: TrainerDialogProps) => {
           data={defeatSentence !== '' ? `“${defeatSentence}”` : '---'}
           disabled={defeatSentence === ''}
         />
+        {trainer.additionalDialogs.length > 0 && <div className="separator" />}
         {trainer.additionalDialogs.map((additionalDialog, index) => {
           const additionalDialogText = getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, additionalDialog.textId);
           return (
             <DataFieldsetField
-              label={`${t('condition')} ${t(`additional_dialog_${additionalDialog.condition}`)}`}
+              label={t(`additional_dialog_${additionalDialog.condition}`)}
               data={additionalDialogText !== '' ? `“${additionalDialogText}”` : '---'}
               disabled={additionalDialogText === ''}
               key={`additional-dialog-${index}`}

--- a/src/views/components/database/trainer/TrainerDialog.tsx
+++ b/src/views/components/database/trainer/TrainerDialog.tsx
@@ -38,12 +38,12 @@ export const TrainerDialog = ({ trainer, dialogsRef }: TrainerDialogProps) => {
       <TrainerDialogContainer>
         <DataFieldsetField
           label={t('trainer_victory')}
-          data={victorySentence !== '' ? `“${victorySentence}”` : '---'}
+          data={victorySentence !== '' ? `“${victorySentence}”` : t('no_sentence')}
           disabled={victorySentence === ''}
         />
         <DataFieldsetField
           label={t('trainer_defeat')}
-          data={defeatSentence !== '' ? `“${defeatSentence}”` : '---'}
+          data={defeatSentence !== '' ? `“${defeatSentence}”` : t('no_sentence')}
           disabled={defeatSentence === ''}
         />
         {trainer.additionalDialogs.length > 0 && <div className="separator" />}
@@ -52,7 +52,7 @@ export const TrainerDialog = ({ trainer, dialogsRef }: TrainerDialogProps) => {
           return (
             <DataFieldsetField
               label={t(`additional_dialog_${additionalDialog.condition}`)}
-              data={additionalDialogText !== '' ? `“${additionalDialogText}”` : '---'}
+              data={additionalDialogText !== '' ? `“${additionalDialogText}”` : t('no_sentence')}
               disabled={additionalDialogText === ''}
               key={`additional-dialog-${index}`}
             />

--- a/src/views/components/database/trainer/TrainerDialog.tsx
+++ b/src/views/components/database/trainer/TrainerDialog.tsx
@@ -3,7 +3,12 @@ import { DataBlockWithTitle, DataFieldsetField } from '../dataBlocks';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useGetProjectText } from '@utils/ReadingProjectText';
-import { StudioTrainer, TRAINER_DEFEAT_SENTENCE_TEXT_ID, TRAINER_VICTORY_SENTENCE_TEXT_ID } from '@modelEntities/trainer';
+import {
+  StudioTrainer,
+  TRAINER_ADDITIONAL_DIALOGS_TEXT_ID,
+  TRAINER_DEFEAT_SENTENCE_TEXT_ID,
+  TRAINER_VICTORY_SENTENCE_TEXT_ID,
+} from '@modelEntities/trainer';
 import { TrainerDialogsRef } from './editors/TrainerEditorOverlay';
 
 const TrainerDialogContainer = styled.div`
@@ -36,6 +41,17 @@ export const TrainerDialog = ({ trainer, dialogsRef }: TrainerDialogProps) => {
           data={defeatSentence !== '' ? `“${defeatSentence}”` : '---'}
           disabled={defeatSentence === ''}
         />
+        {trainer.additionalDialogs.map((additionalDialog, index) => {
+          const additionalDialogText = getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, additionalDialog.textId);
+          return (
+            <DataFieldsetField
+              label={`${t('condition')} ${t(`additional_dialog_${additionalDialog.condition}`)}`}
+              data={additionalDialogText !== '' ? `“${additionalDialogText}”` : '---'}
+              disabled={additionalDialogText === ''}
+              key={`additional-dialog-${index}`}
+            />
+          );
+        })}
       </TrainerDialogContainer>
     </DataBlockWithTitle>
   );

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -134,7 +134,7 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
         <SubEditorContainer>
           <SubEditorSeparator parentEditorHasScrollBar />
           <Editor type="creation" title={t('scripted_dialog')}>
-            <TooltipWrapper data-tooltip={t('available_future_release')}>
+            <TooltipWrapper data-tooltip={!canAddDialog ? t('available_future_release') : undefined}>
               <SecondaryButtonWithPlusIcon disabled={!canAddDialog} onClick={addDialog}>
                 {t('new_dialog')}
               </SecondaryButtonWithPlusIcon>

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -35,18 +35,8 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_trainers');
   const { trainer } = useTrainerPage();
   const updateTrainer = useUpdateTrainer(trainer);
-  const {
-    dialogs,
-    currentDialog,
-    dialogIndex,
-    canAddDialog,
-    defaultSentence,
-    conditionOptions,
-    updateDialogIndex,
-    addDialog,
-    deleteDialog,
-    changeCondition,
-  } = useTrainerDialog();
+  const { dialogs, currentDialog, dialogIndex, canAddDialog, conditionOptions, updateDialogIndex, addDialog, deleteDialog, changeCondition } =
+    useTrainerDialog();
   const dialogsRef = useDialogsRef<TrainerTranslationEditorTitle>();
   const getText = useGetProjectText();
   const setText = useSetProjectText();
@@ -136,7 +126,12 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               <InputWithTopLabelContainer>
                 <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
                 <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
-                  <MultiLineInput id="sentence" defaultValue={defaultSentence} ref={sentenceRef} key={`sentence-${dialogIndex}`} />
+                  <MultiLineInput
+                    id="sentence"
+                    defaultValue={getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId)}
+                    ref={sentenceRef}
+                    key={`sentence-${dialogIndex}`}
+                  />
                 </TranslateInputContainer>
               </InputWithTopLabelContainer>
             </PaddedInputContainer>

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Editor, EditorWithPagination } from '@components/editor';
 import { EditorChildWithSubEditorContainer, SubEditorContainer, SubEditorSeparator } from '@components/editor/EditorContainer';
@@ -6,33 +6,63 @@ import { SecondaryButtonWithPlusIcon } from '@components/buttons';
 import { InputWithTopLabelContainer, Label, MultiLineInput, PaddedInputContainer } from '@components/inputs';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
-import { TRAINER_DEFEAT_SENTENCE_TEXT_ID, TRAINER_VICTORY_SENTENCE_TEXT_ID } from '@modelEntities/trainer';
+import {
+  StudioTrainerAdditionalDialogs,
+  TRAINER_ADDITIONAL_DIALOGS_CONDITION,
+  TRAINER_ADDITIONAL_DIALOGS_TEXT_ID,
+  TRAINER_DEFEAT_SENTENCE_TEXT_ID,
+  TRAINER_VICTORY_SENTENCE_TEXT_ID,
+} from '@modelEntities/trainer';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useTrainerPage } from '@hooks/usePage';
 import { useDialogsRef } from '@hooks/useDialogsRef';
 import { TrainerTranslationEditorTitle, TrainerTranslationOverlay } from './TrainerTranslationOverlay';
 import { TooltipWrapper } from '@ds/Tooltip';
+import { PaginationWithTitleProps } from '@components/PaginationWithTitle';
+import { useTrainerDialog } from './useTrainerDialog';
+import { TFunction } from 'i18next';
+import { Select } from '@ds/Select';
+import { useUpdateTrainer } from './useUpdateTrainer';
+
+const dialogConditionEntries = (t: TFunction<'database_trainers'>) =>
+  TRAINER_ADDITIONAL_DIALOGS_CONDITION.map((condition) => ({ value: condition.toString(), label: t(`additional_dialog_${condition}`) }));
 
 export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_trainers');
   const { trainer } = useTrainerPage();
+  const updateTrainer = useUpdateTrainer(trainer);
+  const { dialogs, currentDialog, dialogCount, dialogIndex, canAddDialog, setDialogIndex, addDialog, deleteDialog, changeCondition } =
+    useTrainerDialog();
   const dialogsRef = useDialogsRef<TrainerTranslationEditorTitle>();
   const getText = useGetProjectText();
   const setText = useSetProjectText();
+  const dialogConditionOptions = useMemo(() => dialogConditionEntries(t), [t]);
   const victoryRef = useRef<HTMLTextAreaElement>(null);
   const defeatRef = useRef<HTMLTextAreaElement>(null);
+  const sentenceRef = useRef<HTMLTextAreaElement>(null);
 
   const saveTexts = () => {
-    if (!victoryRef.current || !defeatRef.current) return;
+    if (victoryRef.current && defeatRef.current) {
+      setText(TRAINER_VICTORY_SENTENCE_TEXT_ID, trainer.id, victoryRef.current.value);
+      setText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, trainer.id, defeatRef.current.value);
+    }
+    if (sentenceRef.current) setText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId, sentenceRef.current.value);
+  };
 
-    setText(TRAINER_VICTORY_SENTENCE_TEXT_ID, trainer.id, victoryRef.current.value);
-    setText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, trainer.id, defeatRef.current.value);
+  const onChangeIndex = (arrow: 'left' | 'right') => {
+    if (arrow === 'left') {
+      if (dialogIndex > 0) setDialogIndex(dialogIndex - 1);
+    } else {
+      if (dialogIndex < dialogCount - 1) setDialogIndex(dialogIndex + 1);
+    }
+    saveTexts();
   };
 
   const onClose = () => {
-    if (!victoryRef.current || !defeatRef.current) return;
-
     saveTexts();
+    updateTrainer({
+      additionalDialogs: dialogs.filter(({ condition }) => condition !== 'default') as StudioTrainerAdditionalDialogs[],
+    });
   };
   useEditorHandlingClose(ref, onClose);
 
@@ -42,51 +72,77 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
 
   const onTranslationOverlayClose = () => {
-    if (!victoryRef.current || !defeatRef.current) return;
+    if (victoryRef.current && defeatRef.current) {
+      victoryRef.current.value = victoryRef.current.defaultValue;
+      defeatRef.current.value = defeatRef.current.defaultValue;
+    }
+    if (sentenceRef.current) sentenceRef.current.value = sentenceRef.current.defaultValue;
+  };
 
-    victoryRef.current.value = victoryRef.current.defaultValue;
-    defeatRef.current.value = defeatRef.current.defaultValue;
+  const paginationProps: PaginationWithTitleProps = {
+    title: `${currentDialog.condition === 'default' ? t('default_dialogs') : t(`additional_dialog_${currentDialog.condition}`)}`,
+    onChangeIndex,
   };
 
   return (
-    <EditorWithPagination type="edit" title={t('dialogs')} paginationProps={undefined}>
+    <EditorWithPagination type="edit" title={t('dialogs')} paginationProps={dialogCount === 1 ? undefined : paginationProps}>
       <EditorChildWithSubEditorContainer>
-        <PaddedInputContainer>
-          <InputWithTopLabelContainer>
-            <Label htmlFor="victory">{t('trainer_victory')}</Label>
-            <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_victory')}>
-              <MultiLineInput
-                id="victory"
-                defaultValue={getText(TRAINER_VICTORY_SENTENCE_TEXT_ID, trainer.id)}
-                ref={victoryRef}
-                placeholder={t('example_victory_sentence')}
-              />
-            </TranslateInputContainer>
-          </InputWithTopLabelContainer>
-          <InputWithTopLabelContainer>
-            <Label htmlFor="defeat">{t('trainer_defeat')}</Label>
-            <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_defeat')}>
-              <MultiLineInput
-                id="defeat"
-                defaultValue={getText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, trainer.id)}
-                ref={defeatRef}
-                placeholder={t('example_defeat_sentence')}
-              />
-            </TranslateInputContainer>
-          </InputWithTopLabelContainer>
-        </PaddedInputContainer>
+        {currentDialog.condition === 'default' ? (
+          <PaddedInputContainer>
+            <InputWithTopLabelContainer>
+              <Label htmlFor="victory">{t('trainer_victory')}</Label>
+              <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_victory')}>
+                <MultiLineInput
+                  id="victory"
+                  defaultValue={getText(TRAINER_VICTORY_SENTENCE_TEXT_ID, trainer.id)}
+                  ref={victoryRef}
+                  placeholder={t('example_victory_sentence')}
+                />
+              </TranslateInputContainer>
+            </InputWithTopLabelContainer>
+            <InputWithTopLabelContainer>
+              <Label htmlFor="defeat">{t('trainer_defeat')}</Label>
+              <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_defeat')}>
+                <MultiLineInput
+                  id="defeat"
+                  defaultValue={getText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, trainer.id)}
+                  ref={defeatRef}
+                  placeholder={t('example_defeat_sentence')}
+                />
+              </TranslateInputContainer>
+            </InputWithTopLabelContainer>
+          </PaddedInputContainer>
+        ) : (
+          <PaddedInputContainer>
+            <InputWithTopLabelContainer>
+              <Label htmlFor="condition">{t('condition_appearance')}</Label>
+              <Select options={dialogConditionOptions} value={currentDialog.condition} onChange={changeCondition} />
+            </InputWithTopLabelContainer>
+            <InputWithTopLabelContainer>
+              <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
+              <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
+                <MultiLineInput
+                  id="sentence"
+                  defaultValue={getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId)}
+                  ref={sentenceRef}
+                  key={`sentence-${dialogIndex}`}
+                />
+              </TranslateInputContainer>
+            </InputWithTopLabelContainer>
+          </PaddedInputContainer>
+        )}
         <SubEditorContainer>
           <SubEditorSeparator parentEditorHasScrollBar />
           <Editor type="creation" title={t('scripted_dialog')}>
             <TooltipWrapper data-tooltip={t('available_future_release')}>
-              <SecondaryButtonWithPlusIcon disabled onClick={() => {}}>
+              <SecondaryButtonWithPlusIcon disabled={!canAddDialog} onClick={addDialog}>
                 {t('new_dialog')}
               </SecondaryButtonWithPlusIcon>
             </TooltipWrapper>
           </Editor>
         </SubEditorContainer>
       </EditorChildWithSubEditorContainer>
-      <TrainerTranslationOverlay trainer={trainer} onClose={onTranslationOverlayClose} ref={dialogsRef} />
+      <TrainerTranslationOverlay trainer={trainer} additionalDialog={currentDialog} onClose={onTranslationOverlayClose} ref={dialogsRef} />
     </EditorWithPagination>
   );
 });

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Editor, EditorWithPagination } from '@components/editor';
 import { EditorChildWithSubEditorContainer, SubEditorContainer, SubEditorSeparator } from '@components/editor/EditorContainer';
-import { SecondaryButtonWithPlusIcon } from '@components/buttons';
+import { DeleteButton, SecondaryButtonWithPlusIcon } from '@components/buttons';
 import { InputWithTopLabelContainer, Label, MultiLineInput, PaddedInputContainer } from '@components/inputs';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
@@ -23,16 +23,35 @@ import { useTrainerDialog } from './useTrainerDialog';
 import { TFunction } from 'i18next';
 import { Select } from '@ds/Select';
 import { useUpdateTrainer } from './useUpdateTrainer';
+import styled from 'styled-components';
 
 const dialogConditionEntries = (t: TFunction<'database_trainers'>) =>
   TRAINER_ADDITIONAL_DIALOGS_CONDITION.map((condition) => ({ value: condition.toString(), label: t(`additional_dialog_${condition}`) }));
+
+const InputWithDeleteButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  padding-bottom: 24px;
+`;
 
 export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_trainers');
   const { trainer } = useTrainerPage();
   const updateTrainer = useUpdateTrainer(trainer);
-  const { dialogs, currentDialog, dialogCount, dialogIndex, canAddDialog, setDialogIndex, addDialog, deleteDialog, changeCondition } =
-    useTrainerDialog();
+  const {
+    dialogs,
+    currentDialog,
+    dialogCount,
+    dialogIndex,
+    canAddDialog,
+    defaultSentence,
+    updateDialogIndex,
+    addDialog,
+    deleteDialog,
+    changeCondition,
+  } = useTrainerDialog();
   const dialogsRef = useDialogsRef<TrainerTranslationEditorTitle>();
   const getText = useGetProjectText();
   const setText = useSetProjectText();
@@ -51,9 +70,9 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
   const onChangeIndex = (arrow: 'left' | 'right') => {
     if (arrow === 'left') {
-      if (dialogIndex > 0) setDialogIndex(dialogIndex - 1);
+      if (dialogIndex > 0) updateDialogIndex(dialogIndex - 1);
     } else {
-      if (dialogIndex < dialogCount - 1) setDialogIndex(dialogIndex + 1);
+      if (dialogIndex < dialogCount - 1) updateDialogIndex(dialogIndex + 1);
     }
     saveTexts();
   };
@@ -113,28 +132,26 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             </InputWithTopLabelContainer>
           </PaddedInputContainer>
         ) : (
-          <PaddedInputContainer>
-            <InputWithTopLabelContainer>
-              <Label htmlFor="condition">{t('condition_appearance')}</Label>
-              <Select options={dialogConditionOptions} value={currentDialog.condition} onChange={changeCondition} />
-            </InputWithTopLabelContainer>
-            <InputWithTopLabelContainer>
-              <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
-              <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
-                <MultiLineInput
-                  id="sentence"
-                  defaultValue={getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId)}
-                  ref={sentenceRef}
-                  key={`sentence-${dialogIndex}`}
-                />
-              </TranslateInputContainer>
-            </InputWithTopLabelContainer>
-          </PaddedInputContainer>
+          <InputWithDeleteButton>
+            <PaddedInputContainer>
+              <InputWithTopLabelContainer>
+                <Label htmlFor="condition">{t('condition_appearance')}</Label>
+                <Select options={dialogConditionOptions} value={currentDialog.condition} onChange={changeCondition} />
+              </InputWithTopLabelContainer>
+              <InputWithTopLabelContainer>
+                <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
+                <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
+                  <MultiLineInput id="sentence" defaultValue={defaultSentence} ref={sentenceRef} key={`sentence-${dialogIndex}`} />
+                </TranslateInputContainer>
+              </InputWithTopLabelContainer>
+            </PaddedInputContainer>
+            <DeleteButton onClick={deleteDialog}>{t('delete_dialog')}</DeleteButton>
+          </InputWithDeleteButton>
         )}
         <SubEditorContainer>
           <SubEditorSeparator parentEditorHasScrollBar />
           <Editor type="creation" title={t('scripted_dialog')}>
-            <TooltipWrapper data-tooltip={!canAddDialog ? t('available_future_release') : undefined}>
+            <TooltipWrapper data-tooltip={!canAddDialog ? t('max_dialog') : undefined}>
               <SecondaryButtonWithPlusIcon disabled={!canAddDialog} onClick={addDialog}>
                 {t('new_dialog')}
               </SecondaryButtonWithPlusIcon>

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -18,8 +18,8 @@ import { useDialogsRef } from '@hooks/useDialogsRef';
 import { TrainerTranslationEditorTitle, TrainerTranslationOverlay } from './TrainerTranslationOverlay';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { PaginationWithTitleProps } from '@components/PaginationWithTitle';
-import { useTrainerDialog } from './useTrainerDialog';
-import { Select } from '@ds/Select';
+import { useTrainerDialog } from './TrainerDialogEditor/useTrainerDialog';
+import { AdditionalDialogEditor } from './TrainerDialogEditor/AdditionalDialogEditor';
 import { useUpdateTrainer } from './useUpdateTrainer';
 import styled from 'styled-components';
 
@@ -35,8 +35,7 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_trainers');
   const { trainer } = useTrainerPage();
   const updateTrainer = useUpdateTrainer(trainer);
-  const { dialogs, currentDialog, dialogIndex, canAddDialog, conditionOptions, updateDialogIndex, addDialog, deleteDialog, changeCondition } =
-    useTrainerDialog();
+  const { dialogs, currentDialog, dialogIndex, canAddDialog, updateDialogIndex, addDialog, deleteDialog, changeCondition } = useTrainerDialog();
   const dialogsRef = useDialogsRef<TrainerTranslationEditorTitle>();
   const getText = useGetProjectText();
   const setText = useSetProjectText();
@@ -123,23 +122,13 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
           </PaddedInputContainer>
         ) : (
           <InputWithDeleteButton>
-            <PaddedInputContainer>
-              <InputWithTopLabelContainer>
-                <Label htmlFor="condition">{t('condition_appearance')}</Label>
-                <Select options={conditionOptions} value={currentDialog.condition} onChange={changeCondition} key={`condition-${dialogIndex}`} />
-              </InputWithTopLabelContainer>
-              <InputWithTopLabelContainer>
-                <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
-                <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
-                  <MultiLineInput
-                    id="sentence"
-                    defaultValue={getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId)}
-                    ref={sentenceRef}
-                    key={`sentence-${dialogIndex}`}
-                  />
-                </TranslateInputContainer>
-              </InputWithTopLabelContainer>
-            </PaddedInputContainer>
+            <AdditionalDialogEditor
+              dialogs={dialogs}
+              dialogIndex={dialogIndex}
+              changeCondition={changeCondition}
+              sentenceRef={sentenceRef}
+              handleTranslateClick={handleTranslateClick}
+            />
             <DeleteButton onClick={deleteDialog}>{t('delete_dialog')}</DeleteButton>
           </InputWithDeleteButton>
         )}

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Editor, EditorWithPagination } from '@components/editor';
 import { EditorChildWithSubEditorContainer, SubEditorContainer, SubEditorSeparator } from '@components/editor/EditorContainer';
@@ -8,7 +8,6 @@ import { TranslateInputContainer } from '@components/inputs/TranslateInputContai
 import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
 import {
   StudioTrainerAdditionalDialogs,
-  TRAINER_ADDITIONAL_DIALOGS_CONDITION,
   TRAINER_ADDITIONAL_DIALOGS_TEXT_ID,
   TRAINER_DEFEAT_SENTENCE_TEXT_ID,
   TRAINER_VICTORY_SENTENCE_TEXT_ID,
@@ -20,13 +19,9 @@ import { TrainerTranslationEditorTitle, TrainerTranslationOverlay } from './Trai
 import { TooltipWrapper } from '@ds/Tooltip';
 import { PaginationWithTitleProps } from '@components/PaginationWithTitle';
 import { useTrainerDialog } from './useTrainerDialog';
-import { TFunction } from 'i18next';
 import { Select } from '@ds/Select';
 import { useUpdateTrainer } from './useUpdateTrainer';
 import styled from 'styled-components';
-
-const dialogConditionEntries = (t: TFunction<'database_trainers'>) =>
-  TRAINER_ADDITIONAL_DIALOGS_CONDITION.map((condition) => ({ value: condition.toString(), label: t(`additional_dialog_${condition}`) }));
 
 const InputWithDeleteButton = styled.div`
   display: flex;
@@ -43,10 +38,10 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const {
     dialogs,
     currentDialog,
-    dialogCount,
     dialogIndex,
     canAddDialog,
     defaultSentence,
+    conditionOptions,
     updateDialogIndex,
     addDialog,
     deleteDialog,
@@ -55,10 +50,10 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const dialogsRef = useDialogsRef<TrainerTranslationEditorTitle>();
   const getText = useGetProjectText();
   const setText = useSetProjectText();
-  const dialogConditionOptions = useMemo(() => dialogConditionEntries(t), [t]);
   const victoryRef = useRef<HTMLTextAreaElement>(null);
   const defeatRef = useRef<HTMLTextAreaElement>(null);
   const sentenceRef = useRef<HTMLTextAreaElement>(null);
+  const dialogCount = dialogs.length;
 
   const saveTexts = () => {
     if (victoryRef.current && defeatRef.current) {
@@ -136,7 +131,7 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             <PaddedInputContainer>
               <InputWithTopLabelContainer>
                 <Label htmlFor="condition">{t('condition_appearance')}</Label>
-                <Select options={dialogConditionOptions} value={currentDialog.condition} onChange={changeCondition} />
+                <Select options={conditionOptions} value={currentDialog.condition} onChange={changeCondition} key={`condition-${dialogIndex}`} />
               </InputWithTopLabelContainer>
               <InputWithTopLabelContainer>
                 <Label htmlFor="sentence">{t('sentence_spoken')}</Label>

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor.tsx
@@ -62,6 +62,11 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     saveTexts();
   };
 
+  const newDialog = () => {
+    saveTexts();
+    setTimeout(addDialog);
+  };
+
   const onClose = () => {
     saveTexts();
     updateTrainer({
@@ -142,7 +147,7 @@ export const TrainerDialogEditor = forwardRef<EditorHandlingClose>((_, ref) => {
           <SubEditorSeparator parentEditorHasScrollBar />
           <Editor type="creation" title={t('scripted_dialog')}>
             <TooltipWrapper data-tooltip={!canAddDialog ? t('max_dialog') : undefined}>
-              <SecondaryButtonWithPlusIcon disabled={!canAddDialog} onClick={addDialog}>
+              <SecondaryButtonWithPlusIcon disabled={!canAddDialog} onClick={newDialog}>
                 {t('new_dialog')}
               </SecondaryButtonWithPlusIcon>
             </TooltipWrapper>

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor/AdditionalDialogEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor/AdditionalDialogEditor.tsx
@@ -1,0 +1,50 @@
+import { InputWithTopLabelContainer, Label, MultiLineInput, PaddedInputContainer } from '@components/inputs';
+import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
+import { Select } from '@ds/Select/Select';
+import { TRAINER_ADDITIONAL_DIALOGS_CONDITION, TRAINER_ADDITIONAL_DIALOGS_TEXT_ID } from '@modelEntities/trainer';
+import { useGetProjectText } from '@utils/ReadingProjectText';
+import { TrainerDialogAdditionalDialogs } from './useTrainerDialog';
+import { TrainerTranslationEditorTitle } from '../TrainerTranslationOverlay';
+import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
+import React, { Ref, useMemo } from 'react';
+
+const dialogConditionEntries = (dialogs: TrainerDialogAdditionalDialogs[], dialogIndex: number, t: TFunction<'database_trainers'>) => {
+  const currentConditions = dialogs.map(({ condition }) => condition).filter((condition) => condition !== dialogs[dialogIndex].condition);
+  const conditions = TRAINER_ADDITIONAL_DIALOGS_CONDITION.filter((condition) => !currentConditions.includes(condition)).map((condition) => ({
+    value: condition.toString(),
+    label: t(`additional_dialog_${condition}`),
+  }));
+  return conditions;
+};
+
+type AdditionalDialogEditorProps = {
+  dialogs: TrainerDialogAdditionalDialogs[];
+  dialogIndex: number;
+  sentenceRef: Ref<HTMLTextAreaElement>;
+  changeCondition: (condition: string) => void;
+  handleTranslateClick: (editorTitle: TrainerTranslationEditorTitle) => () => void;
+};
+
+export const AdditionalDialogEditor = ({ dialogs, dialogIndex, sentenceRef, changeCondition, handleTranslateClick }: AdditionalDialogEditorProps) => {
+  const { t } = useTranslation('database_trainers');
+  const getText = useGetProjectText();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const options = useMemo(() => dialogConditionEntries(dialogs, dialogIndex, t), [dialogs, dialogIndex]);
+  const currentDialog = dialogs[dialogIndex];
+
+  return (
+    <PaddedInputContainer key={`additional-dialogs-${dialogIndex}`}>
+      <InputWithTopLabelContainer>
+        <Label htmlFor="condition">{t('condition_appearance')}</Label>
+        <Select options={options} value={currentDialog.condition} onChange={changeCondition} />
+      </InputWithTopLabelContainer>
+      <InputWithTopLabelContainer>
+        <Label htmlFor="sentence">{t('sentence_spoken')}</Label>
+        <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_additional_dialog')}>
+          <MultiLineInput id="sentence" defaultValue={getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, currentDialog.textId)} ref={sentenceRef} />
+        </TranslateInputContainer>
+      </InputWithTopLabelContainer>
+    </PaddedInputContainer>
+  );
+};

--- a/src/views/components/database/trainer/editors/TrainerDialogEditor/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/TrainerDialogEditor/useTrainerDialog.ts
@@ -10,9 +10,7 @@ import { useTrainerPage } from '@src/hooks/usePage';
 import { cloneEntity } from '@utils/cloneEntity';
 import { findFirstAvailableTextId } from '@utils/ModelUtils';
 import { useSetProjectText } from '@utils/ReadingProjectText';
-import { TFunction } from 'i18next';
 import { useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 const getNewCondition = (dialogs: TrainerDialogAdditionalDialogs[]) => {
   const currentConditions = dialogs.map(({ condition }) => condition);
@@ -31,15 +29,6 @@ const getNewTextId = (additionalDialogs: StudioTrainerAdditionalDialogs[], dialo
   return findFirstAvailableTextId(allAdditionalDialogs);
 };
 
-const dialogConditionEntries = (dialogs: TrainerDialogAdditionalDialogs[], dialogIndex: number, t: TFunction<'database_trainers'>) => {
-  const currentConditions = dialogs.map(({ condition }) => condition).filter((condition) => condition !== dialogs[dialogIndex].condition);
-  const conditions = TRAINER_ADDITIONAL_DIALOGS_CONDITION.filter((condition) => !currentConditions.includes(condition)).map((condition) => ({
-    value: condition.toString(),
-    label: t(`additional_dialog_${condition}`),
-  }));
-  return conditions;
-};
-
 export type TrainerDialogAdditionalDialogs = {
   condition: 'default' | StudioTrainerAdditionalDialogs['condition'];
   textId: number;
@@ -47,7 +36,6 @@ export type TrainerDialogAdditionalDialogs = {
 
 export const useTrainerDialog = () => {
   const { trainer, trainers } = useTrainerPage();
-  const { t } = useTranslation('database_trainers');
   const setText = useSetProjectText();
   const allAdditionalDialogs = useMemo(() => getAllAdditionalDialogs(trainers, trainer), [trainers, trainer]);
   const [dialogIndex, setDialogIndex] = useState<number>(0);
@@ -58,7 +46,6 @@ export const useTrainerDialog = () => {
     },
     ...trainer.additionalDialogs,
   ]);
-  const [conditionOptions, setConditionOptions] = useState(dialogConditionEntries(dialogs, dialogIndex, t));
   const currentDialog = dialogs[dialogIndex];
 
   const addDialog = () => {
@@ -72,7 +59,6 @@ export const useTrainerDialog = () => {
     setTimeout(() => {
       setDialogs(newDialogs);
       setDialogIndex(newIndex);
-      setConditionOptions(dialogConditionEntries(newDialogs, newIndex, t));
     }, 0);
   };
 
@@ -86,7 +72,6 @@ export const useTrainerDialog = () => {
     dialogsUpdated.splice(index, 1);
     setDialogs(dialogsUpdated);
     updateDialogIndex(index - 1);
-    setConditionOptions(dialogConditionEntries(dialogsUpdated, index - 1, t));
   };
 
   const changeCondition = (condition: string) => {
@@ -97,7 +82,6 @@ export const useTrainerDialog = () => {
 
   const updateDialogIndex = (newIndex: number) => {
     setDialogIndex(newIndex);
-    setConditionOptions(dialogConditionEntries(dialogs, newIndex, t));
   };
 
   return {
@@ -105,7 +89,6 @@ export const useTrainerDialog = () => {
     currentDialog,
     dialogIndex,
     canAddDialog: dialogs.length < TRAINER_ADDITIONAL_DIALOGS_CONDITION.length + 1,
-    conditionOptions,
     updateDialogIndex,
     addDialog,
     deleteDialog,

--- a/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
+++ b/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
@@ -22,7 +22,7 @@ export type TrainerTranslationEditorTitle =
 type Props = {
   onClose: () => void;
   trainer: StudioTrainer;
-  additionalDialog: TrainerDialogAdditionalDialogs;
+  additionalDialog?: TrainerDialogAdditionalDialogs;
 };
 
 /**
@@ -66,7 +66,7 @@ export const TrainerTranslationOverlay = defineEditorOverlay<TrainerTranslationE
             title={dialogToShow}
             nameTextId={TRAINER_NAME_TEXT_ID}
             fileId={TRAINER_ADDITIONAL_DIALOGS_TEXT_ID}
-            textIndex={additionalDialog.textId}
+            textIndex={additionalDialog?.textId ?? 0}
             isMultiline={true}
             closeDialog={closeDialog}
             onClose={onClose}

--- a/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
+++ b/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
@@ -9,9 +9,8 @@ import {
   TRAINER_VICTORY_SENTENCE_TEXT_ID,
 } from '@modelEntities/trainer';
 import { assertUnreachable } from '@utils/assertUnreachable';
+import type { TrainerDialogAdditionalDialogs } from './TrainerDialogEditor/useTrainerDialog';
 import React from 'react';
-import type { TrainerDialogAdditionalDialogs } from './useTrainerDialog';
-
 export type TrainerTranslationEditorTitle =
   | 'translation_name'
   | 'translation_class'

--- a/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
+++ b/src/views/components/database/trainer/editors/TrainerTranslationOverlay.tsx
@@ -2,6 +2,7 @@ import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
 import { TranslationEditorWithCloseHandling } from '@components/editor/TranslationEditorWithCloseHandling';
 import {
   StudioTrainer,
+  TRAINER_ADDITIONAL_DIALOGS_TEXT_ID,
   TRAINER_CLASS_TEXT_ID,
   TRAINER_DEFEAT_SENTENCE_TEXT_ID,
   TRAINER_NAME_TEXT_ID,
@@ -9,12 +10,19 @@ import {
 } from '@modelEntities/trainer';
 import { assertUnreachable } from '@utils/assertUnreachable';
 import React from 'react';
+import type { TrainerDialogAdditionalDialogs } from './useTrainerDialog';
 
-export type TrainerTranslationEditorTitle = 'translation_name' | 'translation_class' | 'translation_victory' | 'translation_defeat';
+export type TrainerTranslationEditorTitle =
+  | 'translation_name'
+  | 'translation_class'
+  | 'translation_victory'
+  | 'translation_defeat'
+  | 'translation_additional_dialog';
 
 type Props = {
   onClose: () => void;
   trainer: StudioTrainer;
+  additionalDialog: TrainerDialogAdditionalDialogs;
 };
 
 /**
@@ -22,7 +30,7 @@ type Props = {
  */
 export const TrainerTranslationOverlay = defineEditorOverlay<TrainerTranslationEditorTitle, Props>(
   'TrainerTranslationOverlay',
-  (dialogToShow, handleCloseRef, closeDialog, { onClose, trainer }) => {
+  (dialogToShow, handleCloseRef, closeDialog, { onClose, trainer, additionalDialog }) => {
     switch (dialogToShow) {
       case 'translation_name':
       case 'translation_class':
@@ -46,6 +54,19 @@ export const TrainerTranslationOverlay = defineEditorOverlay<TrainerTranslationE
             nameTextId={TRAINER_NAME_TEXT_ID}
             fileId={dialogToShow === 'translation_victory' ? TRAINER_VICTORY_SENTENCE_TEXT_ID : TRAINER_DEFEAT_SENTENCE_TEXT_ID}
             textIndex={trainer.id}
+            isMultiline={true}
+            closeDialog={closeDialog}
+            onClose={onClose}
+            ref={handleCloseRef}
+          />
+        );
+      case 'translation_additional_dialog':
+        return (
+          <TranslationEditorWithCloseHandling
+            title={dialogToShow}
+            nameTextId={TRAINER_NAME_TEXT_ID}
+            fileId={TRAINER_ADDITIONAL_DIALOGS_TEXT_ID}
+            textIndex={additionalDialog.textId}
             isMultiline={true}
             closeDialog={closeDialog}
             onClose={onClose}

--- a/src/views/components/database/trainer/editors/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/useTrainerDialog.ts
@@ -1,0 +1,48 @@
+import { StudioTrainerAdditionalDialogs, TRAINER_ADDITIONAL_DIALOGS_CONDITION, TrainerAdditionalDialogsCondition } from '@modelEntities/trainer';
+import { useTrainerPage } from '@src/hooks/usePage';
+import { cloneEntity } from '@utils/cloneEntity';
+import { useState } from 'react';
+
+export type TrainerDialogAdditionalDialogs = {
+  condition: 'default' | StudioTrainerAdditionalDialogs['condition'];
+  textId: number;
+};
+
+export const useTrainerDialog = () => {
+  const { trainer } = useTrainerPage();
+  const [dialogIndex, setDialogIndex] = useState<number>(0);
+  const [dialogs, setDialogs] = useState<TrainerDialogAdditionalDialogs[]>([
+    {
+      condition: 'default',
+      textId: trainer.id,
+    },
+    ...trainer.additionalDialogs,
+  ]);
+  const currentDialog = dialogs[dialogIndex];
+
+  const addDialog = () => {
+    console.log('addDialog');
+  };
+
+  const deleteDialog = () => {
+    console.log('deleteDialog');
+  };
+
+  const changeCondition = (condition: string) => {
+    const dialogsUpdated = cloneEntity(dialogs);
+    dialogsUpdated[dialogIndex].condition = condition as TrainerAdditionalDialogsCondition;
+    setDialogs(dialogsUpdated);
+  };
+
+  return {
+    dialogs,
+    currentDialog,
+    dialogCount: dialogs.length,
+    dialogIndex,
+    canAddDialog: dialogs.length < TRAINER_ADDITIONAL_DIALOGS_CONDITION.length + 1,
+    setDialogIndex,
+    addDialog,
+    deleteDialog,
+    changeCondition,
+  };
+};

--- a/src/views/components/database/trainer/editors/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/useTrainerDialog.ts
@@ -9,7 +9,7 @@ import { ProjectData } from '@src/GlobalStateProvider';
 import { useTrainerPage } from '@src/hooks/usePage';
 import { cloneEntity } from '@utils/cloneEntity';
 import { findFirstAvailableTextId } from '@utils/ModelUtils';
-import { useSetProjectText } from '@utils/ReadingProjectText';
+import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
 import { useMemo, useState } from 'react';
 
 const getNewCondition = (dialogs: TrainerDialogAdditionalDialogs[]) => {
@@ -37,6 +37,7 @@ export type TrainerDialogAdditionalDialogs = {
 export const useTrainerDialog = () => {
   const { trainer, trainers } = useTrainerPage();
   const setText = useSetProjectText();
+  const getText = useGetProjectText();
   const allAdditionalDialogs = useMemo(() => getAllAdditionalDialogs(trainers, trainer), [trainers, trainer]);
   const [dialogIndex, setDialogIndex] = useState<number>(0);
   const [dialogs, setDialogs] = useState<TrainerDialogAdditionalDialogs[]>([
@@ -46,6 +47,7 @@ export const useTrainerDialog = () => {
     },
     ...trainer.additionalDialogs,
   ]);
+  const [defaultSentence, setDefaultSentence] = useState(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[dialogIndex].textId));
   const currentDialog = dialogs[dialogIndex];
 
   const addDialog = () => {
@@ -53,15 +55,22 @@ export const useTrainerDialog = () => {
       condition: getNewCondition(dialogs),
       textId: getNewTextId(allAdditionalDialogs, dialogs),
     };
-    console.log(newDialog);
-    // TODO: fix Unable to find text x in dialog file 100069 due to bad refresh
     setText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, newDialog.textId, '');
-    setDialogs((dialogs) => [...dialogs, newDialog]);
+    setDialogs((dialogs) => [...cloneEntity(dialogs), newDialog]);
     setDialogIndex(dialogs.length);
+    setDefaultSentence('');
   };
 
   const deleteDialog = () => {
-    console.log('deleteDialog');
+    if (currentDialog.condition === 'default') return;
+
+    const index = dialogs.findIndex(({ condition }) => condition === currentDialog.condition);
+    if (index === -1) return;
+
+    const dialogsUpdated = cloneEntity(dialogs);
+    dialogsUpdated.splice(index, 1);
+    setDialogs(dialogsUpdated);
+    updateDialogIndex(index - 1);
   };
 
   const changeCondition = (condition: string) => {
@@ -70,13 +79,19 @@ export const useTrainerDialog = () => {
     setDialogs(dialogsUpdated);
   };
 
+  const updateDialogIndex = (newIndex: number) => {
+    setDialogIndex(newIndex);
+    setDefaultSentence(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[newIndex].textId));
+  };
+
   return {
     dialogs,
     currentDialog,
     dialogCount: dialogs.length,
     dialogIndex,
     canAddDialog: dialogs.length < TRAINER_ADDITIONAL_DIALOGS_CONDITION.length + 1,
-    setDialogIndex,
+    defaultSentence,
+    updateDialogIndex,
     addDialog,
     deleteDialog,
     changeCondition,

--- a/src/views/components/database/trainer/editors/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/useTrainerDialog.ts
@@ -10,7 +10,9 @@ import { useTrainerPage } from '@src/hooks/usePage';
 import { cloneEntity } from '@utils/cloneEntity';
 import { findFirstAvailableTextId } from '@utils/ModelUtils';
 import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
+import { TFunction } from 'i18next';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const getNewCondition = (dialogs: TrainerDialogAdditionalDialogs[]) => {
   const currentConditions = dialogs.map(({ condition }) => condition);
@@ -29,6 +31,15 @@ const getNewTextId = (additionalDialogs: StudioTrainerAdditionalDialogs[], dialo
   return findFirstAvailableTextId(allAdditionalDialogs);
 };
 
+const dialogConditionEntries = (dialogs: TrainerDialogAdditionalDialogs[], dialogIndex: number, t: TFunction<'database_trainers'>) => {
+  const currentConditions = dialogs.map(({ condition }) => condition).filter((condition) => condition !== dialogs[dialogIndex].condition);
+  const conditions = TRAINER_ADDITIONAL_DIALOGS_CONDITION.filter((condition) => !currentConditions.includes(condition)).map((condition) => ({
+    value: condition.toString(),
+    label: t(`additional_dialog_${condition}`),
+  }));
+  return conditions;
+};
+
 export type TrainerDialogAdditionalDialogs = {
   condition: 'default' | StudioTrainerAdditionalDialogs['condition'];
   textId: number;
@@ -36,6 +47,7 @@ export type TrainerDialogAdditionalDialogs = {
 
 export const useTrainerDialog = () => {
   const { trainer, trainers } = useTrainerPage();
+  const { t } = useTranslation('database_trainers');
   const setText = useSetProjectText();
   const getText = useGetProjectText();
   const allAdditionalDialogs = useMemo(() => getAllAdditionalDialogs(trainers, trainer), [trainers, trainer]);
@@ -48,6 +60,7 @@ export const useTrainerDialog = () => {
     ...trainer.additionalDialogs,
   ]);
   const [defaultSentence, setDefaultSentence] = useState(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[dialogIndex].textId));
+  const [conditionOptions, setConditionOptions] = useState(dialogConditionEntries(dialogs, dialogIndex, t));
   const currentDialog = dialogs[dialogIndex];
 
   const addDialog = () => {
@@ -55,10 +68,13 @@ export const useTrainerDialog = () => {
       condition: getNewCondition(dialogs),
       textId: getNewTextId(allAdditionalDialogs, dialogs),
     };
+    const newIndex = dialogs.length;
+    const newDialogs = [...dialogs, newDialog];
     setText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, newDialog.textId, '');
-    setDialogs((dialogs) => [...cloneEntity(dialogs), newDialog]);
-    setDialogIndex(dialogs.length);
+    setDialogs(newDialogs);
+    setDialogIndex(newIndex);
     setDefaultSentence('');
+    setConditionOptions(dialogConditionEntries(newDialogs, newIndex, t));
   };
 
   const deleteDialog = () => {
@@ -71,6 +87,7 @@ export const useTrainerDialog = () => {
     dialogsUpdated.splice(index, 1);
     setDialogs(dialogsUpdated);
     updateDialogIndex(index - 1);
+    setConditionOptions(dialogConditionEntries(dialogsUpdated, index - 1, t));
   };
 
   const changeCondition = (condition: string) => {
@@ -82,15 +99,16 @@ export const useTrainerDialog = () => {
   const updateDialogIndex = (newIndex: number) => {
     setDialogIndex(newIndex);
     setDefaultSentence(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[newIndex].textId));
+    setConditionOptions(dialogConditionEntries(dialogs, newIndex, t));
   };
 
   return {
     dialogs,
     currentDialog,
-    dialogCount: dialogs.length,
     dialogIndex,
     canAddDialog: dialogs.length < TRAINER_ADDITIONAL_DIALOGS_CONDITION.length + 1,
     defaultSentence,
+    conditionOptions,
     updateDialogIndex,
     addDialog,
     deleteDialog,

--- a/src/views/components/database/trainer/editors/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/useTrainerDialog.ts
@@ -1,7 +1,33 @@
-import { StudioTrainerAdditionalDialogs, TRAINER_ADDITIONAL_DIALOGS_CONDITION, TrainerAdditionalDialogsCondition } from '@modelEntities/trainer';
+import {
+  StudioTrainer,
+  StudioTrainerAdditionalDialogs,
+  TRAINER_ADDITIONAL_DIALOGS_CONDITION,
+  TRAINER_ADDITIONAL_DIALOGS_TEXT_ID,
+  TrainerAdditionalDialogsCondition,
+} from '@modelEntities/trainer';
+import { ProjectData } from '@src/GlobalStateProvider';
 import { useTrainerPage } from '@src/hooks/usePage';
 import { cloneEntity } from '@utils/cloneEntity';
-import { useState } from 'react';
+import { findFirstAvailableTextId } from '@utils/ModelUtils';
+import { useSetProjectText } from '@utils/ReadingProjectText';
+import { useMemo, useState } from 'react';
+
+const getNewCondition = (dialogs: TrainerDialogAdditionalDialogs[]) => {
+  const currentConditions = dialogs.map(({ condition }) => condition);
+  return TRAINER_ADDITIONAL_DIALOGS_CONDITION.filter((condition) => !currentConditions.includes(condition))[0];
+};
+
+// Get all additional dialogs without the current trainer
+const getAllAdditionalDialogs = (trainersData: ProjectData['trainers'], currentTrainer: StudioTrainer) => {
+  const trainersWithoutCurrentTrainer = Object.values(trainersData).filter((trainer) => trainer.dbSymbol !== currentTrainer.dbSymbol);
+  return trainersWithoutCurrentTrainer.reduce<StudioTrainerAdditionalDialogs[]>((prev, curr) => [...prev, ...curr.additionalDialogs], []);
+};
+
+const getNewTextId = (additionalDialogs: StudioTrainerAdditionalDialogs[], dialogs: TrainerDialogAdditionalDialogs[]) => {
+  const currentDialogs = dialogs.filter(({ condition }) => condition !== 'default') as StudioTrainerAdditionalDialogs[];
+  const allAdditionalDialogs = [...additionalDialogs, ...currentDialogs];
+  return findFirstAvailableTextId(allAdditionalDialogs);
+};
 
 export type TrainerDialogAdditionalDialogs = {
   condition: 'default' | StudioTrainerAdditionalDialogs['condition'];
@@ -9,7 +35,9 @@ export type TrainerDialogAdditionalDialogs = {
 };
 
 export const useTrainerDialog = () => {
-  const { trainer } = useTrainerPage();
+  const { trainer, trainers } = useTrainerPage();
+  const setText = useSetProjectText();
+  const allAdditionalDialogs = useMemo(() => getAllAdditionalDialogs(trainers, trainer), [trainers, trainer]);
   const [dialogIndex, setDialogIndex] = useState<number>(0);
   const [dialogs, setDialogs] = useState<TrainerDialogAdditionalDialogs[]>([
     {
@@ -21,7 +49,15 @@ export const useTrainerDialog = () => {
   const currentDialog = dialogs[dialogIndex];
 
   const addDialog = () => {
-    console.log('addDialog');
+    const newDialog = {
+      condition: getNewCondition(dialogs),
+      textId: getNewTextId(allAdditionalDialogs, dialogs),
+    };
+    console.log(newDialog);
+    // TODO: fix Unable to find text x in dialog file 100069 due to bad refresh
+    setText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, newDialog.textId, '');
+    setDialogs((dialogs) => [...dialogs, newDialog]);
+    setDialogIndex(dialogs.length);
   };
 
   const deleteDialog = () => {

--- a/src/views/components/database/trainer/editors/useTrainerDialog.ts
+++ b/src/views/components/database/trainer/editors/useTrainerDialog.ts
@@ -9,7 +9,7 @@ import { ProjectData } from '@src/GlobalStateProvider';
 import { useTrainerPage } from '@src/hooks/usePage';
 import { cloneEntity } from '@utils/cloneEntity';
 import { findFirstAvailableTextId } from '@utils/ModelUtils';
-import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
+import { useSetProjectText } from '@utils/ReadingProjectText';
 import { TFunction } from 'i18next';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -49,7 +49,6 @@ export const useTrainerDialog = () => {
   const { trainer, trainers } = useTrainerPage();
   const { t } = useTranslation('database_trainers');
   const setText = useSetProjectText();
-  const getText = useGetProjectText();
   const allAdditionalDialogs = useMemo(() => getAllAdditionalDialogs(trainers, trainer), [trainers, trainer]);
   const [dialogIndex, setDialogIndex] = useState<number>(0);
   const [dialogs, setDialogs] = useState<TrainerDialogAdditionalDialogs[]>([
@@ -59,7 +58,6 @@ export const useTrainerDialog = () => {
     },
     ...trainer.additionalDialogs,
   ]);
-  const [defaultSentence, setDefaultSentence] = useState(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[dialogIndex].textId));
   const [conditionOptions, setConditionOptions] = useState(dialogConditionEntries(dialogs, dialogIndex, t));
   const currentDialog = dialogs[dialogIndex];
 
@@ -71,10 +69,11 @@ export const useTrainerDialog = () => {
     const newIndex = dialogs.length;
     const newDialogs = [...dialogs, newDialog];
     setText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, newDialog.textId, '');
-    setDialogs(newDialogs);
-    setDialogIndex(newIndex);
-    setDefaultSentence('');
-    setConditionOptions(dialogConditionEntries(newDialogs, newIndex, t));
+    setTimeout(() => {
+      setDialogs(newDialogs);
+      setDialogIndex(newIndex);
+      setConditionOptions(dialogConditionEntries(newDialogs, newIndex, t));
+    }, 0);
   };
 
   const deleteDialog = () => {
@@ -98,7 +97,6 @@ export const useTrainerDialog = () => {
 
   const updateDialogIndex = (newIndex: number) => {
     setDialogIndex(newIndex);
-    setDefaultSentence(getText(TRAINER_ADDITIONAL_DIALOGS_TEXT_ID, dialogs[newIndex].textId));
     setConditionOptions(dialogConditionEntries(dialogs, newIndex, t));
   };
 
@@ -107,7 +105,6 @@ export const useTrainerDialog = () => {
     currentDialog,
     dialogIndex,
     canAddDialog: dialogs.length < TRAINER_ADDITIONAL_DIALOGS_CONDITION.length + 1,
-    defaultSentence,
     conditionOptions,
     updateDialogIndex,
     addDialog,

--- a/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
+++ b/src/views/components/editor/TranslationEditorWithCloseHandling.tsx
@@ -79,6 +79,7 @@ export type TranslationEditorTitle =
   | 'translation_class'
   | 'translation_victory'
   | 'translation_defeat'
+  | 'translation_additional_dialog'
   | 'translation_form_name'
   | 'translation_form_description';
 


### PR DESCRIPTION
## Description

This PR implements the trainer additional dialogs feature and fix an issue with the migration process.
The feature uses the `100069` csv file. A PSDK implementation is required to take advantage of this feature.

The additional dialog object structure added in the trainer:
```typescript
additionalDialogs: z.array({
   condition: z.union([
    z.literal('before_creature_send'),
    z.literal('after_creature_send'),
    z.literal('after_all_actions_choices'),
    z.literal('after_attack_action'),
    z.literal('after_all_turn_actions'),
    z.literal('end_of_battle_turn'),
  ]),
  textId: POSITIVE_OR_ZERO_INT,
})
```

Closes #409 

## Tests to perform

- [x] The user can change the default dialog (victory and defeat sentence)
- [x] The user can add an additional dialog
- [x] The user can change the additional dialogs (condition and text)
- [x] The user can delete an additional dialog

## Screenshot

![image](https://github.com/user-attachments/assets/52092562-2a15-4f64-88c1-47f14649fb5a)
