### PR TITLE
Fix HealItem healed status Select that now properly displays the All status value

### DIFF
--- a/src/views/components/database/item/editors/ItemHealDataEditor.tsx
+++ b/src/views/components/database/item/editors/ItemHealDataEditor.tsx
@@ -186,11 +186,8 @@ export const ItemHealDataEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               options={statusesOptions}
               value={healChanges.statusList[0] || '???'}
               onChange={(value) => {
-                const newValue = (item.statusList = (value === 'ALL' ? Statuses.slice(0, -2) : [value]) as [
-                  StudioItemStatusCondition,
-                  ...StudioItemStatusCondition[]
-                ]);
-                setHealChanges((prevFormData) => ({ ...prevFormData, statusList: newValue }));
+                const newValue = value === 'ALL' ? Statuses.slice(0, -2) : ([value] as [StudioItemStatusCondition, ...StudioItemStatusCondition[]]);
+                setHealChanges((prevFormData) => ({ ...prevFormData, statusList: newValue.length > 1 ? ['ALL'] : newValue }));
               }}
               noTooltip
             />


### PR DESCRIPTION
## Description
This MR is a fix that closes #434.
Healed status Select now properly displays the All status value and do not displays Poisoned one when the user is selecting the All status one.

## Tests to perform
- GIVEN THAT I want to manage the status healed by a HealItem
- WHEN I go to the Item Database page
- AND I search for "Full Heal" in the control bar
- AND I click on the "Heal" data bloc
- AND I select "Paralyzed"
- AND I select "All status" again
- THEN the Select should display the "All status" value and not "Poisoned"
