### PR TITLE
Pokémon lists are now ordered by following the national Pokédex order

### DIFF
--- a/src/views/components/database/ability/AbilityPokemonTable.tsx
+++ b/src/views/components/database/ability/AbilityPokemonTable.tsx
@@ -13,6 +13,7 @@ import { pokemonIconPath } from '@utils/resourcePath';
 import { useGetEntityNameText, useGetEntityNameTextUsingTextId } from '@utils/ReadingProjectText';
 import { CONTROL, useKeyPress } from '@hooks/useKeyPress';
 import { usePokemonShortcutNavigation, useShortcutNavigation } from '@hooks/useShortcutNavigation';
+import { buildCreaturesListByDexOrder } from '@utils/buildCreaturesListByDexOrder';
 
 type AbilityPokemonTableProps = {
   ability: StudioAbility;
@@ -98,14 +99,14 @@ const getFormWithCurrentAbility = (pokemon: StudioCreature, ability: StudioAbili
     (form) => form.abilities[0] === ability.dbSymbol || form.abilities[1] === ability.dbSymbol || form.abilities[2] === ability.dbSymbol
   ) || pokemon.forms[0];
 
-const getAllPokemonWithCurrentAbility = (state: State, ability: StudioAbility): StudioCreature[] => {
-  return (Object.values(state.projectData.pokemon) as unknown[] as StudioCreature[]) // TODO: Remove as - as
+const getAllPokemonWithCurrentAbility = (state: State, ability: StudioAbility) => {
+  return buildCreaturesListByDexOrder(state)
+    .map((pokemon) => state.projectData.pokemon[pokemon.dbSymbol])
     .filter((pokemon) =>
       pokemon.forms.find(
         (form) => form.abilities[0] === ability.dbSymbol || form.abilities[1] === ability.dbSymbol || form.abilities[2] === ability.dbSymbol
       )
-    )
-    .sort((a, b) => a.id - b.id);
+    );
 };
 
 const RenderPokemon = ({ pokemon, ability, state }: RenderAbilityProps) => {

--- a/src/views/components/database/move/moveTable/MovePokemonTable.tsx
+++ b/src/views/components/database/move/moveTable/MovePokemonTable.tsx
@@ -11,6 +11,7 @@ import { StudioCreature, StudioLevelLearnableMove } from '@modelEntities/creatur
 import { StudioMove } from '@modelEntities/move';
 import { CONTROL, useKeyPress } from '@hooks/useKeyPress';
 import { usePokemonShortcutNavigation } from '@hooks/useShortcutNavigation';
+import { buildCreaturesListByDexOrder } from '@utils/buildCreaturesListByDexOrder';
 
 export type FilterType = 'LevelLearnableMove' | 'TutorLearnableMove' | 'TechLearnableMove' | 'BreedLearnableMove' | 'EvolutionLearnableMove';
 
@@ -20,15 +21,15 @@ type MovePokemonTableProps = {
 };
 
 const getAllPokemonFiltered = (state: State, move: StudioMove, filter: FilterType) => {
-  return Object.values(state.projectData.pokemon).filter((pokemon) =>
-    pokemon.forms.find((form) => form.moveSet.find((m) => m.klass === filter && m.move === move.dbSymbol))
-  );
+  return buildCreaturesListByDexOrder(state)
+    .map((pokemon) => state.projectData.pokemon[pokemon.dbSymbol])
+    .filter((pokemon) => pokemon.forms.find((form) => form.moveSet.find((m) => m.klass === filter && m.move === move.dbSymbol)));
 };
 
 export const MovePokemonTable = ({ move, filter }: MovePokemonTableProps) => {
   const [state] = useGlobalState();
   const { t } = useTranslation(['database_types', 'database_moves', 'database_pokemon']);
-  const allPokemon = getAllPokemonFiltered(state, move, filter).sort((a, b) => a.id - b.id);
+  const allPokemon = getAllPokemonFiltered(state, move, filter);
 
   return allPokemon.length === 0 ? (
     <NoPokemonFound>{t('database_pokemon:no_option')}</NoPokemonFound>

--- a/src/views/components/database/type/TypePokemonTable.tsx
+++ b/src/views/components/database/type/TypePokemonTable.tsx
@@ -13,6 +13,7 @@ import { StudioCreature } from '@modelEntities/creature';
 import { StudioType } from '@modelEntities/type';
 import { CONTROL, useKeyPress } from '@hooks/useKeyPress';
 import { usePokemonShortcutNavigation, useShortcutNavigation } from '@hooks/useShortcutNavigation';
+import { buildCreaturesListByDexOrder } from '@utils/buildCreaturesListByDexOrder';
 
 type TypePokemonTableProps = {
   type: StudioType;
@@ -151,9 +152,9 @@ const RenderPokemon = ({ pokemon, type, state }: RenderMoveProps) => {
 };
 
 const getAllPokemonWithCurrentType = (type: StudioType, state: State) => {
-  return Object.values(state.projectData.pokemon)
-    .filter((pokemon) => pokemon.forms.find((form) => form.type1 === type.dbSymbol || form.type2 === type.dbSymbol))
-    .sort((a, b) => a.id - b.id);
+  return buildCreaturesListByDexOrder(state)
+    .map((pokemon) => state.projectData.pokemon[pokemon.dbSymbol])
+    .filter((pokemon) => pokemon.forms.find((form) => form.type1 === type.dbSymbol || form.type2 === type.dbSymbol));
 };
 
 export const TypePokemonTable = ({ type }: TypePokemonTableProps) => {


### PR DESCRIPTION
## Description

Faire en sorte que les listes de Pokémon soient toutes ordonnées en suivant le Pokédex National au lieu des IDs.
closes #417 

## Note before testing
Modifiez l'ordre du Pokédex National pour bouger certains Pokémon au début de la liste et en supprimer d'autres.

## Tests to perform
### Liste des Pokémon ayant un certain type
Ouvrir la page Types de la base de données, puis ouvrir la liste des Pokémon possédant le type XX
- [x] Les Pokémon que vous avez bougé au début du Pokédex doivent être au début de la liste
- [x] Les Pokémon que vous avez supprimé du Pokédex doivent être à la fin de la liste

### Liste des Pokémon ayant un certain talent
Ouvrir la page Talents de la base de données, puis ouvrir la liste des Pokémon possédant le talent XX
- [x] Les Pokémon que vous avez bougé au début du Pokédex doivent être au début de la liste
- [x] Les Pokémon que vous avez supprimé du Pokédex doivent être à la fin de la liste

### Liste des Pokémon apprenant une certaine attaque
Ouvrir la page Attaques de la base de données, puis ouvrir la liste des Pokémon apprenant l'attaque XX
- [x] Les Pokémon que vous avez bougé au début du Pokédex doivent être au début de la liste
- [x] Les Pokémon que vous avez supprimé du Pokédex doivent être à la fin de la liste
