### PR TITLE
Add a shortcut to quickly navigate between Pokémon forms

### DIFF
--- a/src/hooks/useShortcuts.tsx
+++ b/src/hooks/useShortcuts.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-const STUDIO_SHORTCUTS = {
+const STUDIO_CTRL_SHORTCUTS = {
   db_previous: ['ArrowLeft', 'Left'],
   db_next: ['ArrowRight', 'Right'],
   db_new: ['KeyN'],
@@ -8,11 +8,20 @@ const STUDIO_SHORTCUTS = {
   play: ['KeyP'],
 } as const;
 
-export type StudioShortcut = keyof typeof STUDIO_SHORTCUTS;
+const STUDIO_CTRL_SHIFT_SHORTCUTS = {
+  db_previous_variant: ['ArrowLeft', 'Left'],
+  db_next_variant: ['ArrowRight', 'Right'],
+} as const;
+
+export type StudioShortcut = keyof typeof STUDIO_CTRL_SHORTCUTS | keyof typeof STUDIO_CTRL_SHIFT_SHORTCUTS;
 export type StudioShortcutActions = Partial<Record<StudioShortcut, () => void>>;
 
-const KEY_TO_STUDIO_SHORTCUT = Object.fromEntries(
-  Object.entries(STUDIO_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut]))
+const KEY_TO_STUDIO_CTRL_SHORTCUT = Object.fromEntries(
+  Object.entries(STUDIO_CTRL_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut]))
+);
+
+const KEY_TO_STUDIO_CTRL_SHIFT_SHORTCUT = Object.fromEntries(
+  Object.entries(STUDIO_CTRL_SHIFT_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut]))
 );
 
 export const useShortcut = (shortcutActions: StudioShortcutActions) => {
@@ -30,7 +39,8 @@ export const useShortcut = (shortcutActions: StudioShortcutActions) => {
       } else {
         if (!e.ctrlKey) return;
       }
-      const shortcut = KEY_TO_STUDIO_SHORTCUT[e.code];
+
+      const shortcut = e.shiftKey ? KEY_TO_STUDIO_CTRL_SHIFT_SHORTCUT[e.code] : KEY_TO_STUDIO_CTRL_SHORTCUT[e.code];
       const action = shortcutActions[shortcut];
       if (action) action();
     };

--- a/src/views/components/database/pokemon/PokemonControlBar.tsx
+++ b/src/views/components/database/pokemon/PokemonControlBar.tsx
@@ -25,6 +25,14 @@ export const PokemonControlBar = ({ dialogsRef, setEvolutionIndex }: Props) => {
   const { selectedDataIdentifier: currentPokemon, setSelectedDataIdentifier, state } = useProjectPokemon();
   const shortcutMap = useMemo<StudioShortcutActions>(() => {
     const isShortcutEnabled = () => dialogsRef?.current?.currentDialog === undefined;
+    const offsetCurrentForm = (offset: number) => {
+      // To avoid issues with negative numbers
+      const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+      const forms = state.projectData.pokemon[currentPokemon.specie]?.forms ?? [];
+      const currentIndex = forms.findIndex(({ form }) => currentPokemon.form === form);
+      return forms[mod(currentIndex + offset, forms.length)].form;
+    };
 
     return {
       db_previous: () => {
@@ -37,9 +45,19 @@ export const PokemonControlBar = ({ dialogsRef, setEvolutionIndex }: Props) => {
         if (setEvolutionIndex) setEvolutionIndex(0);
         setSelectedDataIdentifier({ pokemon: { specie: getNextDbSymbolByDexOrder(currentPokemon.specie, state), form: 0 } });
       },
+      db_previous_variant: () => {
+        if (!isShortcutEnabled()) return;
+        if (setEvolutionIndex) setEvolutionIndex(0);
+        setSelectedDataIdentifier({ pokemon: { specie: currentPokemon.specie, form: offsetCurrentForm(-1) } });
+      },
+      db_next_variant: () => {
+        if (!isShortcutEnabled()) return;
+        if (setEvolutionIndex) setEvolutionIndex(0);
+        setSelectedDataIdentifier({ pokemon: { specie: currentPokemon.specie, form: offsetCurrentForm(1) } });
+      },
       db_new: () => isShortcutEnabled() && dialogsRef?.current?.openDialog('new'),
     };
-  }, [currentPokemon.specie]);
+  }, [currentPokemon.specie, currentPokemon.form]);
   useShortcut(shortcutMap);
 
   const onClickNew = dialogsRef ? () => dialogsRef.current?.openDialog('new') : undefined;


### PR DESCRIPTION
## Description

I implemented #308. Since the story didn't specify any keys, I chose CTRL+UP and CTRL+DOWN, but I'm open to other suggestions.

## Note before testing

None.

## Tests to perform

- Go to the species database.
- Choose a Pokémon with different forms.
- Press CTRL+UP to go to the next form, press CTRL+DOWN to go to the previous one.
