### PR TITLE
New moves can be created by importing data from another move

### DIFF
--- a/assets/i18n/en/database_moves.json
+++ b/assets/i18n/en/database_moves.json
@@ -160,5 +160,9 @@
   "error_status_format": "The status format is not correct.",
   "error_chances": "The chances of inflicting a status must be between 1 and 100.",
   "error_overflow": "The sum of your chances to inflict a status must not exceed 100%.",
-  "invalid_format": "Invalid format"
+  "invalid_format": "Invalid format",
+  "move_import_info": "You can create this new Move by importing data from another existing Move.",
+  "none_option": "None",
+  "other_data": "Other data",
+  "import_move_from": "Import data from"
 }

--- a/assets/i18n/fr/database_moves.json
+++ b/assets/i18n/fr/database_moves.json
@@ -160,5 +160,9 @@
   "error_status_format": "Le format du status n'est pas correct.",
   "error_chances": "Les chances d'infliger un statut doivent être comprises entre 1 et 100.",
   "error_overflow": "La somme de vos chances d'infliger un statut ne doit pas excéder 100\u00a0%.",
-  "invalid_format": "Format non valide"
+  "invalid_format": "Format non valide",
+  "move_import_info": "Vous pouvez créer cette nouvelle attaque en copiant les données d'une autre attaque déjà existante.",
+  "none_option": "Aucun",
+  "other_data": "Autres données",
+  "import_move_from": "Importer les données de"
 }

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -1,4 +1,5 @@
 import { StudioTrainer } from '@modelEntities/trainer';
+import { StudioMove } from '@modelEntities/move';
 import { cloneEntity } from './cloneEntity';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
@@ -10,5 +11,17 @@ export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTr
     party: cloneData.party,
     additionalDialogs: cloneData.additionalDialogs,
     resources: cloneData.resources,
+  };
+};
+
+export const importMoveData = (move: StudioMove, dataToImport: StudioMove): StudioMove => {
+  const cloneData = cloneEntity(dataToImport);
+
+  return {
+    ...cloneData,
+    id: move.id,
+    dbSymbol: move.dbSymbol,
+    type: move.type,
+    category: move.category,
   };
 };

--- a/src/views/components/database/move/editors/MoveNewEditor.tsx
+++ b/src/views/components/database/move/editors/MoveNewEditor.tsx
@@ -11,13 +11,16 @@ import { checkDbSymbolExist, generateDefaultDbSymbol, wrongDbSymbol } from '@uti
 import { MOVE_CATEGORIES, MOVE_DESCRIPTION_TEXT_ID, MOVE_NAME_TEXT_ID, MOVE_VALIDATOR } from '@modelEntities/move';
 import { createMove } from '@utils/entityCreation';
 import { DbSymbol } from '@modelEntities/dbSymbol';
-import { useSetProjectText } from '@utils/ReadingProjectText';
+import { useSetProjectText, useGetProjectText } from '@utils/ReadingProjectText';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { useZodForm } from '@hooks/useZodForm';
 import { useSelectOptions } from '@hooks/useSelectOptions';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { useInputAttrsWithLabel } from '@hooks/useInputAttrs';
+import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
+import { SelectMove } from '@components/selects';
+import { importMoveData } from '@utils/importEntityDataUtils';
 
 const moveCategoryEntries = (t: TFunction<'database_types'>) =>
   MOVE_CATEGORIES.map((category) => ({ value: category, label: t(category) })).sort((a, b) => a.label.localeCompare(b.label));
@@ -27,6 +30,18 @@ const ButtonContainer = styled.div`
   flex-direction: column;
   padding: 16px 0 0 0;
   gap: 8px;
+`;
+
+const ImportInfo = styled.div`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+`;
+
+const ImportInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 
 type MoveNewEditorProps = {
@@ -49,6 +64,9 @@ export const MoveNewEditor = forwardRef<EditorHandlingClose, MoveNewEditorProps>
   const move = { type: (typeOptions[0]?.value || '__undef__') as DbSymbol, category: categoryOptions[0].value };
   const { getFormData, defaults, formRef } = useZodForm(MOVE_NEW_EDITOR_SCHEMA, move);
   const { Select } = useInputAttrsWithLabel(MOVE_NEW_EDITOR_SCHEMA, defaults);
+  const getText = useGetProjectText();
+  const [selectedMove, setSelectedMove] = useState('__undef__');
+  const [importing, setImporting] = useState(false);
 
   useEditorHandlingClose(ref);
 
@@ -58,7 +76,12 @@ export const MoveNewEditor = forwardRef<EditorHandlingClose, MoveNewEditorProps>
 
     const dbSymbol = dbSymbolRef.current.value as DbSymbol;
     const { type, category } = result.data;
-    const newMove = createMove(moves, dbSymbol, type, category);
+    let newMove = createMove(moves, dbSymbol, type, category);
+
+    if (importing && selectedMove !== '__undef__') {
+      newMove = importMoveData(newMove, moves[selectedMove]);
+    }
+
     setText(MOVE_NAME_TEXT_ID, newMove.id, name);
     setText(MOVE_DESCRIPTION_TEXT_ID, newMove.id, descriptionRef.current.value);
 
@@ -126,6 +149,15 @@ export const MoveNewEditor = forwardRef<EditorHandlingClose, MoveNewEditorProps>
           {dbSymbolErrorType === 'value' && <TextInputError>{t('incorrect_format')}</TextInputError>}
           {dbSymbolErrorType === 'duplicate' && <TextInputError>{t('db_symbol_already_used')}</TextInputError>}
         </InputWithTopLabelContainer>
+        <InputGroupCollapse title={t('other_data')} gap="16px" onClick={() => setImporting(!importing)}>
+          <ImportInfoContainer>
+            <ImportInfo>{t('move_import_info')}</ImportInfo>
+          </ImportInfoContainer>
+          <InputWithTopLabelContainer>
+            <Label htmlFor="select-move-to-import">{t('import_move_from')}</Label>
+            <SelectMove dbSymbol={selectedMove} onChange={(dbSymbol) => setSelectedMove(dbSymbol)} noLabel undefValueOption={t('none_option')} />
+          </InputWithTopLabelContainer>
+        </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={isDisabled ? t('fields_asterisk_required') : undefined}>
             <PrimaryButton onClick={onClickNew} disabled={isDisabled}>

--- a/src/views/components/database/move/editors/MoveNewEditor.tsx
+++ b/src/views/components/database/move/editors/MoveNewEditor.tsx
@@ -11,7 +11,7 @@ import { checkDbSymbolExist, generateDefaultDbSymbol, wrongDbSymbol } from '@uti
 import { MOVE_CATEGORIES, MOVE_DESCRIPTION_TEXT_ID, MOVE_NAME_TEXT_ID, MOVE_VALIDATOR } from '@modelEntities/move';
 import { createMove } from '@utils/entityCreation';
 import { DbSymbol } from '@modelEntities/dbSymbol';
-import { useSetProjectText, useGetProjectText } from '@utils/ReadingProjectText';
+import { useSetProjectText } from '@utils/ReadingProjectText';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { useZodForm } from '@hooks/useZodForm';
@@ -64,7 +64,6 @@ export const MoveNewEditor = forwardRef<EditorHandlingClose, MoveNewEditorProps>
   const move = { type: (typeOptions[0]?.value || '__undef__') as DbSymbol, category: categoryOptions[0].value };
   const { getFormData, defaults, formRef } = useZodForm(MOVE_NEW_EDITOR_SCHEMA, move);
   const { Select } = useInputAttrsWithLabel(MOVE_NEW_EDITOR_SCHEMA, defaults);
-  const getText = useGetProjectText();
   const [selectedMove, setSelectedMove] = useState('__undef__');
   const [importing, setImporting] = useState(false);
 


### PR DESCRIPTION
## Description

The user can now create a new move by importing data from another existing move.

closes #458  

## Tests to perform

Open the "New Move" editor

### Creating a new move without importing any data

- [x] Fill the basic data and create the move => only the basic data is filled for the new move, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, leave the selection on "None" and create the move => only the basic data is filled for the new move, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, select a move, re-collapse the "other data" component and create the move => only the basic data is filled for the new move, all other data are filled with default values

### Creating a new move by importing data
- [x] Fill the basic data, un-collapse the "other data" component, select a move and create the move => the basic data is filled for the new move with the information you entered **AND** all other data are filled with the same data as the chosen move

