### PR TITLE
Remove showModal to replace it by css to not block windows bar actions

### DIFF
--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -4,6 +4,22 @@ import React, { forwardRef, PropsWithoutRef, ReactNode, useEffect, useImperative
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
+export const BackDrop = styled.div`
+  display: none; /* Hidden by default */
+  position: fixed;
+  z-index: 99; /* Ensure the backdrop is just below the modal */
+  left: 0;
+  width: 100vw; /* Full viewport width */
+
+  background-color: rgba(10, 9, 11, 0.3);
+  top: ${({ theme }) => theme.calc.titleBarHeight};
+  height: ${({ theme }) => theme.calc.height};
+
+  &.open {
+    display: block; /* Show the backdrop when open */
+  }
+`;
+
 export const DialogContainer = styled.dialog`
   overflow: visible;
   padding: 0;
@@ -16,29 +32,30 @@ export const DialogContainer = styled.dialog`
     top: ${({ theme }) => theme.calc.titleBarHeight};
     height: ${({ theme }) => theme.calc.height};
     left: 100%;
+
+    &.open {
+      transform: translateX(-100%);
+      opacity: 1;
+    }
+  }
+
+  &.open {
+    display: block;
+    z-index: 100;
   }
 
   &.center {
     opacity: 0;
+
+    &.open {
+      opacity: 1;
+      top: 40%;
+    }
   }
 
   & > div {
     left: unset;
     position: unset;
-  }
-
-  &::backdrop {
-    background-color: rgba(10, 9, 11, 0.3);
-    top: ${({ theme }) => theme.calc.titleBarHeight};
-    height: ${({ theme }) => theme.calc.height};
-  }
-
-  &.right[open] {
-    transform: translateX(-100%);
-  }
-
-  &.center[open] {
-    opacity: 1;
   }
 
   &:focus {
@@ -80,18 +97,22 @@ const animationOption = {
   easing: 'ease-in',
 } as const;
 
-const closeDialogWithAnimation = (dialog: HTMLDialogElement, isCenter: boolean, onFinish: () => void) => {
+const closeDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivElement, isCenter: boolean, onFinish: () => void) => {
   const animation = dialog.animate(isCenter ? animationKeys.center.close : animationKeys.right.close, animationOption);
+
   animation.onfinish = () => {
-    onFinish();
+    dialog.classList.remove('open');
+    backdrop.classList.remove('open');
     dialog.close();
+    onFinish();
     dialog.removeEventListener('cancel', onDialogCancel);
   };
 };
 
-const openDialogWithAnimation = (dialog: HTMLDialogElement, isCenter: boolean) => {
+const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivElement, isCenter: boolean) => {
   dialog.addEventListener('cancel', onDialogCancel);
-  dialog.showModal();
+  dialog.classList.add('open');
+  backdrop.classList.add('open');
   dialog.animate(isCenter ? animationKeys.center.open : animationKeys.right.open, animationOption);
 };
 
@@ -138,10 +159,12 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     const handleCloseRef = useEditorHandlingCloseRef();
     const [currentDialog, setCurrentDialog] = useState<Keys | undefined>(undefined);
     const [isCenter, setIsCenter] = useState(false);
+    const backdropRef = useRef<HTMLDivElement>(null);
 
     const closeDialog = () => {
       handleCloseRef.current?.onClose();
-      if (dialogRef.current) closeDialogWithAnimation(dialogRef.current, isCenter, () => setCurrentDialog(undefined));
+      if (dialogRef.current && backdropRef.current)
+        closeDialogWithAnimation(dialogRef.current, backdropRef.current, isCenter, () => setCurrentDialog(undefined));
     };
 
     const currentlyRenderedDialog = useMemo(() => {
@@ -154,14 +177,17 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       if (handleCloseRef.current?.canClose()) closeDialog();
     };
 
-    const onClickOutside = (e: React.MouseEvent<HTMLDialogElement, MouseEvent>) => {
+    const onClickOutside = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       if (e.currentTarget === e.target) onEscape();
     };
 
     const openDialog = (name: Keys, isCenterDialog?: boolean) => {
       setIsCenter(isCenterDialog || false);
       setCurrentDialog(name);
-      if (dialogRef.current) openDialogWithAnimation(dialogRef.current, isCenterDialog || false);
+      // Without tick, if the dialog change between center and right, the dialog is not displayed correctly
+      setTimeout(() => {
+        if (dialogRef.current && backdropRef.current) openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog || false);
+      }, 0);
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -182,9 +208,12 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     }, [currentDialog]);
 
     return createPortal(
-      <DialogContainer ref={dialogRef} onMouseDown={onClickOutside} className={isCenter ? 'center' : 'right'}>
-        {currentlyRenderedDialog}
-      </DialogContainer>,
+      <>
+        <BackDrop ref={backdropRef} onClick={onClickOutside}></BackDrop>
+        <DialogContainer ref={dialogRef} className={isCenter ? 'center' : 'right'}>
+          {currentlyRenderedDialog}
+        </DialogContainer>
+      </>,
       document.querySelector('#dialogs') || document.createElement('div')
     );
   });

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -65,6 +65,8 @@ export const DialogContainer = styled.dialog`
 
 const onDialogCancel = (e: Event) => e.preventDefault();
 
+const focusableHtmlElements = 'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
 const animationKeys = {
   right: {
     open: [
@@ -110,9 +112,7 @@ const closeDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEl
     // If another dialogs is open, then focus the first focusable element in this modal
     const otherDialogs = document.querySelectorAll('dialog.open');
     if (otherDialogs.length) {
-      const focusableElements = otherDialogs[otherDialogs.length - 1].querySelectorAll(
-        'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
-      );
+      const focusableElements = otherDialogs[otherDialogs.length - 1].querySelectorAll(focusableHtmlElements);
       if (focusableElements.length > 0) {
         (focusableElements[0] as HTMLElement).focus();
       }
@@ -127,7 +127,7 @@ const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEle
   dialog.animate(isCenter ? animationKeys.center.open : animationKeys.right.open, animationOption);
 
   setTimeout(() => {
-    const focusableElements = dialog.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+    const focusableElements = dialog.querySelectorAll(focusableHtmlElements);
     if (focusableElements.length > 0) {
       (focusableElements[0] as HTMLElement).focus();
     }
@@ -228,7 +228,8 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     useEffect(() => {
       const handleTabKey = (event: KeyboardEvent) => {
         if (event.key !== 'Tab') return;
-        const focusableElements = dialogRef.current?.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+        const focusableElements = dialogRef.current?.querySelectorAll(focusableHtmlElements);
+
         if (!focusableElements || focusableElements.length === 0) return;
 
         const firstElement = focusableElements[0] as HTMLElement;

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -262,8 +262,35 @@ useEffect(() => {
     }
   };
 
-  window.addEventListener('keydown', handleTabKey);
-  return () => window.removeEventListener('keydown', handleTabKey);
+        const handleCtrlA = (event: KeyboardEvent) => {
+          if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
+            const openDialogs = document.querySelectorAll('dialog.open');
+            if (openDialogs.length === 0) return;
+
+            const lastDialog = openDialogs[openDialogs.length - 1] as HTMLDialogElement;
+            if (lastDialog.contains(event.target as Node)) {
+              event.preventDefault();
+              const target = event.target as HTMLElement;
+
+              if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+                (target as HTMLInputElement | HTMLTextAreaElement).select();
+              } else {
+                const range = document.createRange();
+                range.selectNodeContents(lastDialog);
+                const selection = window.getSelection();
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+              }
+            }
+          }
+        };
+
+        window.addEventListener('keydown', handleCtrlA);
+        window.addEventListener('keydown', handleTabKey);
+        return () => {
+          window.removeEventListener('keydown', handleCtrlA);
+          window.removeEventListener('keydown', handleTabKey);
+        };
 }, [currentDialog]);
 
 return createPortal(

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -128,7 +128,7 @@ const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEle
 
   setTimeout(() => {
     const focusableElements = dialog.querySelectorAll(focusableHtmlElements);
-    if (focusableElements.length > 0) {
+    if (focusableElements?.length) {
       (focusableElements[0] as HTMLElement).focus();
     }
   }, animationOption.duration);
@@ -227,22 +227,39 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
 
     useEffect(() => {
       const handleTabKey = (event: KeyboardEvent) => {
-        if (event.key !== 'Tab') return;
-        const focusableElements = dialogRef.current?.querySelectorAll(focusableHtmlElements);
+        if (event.key !== 'Tab' || !currentDialog || !dialogRef.current) {
+          return;
+        }
 
-        if (!focusableElements || focusableElements.length === 0) return;
+        const focusableElements = Array.from(dialogRef.current.querySelectorAll(focusableHtmlElements)) as HTMLElement[];
 
-        const firstElement = focusableElements[0] as HTMLElement;
-        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+        if (focusableElements.length === 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
 
         if (event.shiftKey) {
-          // Shift + Tab
-          if (document.activeElement === firstElement) {
-            lastElement.focus();
+          if (document.activeElement === firstElement || !dialogRef.current.contains(document.activeElement)) {
+            const otherDialogs = document.querySelectorAll('dialog.open');
+            const currentDialogIndex = Array.from(otherDialogs).indexOf(dialogRef.current);
+            if (otherDialogs.length > 1 && currentDialogIndex > 0) {
+              const lastDialog = otherDialogs[currentDialogIndex - 1] as HTMLDialogElement;
+              const otherFocusableElements = Array.from(lastDialog.querySelectorAll(focusableHtmlElements)) as HTMLElement[];
+
+              //
+              if (otherFocusableElements.length > 0) {
+                otherFocusableElements[otherFocusableElements.length - 1].focus();
+              }
+            } else {
+              lastElement.focus();
+            }
+
             event.preventDefault();
           }
         } else {
-          // Tab
           if (document.activeElement === lastElement) {
             firstElement.focus();
             event.preventDefault();
@@ -251,7 +268,6 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       };
 
       window.addEventListener('keydown', handleTabKey);
-
       return () => window.removeEventListener('keydown', handleTabKey);
     }, [currentDialog]);
 
@@ -259,7 +275,27 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       <>
         <BackDrop ref={backdropRef} onClick={onClickOutside}></BackDrop>
         <DialogContainer ref={dialogRef} className={isCenter ? 'center' : 'right'}>
+          <div
+            tabIndex={0}
+            onFocus={(e) => {
+              const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
+              if (focusableElements.length > 0 && e.relatedTarget === focusableElements[focusableElements.length - 1]) {
+                requestAnimationFrame(() => focusableElements[0].focus());
+              }
+            }}
+          ></div>
+
           {currentlyRenderedDialog}
+
+          <div
+            tabIndex={0}
+            onFocus={(e) => {
+              const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
+              if (focusableElements.length > 0 && e.relatedTarget === focusableElements[0]) {
+                requestAnimationFrame(() => focusableElements[focusableElements.length - 1].focus());
+              }
+            }}
+          ></div>
         </DialogContainer>
       </>,
       document.querySelector('#dialogs') || document.createElement('div')

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -106,6 +106,17 @@ const closeDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEl
     dialog.close();
     onFinish();
     dialog.removeEventListener('cancel', onDialogCancel);
+
+    // If another dialogs is open, then focus the first focusable element in this modal
+    const otherDialogs = document.querySelectorAll('dialog.open');
+    if (otherDialogs.length) {
+      const focusableElements = otherDialogs[otherDialogs.length - 1].querySelectorAll(
+        'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableElements.length > 0) {
+        (focusableElements[0] as HTMLElement).focus();
+      }
+    }
   };
 };
 
@@ -114,6 +125,13 @@ const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEle
   dialog.classList.add('open');
   backdrop.classList.add('open');
   dialog.animate(isCenter ? animationKeys.center.open : animationKeys.right.open, animationOption);
+
+  setTimeout(() => {
+    const focusableElements = dialog.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+    if (focusableElements.length > 0) {
+      (focusableElements[0] as HTMLElement).focus();
+    }
+  }, animationOption.duration);
 };
 
 /**
@@ -207,35 +225,34 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentDialog]);
 
-     useEffect(() => {
-       const handleTabKey = (event: KeyboardEvent) => {
-         if (event.key !== 'Tab') return;
+    useEffect(() => {
+      const handleTabKey = (event: KeyboardEvent) => {
+        if (event.key !== 'Tab') return;
+        const focusableElements = dialogRef.current?.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+        if (!focusableElements || focusableElements.length === 0) return;
 
-         const focusableElements = dialogRef.current?.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
-         if (!focusableElements || focusableElements.length === 0) return;
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
 
-         const firstElement = focusableElements[0] as HTMLElement;
-         const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+        if (event.shiftKey) {
+          // Shift + Tab
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          // Tab
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            event.preventDefault();
+          }
+        }
+      };
 
-         if (event.shiftKey) {
-           // Shift + Tab
-           if (document.activeElement === firstElement) {
-             lastElement.focus();
-             event.preventDefault();
-           }
-         } else {
-           // Tab
-           if (document.activeElement === lastElement) {
-             firstElement.focus();
-             event.preventDefault();
-           }
-         }
-       };
+      window.addEventListener('keydown', handleTabKey);
 
-       window.addEventListener('keydown', handleTabKey);
-
-       return () => window.removeEventListener('keydown', handleTabKey);
-     }, [currentDialog]);
+      return () => window.removeEventListener('keydown', handleTabKey);
+    }, [currentDialog]);
 
     return createPortal(
       <>

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -207,6 +207,36 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentDialog]);
 
+     useEffect(() => {
+       const handleTabKey = (event: KeyboardEvent) => {
+         if (event.key !== 'Tab') return;
+
+         const focusableElements = dialogRef.current?.querySelectorAll('a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+         if (!focusableElements || focusableElements.length === 0) return;
+
+         const firstElement = focusableElements[0] as HTMLElement;
+         const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+         if (event.shiftKey) {
+           // Shift + Tab
+           if (document.activeElement === firstElement) {
+             lastElement.focus();
+             event.preventDefault();
+           }
+         } else {
+           // Tab
+           if (document.activeElement === lastElement) {
+             firstElement.focus();
+             event.preventDefault();
+           }
+         }
+       };
+
+       window.addEventListener('keydown', handleTabKey);
+
+       return () => window.removeEventListener('keydown', handleTabKey);
+     }, [currentDialog]);
+
     return createPortal(
       <>
         <BackDrop ref={backdropRef} onClick={onClickOutside}></BackDrop>

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -225,81 +225,78 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentDialog]);
 
-    useEffect(() => {
-      const handleTabKey = (event: KeyboardEvent) => {
-        if (event.key !== 'Tab' || !currentDialog || !dialogRef.current) {
-          return;
-        }
+useEffect(() => {
+  const handleTabKey = (event: KeyboardEvent) => {
+    if (event.key !== 'Tab') return;
 
-        const focusableElements = Array.from(dialogRef.current.querySelectorAll(focusableHtmlElements)) as HTMLElement[];
+    const openDialogs = document.querySelectorAll('dialog.open');
+    if (openDialogs.length === 0) return;
 
-        if (focusableElements.length === 0) {
-          event.preventDefault();
-          return;
-        }
+    const lastDialog = openDialogs[openDialogs.length - 1] as HTMLDialogElement;
+    if (!lastDialog.contains(event.target as Node)) return;
 
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
+    const focusableElements = Array.from(lastDialog.querySelectorAll(focusableHtmlElements)) as HTMLElement[];
+    if (focusableElements.length === 0) return;
 
-        if (event.shiftKey) {
-          if (document.activeElement === firstElement || !dialogRef.current.contains(document.activeElement)) {
-            const otherDialogs = document.querySelectorAll('dialog.open');
-            const currentDialogIndex = Array.from(otherDialogs).indexOf(dialogRef.current);
-            if (otherDialogs.length > 1 && currentDialogIndex > 0) {
-              const lastDialog = otherDialogs[currentDialogIndex - 1] as HTMLDialogElement;
-              const otherFocusableElements = Array.from(lastDialog.querySelectorAll(focusableHtmlElements)) as HTMLElement[];
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
 
-              //
-              if (otherFocusableElements.length > 0) {
-                otherFocusableElements[otherFocusableElements.length - 1].focus();
-              }
-            } else {
-              lastElement.focus();
-            }
+    if (event.shiftKey) {
 
-            event.preventDefault();
-          }
+      if (document.activeElement === firstElement) {
+        event.preventDefault();
+        if (focusableElements[focusableElements.length - 2].getAttribute('type') === 'hidden') {
+          const lastFocusableElement = focusableElements
+            .reverse()
+            .find((el) => el.getAttribute('type') !== 'hidden' && el.getAttribute('aria-hidden') !== 'true');
+          lastFocusableElement?.focus();
         } else {
-          if (document.activeElement === lastElement) {
-            firstElement.focus();
-            event.preventDefault();
-          }
+          focusableElements[focusableElements.length - 2].focus();
         }
-      };
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        event.preventDefault();
+        focusableElements[1].focus();
+      }
+    }
+  };
 
-      window.addEventListener('keydown', handleTabKey);
-      return () => window.removeEventListener('keydown', handleTabKey);
-    }, [currentDialog]);
+  window.addEventListener('keydown', handleTabKey);
+  return () => window.removeEventListener('keydown', handleTabKey);
+}, [currentDialog]);
 
-    return createPortal(
-      <>
-        <BackDrop ref={backdropRef} onClick={onClickOutside}></BackDrop>
-        <DialogContainer ref={dialogRef} className={isCenter ? 'center' : 'right'}>
-          <div
-            tabIndex={0}
-            onFocus={(e) => {
-              const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
-              if (focusableElements.length > 0 && e.relatedTarget === focusableElements[focusableElements.length - 1]) {
-                requestAnimationFrame(() => focusableElements[0].focus());
-              }
-            }}
-          ></div>
+return createPortal(
+  <>
+    <BackDrop ref={backdropRef} onClick={onClickOutside}></BackDrop>
+    <DialogContainer ref={dialogRef} className={isCenter ? 'center' : 'right'}>
+      <div
+        tabIndex={0}
+        aria-hidden="true"
+        onFocus={(e) => {
+          const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
+          if (focusableElements.length > 0 && e.relatedTarget === focusableElements[focusableElements.length - 1]) {
+            requestAnimationFrame(() => focusableElements[0].focus());
+          }
+        }}
+      ></div>
 
-          {currentlyRenderedDialog}
+      {currentlyRenderedDialog}
 
-          <div
-            tabIndex={0}
-            onFocus={(e) => {
-              const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
-              if (focusableElements.length > 0 && e.relatedTarget === focusableElements[0]) {
-                requestAnimationFrame(() => focusableElements[focusableElements.length - 1].focus());
-              }
-            }}
-          ></div>
-        </DialogContainer>
-      </>,
-      document.querySelector('#dialogs') || document.createElement('div')
-    );
+      <div
+        tabIndex={0}
+        aria-hidden="true"
+        onFocus={(e) => {
+          const focusableElements = Array.from(dialogRef.current?.querySelectorAll(focusableHtmlElements) || []) as HTMLElement[];
+          if (focusableElements.length > 0 && e.relatedTarget === focusableElements[0]) {
+            requestAnimationFrame(() => focusableElements[focusableElements.length - 1].focus());
+          }
+        }}
+      ></div>
+    </DialogContainer>
+  </>,
+  document.querySelector('#dialogs') || document.createElement('div')
+);
   });
   reactComponent.displayName = displayName;
   return reactComponent;

--- a/src/views/components/inputs/Input.tsx
+++ b/src/views/components/inputs/Input.tsx
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import TextareaAutosize from 'react-textarea-autosize';
 
 type InputProps = {
   error?: boolean;
@@ -130,7 +129,8 @@ const sharedInputStyles = css<SharedInputStylesProps>`
 
 type MultiLineInputProps = SharedInputStylesProps;
 
-export const MultiLineInput = styled(TextareaAutosize)<MultiLineInputProps>`
+export const MultiLineInput = styled.textarea<MultiLineInputProps>`
+  field-sizing: content;
   ${sharedInputStyles}
 `;
 

--- a/src/views/components/modals/UnsavedWarningModal.tsx
+++ b/src/views/components/modals/UnsavedWarningModal.tsx
@@ -72,6 +72,23 @@ export const UnsavedWarningModal = () => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDataToSave, state]);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Tab' || (event.shiftKey && event.key === 'Tab') || (event.ctrlKey && event.key === 'a')) {
+        event.preventDefault();
+      }
+    };
+
+    if (show) {
+      document.addEventListener('keydown', handleKeyDown);
+    } else {
+      document.removeEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [show]);
 
   return show ? (
     <OverlayContainer className="active">


### PR DESCRIPTION
Remove showModal to replace it by css to not block window top bar

Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You are following the [Code guidelines](../CodeGuidelines.md)
- [X] You tested your code to make sure it does what it is supposed to do

## Description

Remove the showModel so now, when a dialog is open, u can pressed button in top of app, like reduce, fullscreen or close

## Note before testing
 If u make changes on a dialog and try to close the app, a dialog will open for save the app

## Tests to perform

Test dialogs over application to be sure thats good ! ;)

Closes https://github.com/PokemonWorkshop/PokemonStudio/issues/43