### PR TITLE
Fix forced given name for Pokemon imported with Showdown

### DIFF
--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -64,7 +64,7 @@ const buildExpandPokemonSetup = (set: PokemonSet, from: string) => {
 
   if (from === 'trainer') {
     setupFields.push({ type: 'caughtWith', value: convertToDbSymbol(set.pokeball) || ('poke_ball' as DbSymbol) });
-    setupFields.push({ type: 'givenName', value: set.name || '' });
+    if (set.name) setupFields.push({ type: 'givenName', value: set.name });
     setupFields.push({ type: 'ivs', value: formatStats(set.ivs, 31) });
     setupFields.push({ type: 'loyalty', value: set.happiness ?? 70 });
     setupFields.push({ type: 'originalTrainerId', value: 0 });

--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -64,7 +64,7 @@ const buildExpandPokemonSetup = (set: PokemonSet, from: string) => {
 
   if (from === 'trainer') {
     setupFields.push({ type: 'caughtWith', value: convertToDbSymbol(set.pokeball) || ('poke_ball' as DbSymbol) });
-    setupFields.push({ type: 'givenName', value: set.name || set.species });
+    setupFields.push({ type: 'givenName', value: set.name || '' });
     setupFields.push({ type: 'ivs', value: formatStats(set.ivs, 31) });
     setupFields.push({ type: 'loyalty', value: set.happiness ?? 70 });
     setupFields.push({ type: 'originalTrainerId', value: 0 });


### PR DESCRIPTION
## Description

When we imported a Pokemon with Showdown without giving it a nickname, it would automatically be assigned its name, but in English, of course. Now, we leave it as is so that it shows its name in the Studio's language.

## Tests to perform

* [x] Import the Pokémon below as Mamambo and not Alomomola

```
Alomomola  
Ability: Healer  
Tera Type: Water
```
