### PR TITLE
Fix the drag and drop used to import resources

### DIFF
--- a/src/hooks/useResource.tsx
+++ b/src/hooks/useResource.tsx
@@ -24,17 +24,18 @@ export const useResource = ({ name, path, extensions, onResourceChoosen }: Props
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      copyFile(
-        { srcFile: acceptedFiles[0].path, destFolder: dirname(path) },
-        ({ destFile }) =>
-          setTimeout(() => {
-            onResourceChoosen(destFile);
-            setFlipFlap((last) => !last);
-          }),
-        ({ errorMessage }) => window.api.log.error(errorMessage)
-      );
-    }
+    if (acceptedFiles.length <= 0) return;
+
+    const srcFilePath = window.api.getPathForFile(acceptedFiles[0]);
+    copyFile(
+      { srcFile: srcFilePath, destFolder: dirname(path) },
+      ({ destFile }) =>
+        setTimeout(() => {
+          onResourceChoosen(destFile);
+          setFlipFlap((last) => !last);
+        }),
+      ({ errorMessage }) => window.api.log.error(errorMessage)
+    );
   };
 
   const onClick = async () => {

--- a/src/hooks/useResource.tsx
+++ b/src/hooks/useResource.tsx
@@ -26,9 +26,9 @@ export const useResource = ({ name, path, extensions, onResourceChoosen }: Props
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => extensions.includes(file.name.split('.').pop() ?? ''));
     if (acceptedFiles.length <= 0) return;
 
-    const srcFilePath = window.api.getPathForFile(acceptedFiles[0]);
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
     copyFile(
-      { srcFile: srcFilePath, destFolder: dirname(path) },
+      { srcFile: acceptedFilesPath, destFolder: dirname(path) },
       ({ destFile }) =>
         setTimeout(() => {
           onResourceChoosen(destFile);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { ipcRenderer, contextBridge, webFrame, IpcRendererEvent } from 'electron';
+import { ipcRenderer, contextBridge, webFrame, IpcRendererEvent, webUtils } from 'electron';
 import { BackendTaskWithGenericError, BackendTaskWithGenericErrorAndNoProgress, GenericBackendProgress, defineBackendTask } from '@utils/BackendTask';
 import type { PSDKVersion } from '@services/getPSDKVersion';
 import type { StudioShortcut } from '@hooks/useShortcuts';
@@ -112,6 +112,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   platform: process.platform,
   externalWindow: (link) => ipcRenderer.send('external-window', link),
+  getPathForFile: (file) => webUtils.getPathForFile(file),
   getStudioVersion: defineBackendTask(ipcRenderer, 'get-studio-version'),
   chooseProjectFileToOpen: defineBackendTask(ipcRenderer, 'choose-project-file-to-open'),
   writeProjectMetadata: defineBackendTask(ipcRenderer, 'write-project-metadata'),
@@ -204,6 +205,7 @@ declare global {
       startPSDKWorldmap: (projectPath: string) => void;
       platform: string;
       externalWindow: (link: string) => void;
+      getPathForFile: (file: File) => string;
       getStudioVersion: BackendTaskWithGenericErrorAndNoProgress<AnyObj, GetStudioVersionOutput>;
       chooseProjectFileToOpen: BackendTaskWithGenericErrorAndNoProgress<ChooseProjectFileToOpenInput, ChooseProjectFileToOpenOutput>;
       writeProjectMetadata: BackendTaskWithGenericErrorAndNoProgress<WriteProjectMetadataInput, AnyObj>;

--- a/src/views/components/inputs/AudioInput.tsx
+++ b/src/views/components/inputs/AudioInput.tsx
@@ -75,18 +75,19 @@ export const AudioInput = ({ audioPathInProject, name, extensions, destFolderToC
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !extensions || extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      if (destFolderToCopy === undefined) {
-        onAudioChoosen(acceptedFiles[0].path);
-      } else {
-        copyFile(
-          { srcFile: acceptedFiles[0].path, destFolder: destFolderToCopy },
-          ({ destFile }) => {
-            setTimeout(() => onAudioChoosen(destFile));
-          },
-          ({ errorMessage }) => window.api.log.error(errorMessage)
-        );
-      }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+    if (destFolderToCopy === undefined) {
+      onAudioChoosen(acceptedFilesPath);
+    } else {
+      copyFile(
+        { srcFile: acceptedFilesPath, destFolder: destFolderToCopy },
+        ({ destFile }) => {
+          setTimeout(() => onAudioChoosen(destFile));
+        },
+        ({ errorMessage }) => window.api.log.error(errorMessage)
+      );
     }
   };
 

--- a/src/views/components/inputs/DropInput.tsx
+++ b/src/views/components/inputs/DropInput.tsx
@@ -96,18 +96,19 @@ export const DropInput = ({
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !extensions || extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      if (destFolderToCopy === undefined) {
-        onFileChoosen(acceptedFiles[0].path);
-      } else {
-        copyFile(
-          { srcFile: acceptedFiles[0].path, destFolder: destFolderToCopy },
-          ({ destFile }) => {
-            setTimeout(() => onFileChoosen(destFile));
-          },
-          ({ errorMessage }) => window.api.log.error(errorMessage)
-        );
-      }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+    if (destFolderToCopy === undefined) {
+      onFileChoosen(acceptedFilesPath);
+    } else {
+      copyFile(
+        { srcFile: acceptedFilesPath, destFolder: destFolderToCopy },
+        ({ destFile }) => {
+          setTimeout(() => onFileChoosen(destFile));
+        },
+        ({ errorMessage }) => window.api.log.error(errorMessage)
+      );
     }
   };
 

--- a/src/views/components/inputs/DropInputFolder.tsx
+++ b/src/views/components/inputs/DropInputFolder.tsx
@@ -40,9 +40,10 @@ export const DropInputFolder = ({ onFolderChoosen }: DropInputFolderProps) => {
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !file.type);
-    if (acceptedFiles.length > 0) {
-      onFolderChoosen(acceptedFiles[0].path);
-    }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+    onFolderChoosen(acceptedFilesPath);
   };
 
   const onClick = async () => {

--- a/src/views/components/inputs/FileInput.tsx
+++ b/src/views/components/inputs/FileInput.tsx
@@ -99,18 +99,19 @@ export const FileInput = ({
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !extensions || extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      if (destFolderToCopy === undefined) {
-        onFileChoosen(acceptedFiles[0].path);
-      } else {
-        copyFile(
-          { srcFile: acceptedFiles[0].path, destFolder: destFolderToCopy },
-          ({ destFile }) => {
-            setTimeout(() => onFileChoosen(destFile));
-          },
-          ({ errorMessage }) => window.api.log.error(errorMessage)
-        );
-      }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+    if (destFolderToCopy === undefined) {
+      onFileChoosen(acceptedFilesPath);
+    } else {
+      copyFile(
+        { srcFile: acceptedFilesPath, destFolder: destFolderToCopy },
+        ({ destFile }) => {
+          setTimeout(() => onFileChoosen(destFile));
+        },
+        ({ errorMessage }) => window.api.log.error(errorMessage)
+      );
     }
   };
 

--- a/src/views/components/inputs/IconInput.tsx
+++ b/src/views/components/inputs/IconInput.tsx
@@ -78,21 +78,23 @@ export const IconInput = ({
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !extensions || extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      if (destFolderToCopy === undefined) {
-        onIconChoosen(acceptedFiles[0].path);
-      } else {
-        copyFile(
-          { srcFile: acceptedFiles[0].path, destFolder: destFolderToCopy },
-          ({ destFile }) => {
-            setTimeout(() => {
-              onIconChoosen(destFile);
-              setFlipFlap((last) => !last);
-            });
-          },
-          ({ errorMessage }) => window.api.log.error(errorMessage)
-        );
-      }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+
+    if (destFolderToCopy === undefined) {
+      onIconChoosen(acceptedFilesPath);
+    } else {
+      copyFile(
+        { srcFile: acceptedFilesPath, destFolder: destFolderToCopy },
+        ({ destFile }) => {
+          setTimeout(() => {
+            onIconChoosen(destFile);
+            setFlipFlap((last) => !last);
+          });
+        },
+        ({ errorMessage }) => window.api.log.error(errorMessage)
+      );
     }
   };
 

--- a/src/views/components/inputs/PictureInput.tsx
+++ b/src/views/components/inputs/PictureInput.tsx
@@ -79,18 +79,19 @@ export const PictureInput = ({ picturePathInProject, name, extensions, destFolde
     event.preventDefault();
     event.stopPropagation();
     const acceptedFiles = Array.from(event.dataTransfer.files).filter((file) => !extensions || extensions.includes(file.name.split('.').pop() ?? ''));
-    if (acceptedFiles.length > 0) {
-      if (destFolderToCopy === undefined) {
-        onPictureChoosen(acceptedFiles[0].path);
-      } else {
-        copyFile(
-          { srcFile: acceptedFiles[0].path, destFolder: destFolderToCopy },
-          ({ destFile }) => {
-            setTimeout(() => onPictureChoosen(destFile));
-          },
-          ({ errorMessage }) => window.api.log.error(errorMessage)
-        );
-      }
+    if (acceptedFiles.length <= 0) return;
+
+    const acceptedFilesPath = window.api.getPathForFile(acceptedFiles[0]);
+    if (destFolderToCopy === undefined) {
+      onPictureChoosen(acceptedFilesPath);
+    } else {
+      copyFile(
+        { srcFile: acceptedFilesPath, destFolder: destFolderToCopy },
+        ({ destFile }) => {
+          setTimeout(() => onPictureChoosen(destFile));
+        },
+        ({ errorMessage }) => window.api.log.error(errorMessage)
+      );
     }
   };
 


### PR DESCRIPTION
## Description

After the Electron update, they added a security feature to make the client side more secure, which means that path is no longer accessible. Now, we retrieve the information through the backend.

## Tests to perform

* [x] Try Drap & Drop for Pokemon Ressources
