### PR TITLE
Fix a bug with some data input in the evolution editor

### DIFF
--- a/src/views/components/database/pokemon/editors/EvolutionEditor/DayNightInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/DayNightInput.tsx
@@ -20,7 +20,8 @@ export const DayNightInput = ({ state, inputRefs }: EvolutionConditionEditorInpu
 
   useEffect(() => {
     setValue(state.defaults.dayNight?.toString());
-  }, [state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.evolutionIndex]);
 
   return (
     <InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/GenderInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/GenderInput.tsx
@@ -19,7 +19,8 @@ export const GenderInput = ({ state, inputRefs }: EvolutionConditionEditorInput)
 
   useEffect(() => {
     setValue(state.defaults.gender?.toString());
-  }, [state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.evolutionIndex]);
 
   return (
     <InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/NumberInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/NumberInput.tsx
@@ -26,7 +26,7 @@ export const NumberInput = ({ state, inputRefs, type, min, max, label }: NumberI
 
     ref.value = state.defaults[type]?.toString() || '';
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
+  }, [state.evolutionIndex]);
 
   if (!isTypeValidInput(type)) return null;
 

--- a/src/views/components/database/pokemon/editors/EvolutionEditor/TextInput.tsx
+++ b/src/views/components/database/pokemon/editors/EvolutionEditor/TextInput.tsx
@@ -30,7 +30,7 @@ export const TextInput = ({ type, state, inputRefs, evolutionInfo }: TextInputPr
 
     ref.value = state.defaults[type]?.toString() || '';
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
+  }, [state.evolutionIndex]);
 
   if (!isTypeValidInput(type)) return null;
 


### PR DESCRIPTION
## Description

This PR fixes a bug with some data input in the evolution editor.

The bug was introduced when a correction was made to fix a problem in the data when using the evolution navigation from the editor (the elements of the evolution n could overwrite the data of evolution n+1 ou n - 1 in some cases). #270 

This correction was a little too powerful, as it also occurred when a condition was added or deleted, which produces rollbacks.
The input refresh condition has been adjusted so that it only occurs when you change evolution.

The PSDK submodule has been updated.

Closes: #426 

## Tests to perform

- [x] Inputs no longer have rollbacks when a condition is added or deleted
- [x] The input data is correct when the evolution is changed
