### PR TITLE
Fixed a bug that forced users to click twice on the button to clear a text value in the text management pages

### DIFF
--- a/src/views/components/textmanagement/TextList.tsx
+++ b/src/views/components/textmanagement/TextList.tsx
@@ -116,14 +116,10 @@ export const TextList = ({ dialogsRef, disabledTranslation }: TextListProps) => 
                             #{padStr(textsFiltered[index].textId, 4)}
                           </span>
                           <ClearInput
-                            key={`${textsFiltered[index].textId}-${textsFiltered[index].dialog}`}
-                            defaultValue={textsFiltered[index].dialog}
+                            key={`${textsFiltered[index].textId}`}
+                            value={textsFiltered[index].dialog}
                             placeholder={`[~ ${index}]`}
-                            onBlur={(event) => {
-                              const newText = event.target.value;
-                              if (newText === event.target.defaultValue) return;
-                              setText(textInfo.fileId, textsFiltered[index].textId, newText);
-                            }}
+                            onChange={(event) => setText(textInfo.fileId, textsFiltered[index].textId, event.target.value)}
                             onClear={() => setText(textInfo.fileId, textsFiltered[index].textId, '')}
                             onFocus={(event) => (focusedInputRef.current = event.target)}
                           />


### PR DESCRIPTION
## Description

The bug was caused by the OnBlur event triggering before the OnClear event, setting the new text and updating the 'key' field of the component. The update of the 'key' field then forced the component to re-render, preventing the OnClear event from triggering.

closes #430

## Tests to perform

Go to the Text Management page
- [x] Clearing a text without focusing an input still works properly
- [x] Entering or modifying a text and un-focusing the input still works properly
- [x] Entering text in an empty input and then trying to clear it without un-focusing now correctly clears it
- [x] Modifying a text and then trying to clear it without un-focusing now correctly clears it