### PR TITLE
Fix types table responsiveness

### DIFF
--- a/src/views/components/database/type/TypeTable.tsx
+++ b/src/views/components/database/type/TypeTable.tsx
@@ -6,6 +6,7 @@ import { TitleContainer } from '@components/editor/DataBlockEditorStyle';
 import { useProjectTypes } from '@hooks/useProjectData';
 import { HelperSelectedType, TypeHelper } from './TypeHelper';
 import { StudioType } from '@modelEntities/type';
+import { TypeTableDefensiveContainer } from './table/TypeTableContainers';
 
 export const TypeTable = () => {
   const { projectDataValues: types, setProjectDataValues: setType } = useProjectTypes();
@@ -29,6 +30,7 @@ export const TypeTable = () => {
         <TitleContainer onMouseEnter={onMouseLeaveEnter}>
           <p>{t('edit')}</p>
           <h3>{t('table')}</h3>
+          <TypeTableDefensiveContainer>{t('defensive')}</TypeTableDefensiveContainer>
         </TitleContainer>
         <TableTypeContainer>
           <TypeTableHead allTypes={allTypes} t={t} hoveredDefensiveType={hoveredDefensiveType} />

--- a/src/views/components/database/type/table/TypeTableContainers.tsx
+++ b/src/views/components/database/type/table/TypeTableContainers.tsx
@@ -27,6 +27,10 @@ export const TypeTableRowContainer = styled.div`
   flex-wrap: nowrap;
   column-gap: 16px;
   row-gap: 8px;
+  width: max-content;
+  .type-indicator > span {
+    box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.colors.dark16};
+  }
   &:hover > .type-indicator > span {
     box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.colors.primaryHover};
   }
@@ -36,12 +40,26 @@ export const TypeTableHeadContainer = styled(TypeTableRowContainer)`
   position: sticky;
   top: 0;
   margin-bottom: 16px;
+  z-index: 2;
+  width: max-content;
   &:hover {
     filter: none;
   }
 `;
 
-export const TypeTableHeadTitleContainer = styled.span`
+export const TypeTableDefensiveContainer = styled.span`
+  ${({ theme }) => theme.fonts.normalRegular}
+  color: ${(props) => props.theme.colors.text400};
+  text-align: center;
+  gap: 8px;
+  width: calc(100% - 112px);
+  align-self: flex-end;
+  margin-top: -4px;
+  margin-bottom: 8px;
+  background-color: ${({ theme }) => theme.colors.dark16};
+`;
+
+export const TypeTableOffensiveContainer = styled.span`
   width: 96px;
   ${({ theme }) => theme.fonts.normalRegular}
   color: ${(props) => props.theme.colors.text400};
@@ -53,6 +71,7 @@ export const TypeTableHeadTitleContainer = styled.span`
   flex-direction: column-reverse;
   flex-shrink: 0;
   background-color: ${({ theme }) => theme.colors.dark16};
+  box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.colors.dark16};
 `;
 
 export const TypeIconListContainer = styled.div`
@@ -60,6 +79,9 @@ export const TypeIconListContainer = styled.div`
   flex-wrap: nowrap;
   column-gap: 8px;
   row-gap: 8px;
+  span {
+    box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.colors.dark16};
+  }
 `;
 
 export const TableTypeContainer = styled.div`
@@ -67,6 +89,8 @@ export const TableTypeContainer = styled.div`
   max-width: calc(100vw - 400px);
   padding-left: 2px;
   margin-left: -2px;
+  padding-top: 2px;
+  margin-top: -2px;
 
   padding-bottom: 8px;
 

--- a/src/views/components/database/type/table/TypeTableHead.tsx
+++ b/src/views/components/database/type/table/TypeTableHead.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { TFunction } from 'i18next';
 
-import { TypeTableHeadContainer, TypeIconListContainer, TypeTableHeadTitleContainer } from './TypeTableContainers';
-import { DataFieldsetFieldCenteredWithChild } from '../../dataBlocks/DataFieldsetField';
+import { TypeTableHeadContainer, TypeIconListContainer, TypeTableOffensiveContainer } from './TypeTableContainers';
 import { TypeCategoryIcon } from '@components/categories';
 import styled from 'styled-components';
 import { StudioType } from '@modelEntities/type';
@@ -23,19 +22,17 @@ const Background = styled.div`
 export const TypeTableHead = ({ allTypes, t, hoveredDefensiveType }: TypeTableHeadProps) => {
   return (
     <TypeTableHeadContainer>
-      <TypeTableHeadTitleContainer>{t('offensive')}</TypeTableHeadTitleContainer>
+      <TypeTableOffensiveContainer>{t('offensive')}</TypeTableOffensiveContainer>
       <Background>
-        <DataFieldsetFieldCenteredWithChild label={t('defensive')} size="m">
-          <TypeIconListContainer>
-            {allTypes.map((type) => (
-              <TypeCategoryIcon
-                type={type.dbSymbol}
-                key={`${type.dbSymbol}-icon`}
-                className={hoveredDefensiveType === type.dbSymbol ? 'hovered-defensive-type' : undefined}
-              />
-            ))}
-          </TypeIconListContainer>
-        </DataFieldsetFieldCenteredWithChild>
+        <TypeIconListContainer>
+          {allTypes.map((type) => (
+            <TypeCategoryIcon
+              type={type.dbSymbol}
+              key={`${type.dbSymbol}-icon`}
+              className={hoveredDefensiveType === type.dbSymbol ? 'hovered-defensive-type' : undefined}
+            />
+          ))}
+        </TypeIconListContainer>
       </Background>
     </TypeTableHeadContainer>
   );


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] You are following the [Code guidelines](../CodeGuidelines.md)
- [X] You tested your code to make sure it does what it is supposed to do

## Description

I tried implementing #62. Here are some screenshots to show the changes:

Before:
![Before, type labels have moved to weird places](https://github.com/user-attachments/assets/f359eb0a-957a-46c1-b85a-23acb35bf310)

After:
![After, everything is in place](https://github.com/user-attachments/assets/950ba605-7888-44ca-aa0f-d7d685122b9b)

## Note before testing

None.

## Tests to perform

- Create some custom types.
- Open the types table.
- Shrink your window, and see if the table behaves correctly.
