### PR TITLE
Use the PSDK binaries from GitHub

### DIFF
--- a/.github/actions/publish_studio/action.yml
+++ b/.github/actions/publish_studio/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         git submodule update --init --recursive
         cd psdk-binaries
-        curl -s https://download.psdk.pokemonworkshop.com/binaries/${{ runner.os }}.7z -o binaries.7z
+        curl -L https://github.com/PokemonWorkshop/PokemonSDKBinaries/releases/latest/download/${{ runner.os }}.7z > binaries.7z
         7z x binaries.7z
         rm binaries.7z
         cd ..


### PR DESCRIPTION
## Description

This PR updates the link to download the PSDK Binaries in the CI.
Now we use the binaries from this repository: https://github.com/PokemonWorkshop/PokemonSDKBinaries/releases
The readme file was already up to date.

Closes #449 

## Tests to perform

- [x] Make a draft release and check that Pokémon Studio has the PSDK binaries.

Note: I didn't test the CI, but the curl command works on Linux (tested on Debian), so it should work fine.