### PR TITLE
New Pokemon can be created by importing data from another Pokemon

### DIFF
--- a/assets/i18n/en/database_pokemon.json
+++ b/assets/i18n/en/database_pokemon.json
@@ -225,5 +225,9 @@
   "form_name": "Form name",
   "example_form_name": "Unown A",
   "form_description": "Form description",
-  "use_default_description": "Use the default description"
+  "use_default_description": "Use the default description",
+  "creature_import_info": "You can create this new Pokémon by importing data from another existing Pokémon.",
+  "none_option": "None",
+  "other_data": "Other data",
+  "import_creature_from": "Import data from"
 }

--- a/assets/i18n/fr/database_pokemon.json
+++ b/assets/i18n/fr/database_pokemon.json
@@ -225,5 +225,9 @@
   "form_name": "Nom de la forme",
   "example_form_name": "Zarbi A",
   "form_description": "Description de la forme",
-  "use_default_description": "Utiliser la description par défaut"
+  "use_default_description": "Utiliser la description par défaut",
+  "creature_import_info": "Vous pouvez créer ce nouveau Pokémon en copiant les données d'un autre Pokémon déjà existant.",
+  "none_option": "Aucun",
+  "other_data": "Autres données",
+  "import_creature_from": "Importer les données de"
 }

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -28,23 +28,18 @@ export const importCreatureData = (creature: StudioCreature, dataToImport: Studi
   newCreature.forms[0].type2 = creature.forms[0].type2;
   newCreature.forms[0].formTextId.name = findFirstAvailableFormTextId(allPokemon, 0, 'name');
 
-  let newAllPokemon = {
+  const newAllPokemon = {
     ...allPokemon,
     [newCreature.dbSymbol]: newCreature,
   }; //To avoid getting same text IDs for other forms
 
   //Update form text IDs
-  for (let i = 1; i < newCreature.forms.length; i++) {
+  newCreature.forms.slice(1).forEach((form) => {
     const formTextIdName = findFirstAvailableFormTextId(newAllPokemon, 0, 'name');
     const formTextIdDescription = findFirstAvailableFormTextId(newAllPokemon, 0, 'description');
-    newCreature.forms[i].formTextId.name = formTextIdName;
-    newCreature.forms[i].formTextId.description = formTextIdDescription;
-
-    newAllPokemon = {
-      ...allPokemon,
-      [newCreature.dbSymbol]: newCreature,
-    }; //To avoid getting same text IDs for other forms
-  }
+    form.formTextId.name = formTextIdName;
+    form.formTextId.description = formTextIdDescription;
+  });
 
   return newCreature;
 };

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -1,5 +1,8 @@
 import { StudioTrainer } from '@modelEntities/trainer';
+import { StudioCreature } from '@modelEntities/creature';
 import { cloneEntity } from './cloneEntity';
+import { findFirstAvailableFormTextId } from './ModelUtils';
+import { ProjectData } from '@src/GlobalStateProvider';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -11,4 +14,37 @@ export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTr
     additionalDialogs: cloneData.additionalDialogs,
     resources: cloneData.resources,
   };
+};
+
+export const importCreatureData = (creature: StudioCreature, dataToImport: StudioCreature, allPokemon: ProjectData['pokemon']): StudioCreature => {
+  const cloneData = cloneEntity(dataToImport);
+
+  const newCreature = {
+    ...creature,
+    forms: cloneData.forms,
+  };
+
+  newCreature.forms[0].type1 = creature.forms[0].type1;
+  newCreature.forms[0].type2 = creature.forms[0].type2;
+  newCreature.forms[0].formTextId.name = findFirstAvailableFormTextId(allPokemon, 0, 'name');
+
+  let newAllPokemon = {
+    ...allPokemon,
+    [newCreature.dbSymbol]: newCreature,
+  }; //To avoid getting same text IDs for other forms
+
+  //Update form text IDs
+  for (let i = 1; i < newCreature.forms.length; i++) {
+    const formTextIdName = findFirstAvailableFormTextId(newAllPokemon, 0, 'name');
+    const formTextIdDescription = findFirstAvailableFormTextId(newAllPokemon, 0, 'description');
+    newCreature.forms[i].formTextId.name = formTextIdName;
+    newCreature.forms[i].formTextId.description = formTextIdDescription;
+
+    newAllPokemon = {
+      ...allPokemon,
+      [newCreature.dbSymbol]: newCreature,
+    }; //To avoid getting same text IDs for other forms
+  }
+
+  return newCreature;
 };

--- a/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
@@ -87,18 +87,20 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
       setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, getText(CREATURE_SPECIE_TEXT_ID, creatures[selectedCreature].id));
 
       //Copy other forms texts
-      for (let i = 1; i < newCreature.forms.length; i++) {
+      let formCpt = 1;
+      newCreature.forms.slice(1).forEach((form) => {
         setText(
           CREATURE_FORM_NAME_TEXT_ID,
-          newCreature.forms[i].formTextId.name,
-          getText(CREATURE_FORM_NAME_TEXT_ID, creatures[selectedCreature].forms[i].formTextId.name)
+          form.formTextId.name,
+          getText(CREATURE_FORM_NAME_TEXT_ID, creatures[selectedCreature].forms[formCpt].formTextId.name)
         );
         setText(
           CREATURE_FORM_DESCRIPTION_TEXT_ID,
-          newCreature.forms[i].formTextId.description,
-          getText(CREATURE_FORM_DESCRIPTION_TEXT_ID, creatures[selectedCreature].forms[i].formTextId.description)
+          form.formTextId.description,
+          getText(CREATURE_FORM_DESCRIPTION_TEXT_ID, creatures[selectedCreature].forms[formCpt].formTextId.description)
         );
-      }
+        formCpt++;
+      });
     } else {
       setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, '-');
     }

--- a/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
@@ -8,13 +8,14 @@ import { TextInputError } from '@components/inputs/Input';
 import { checkDbSymbolExist, generateDefaultDbSymbol, wrongDbSymbol } from '@utils/dbSymbolUtils';
 import { useProjectPokemon, useProjectDex } from '@hooks/useProjectData';
 import { createCreature } from '@utils/entityCreation';
-import { useSetProjectText } from '@utils/ReadingProjectText';
+import { useSetProjectText, useGetProjectText } from '@utils/ReadingProjectText';
 import {
   CREATURE_DESCRIPTION_TEXT_ID,
   CREATURE_FORM_NAME_TEXT_ID,
   CREATURE_FORM_VALIDATOR,
   CREATURE_NAME_TEXT_ID,
   CREATURE_SPECIE_TEXT_ID,
+  CREATURE_FORM_DESCRIPTION_TEXT_ID,
 } from '@modelEntities/creature';
 import { DbSymbol } from '@modelEntities/dbSymbol';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
@@ -24,12 +25,27 @@ import { useZodForm } from '@hooks/useZodForm';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { TypeFields } from './InformationEditor/TypeFields';
 import { useSelectOptions } from '@hooks/useSelectOptions';
+import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
+import { SelectPokemon } from '@components/selects/SelectPokemon';
+import { importCreatureData } from '@utils/importEntityDataUtils';
 
 const ButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: 16px 0 0 0;
   gap: 8px;
+`;
+
+const ImportInfo = styled.div`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+`;
+
+const ImportInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 
 type Props = {
@@ -54,6 +70,9 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
   const form = { type1: (typeOptions[0]?.value || '__undef__') as DbSymbol, type2: '__undef__' as DbSymbol };
   const { getFormData, defaults, formRef } = useZodForm(CREATURE_NEW_EDITOR_SCHEMA, form);
   useEditorHandlingClose(ref);
+  const getText = useGetProjectText();
+  const [selectedCreature, setSelectedCreature] = useState('__undef__');
+  const [importing, setImporting] = useState(false);
 
   const onClickNew = () => {
     const result = getFormData();
@@ -61,10 +80,31 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
 
     const dbSymbol = dbSymbolRef.current.value as DbSymbol;
     const { type1, type2 } = result.data;
-    const newCreature = createCreature(creatures, dbSymbol, type1, type2);
+    let newCreature = createCreature(creatures, dbSymbol, type1, type2);
+
+    if (importing && selectedCreature !== '__undef__') {
+      newCreature = importCreatureData(newCreature, creatures[selectedCreature], creatures);
+      setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, getText(CREATURE_SPECIE_TEXT_ID, creatures[selectedCreature].id));
+
+      //Copy other forms texts
+      for (let i = 1; i < newCreature.forms.length; i++) {
+        setText(
+          CREATURE_FORM_NAME_TEXT_ID,
+          newCreature.forms[i].formTextId.name,
+          getText(CREATURE_FORM_NAME_TEXT_ID, creatures[selectedCreature].forms[i].formTextId.name)
+        );
+        setText(
+          CREATURE_FORM_DESCRIPTION_TEXT_ID,
+          newCreature.forms[i].formTextId.description,
+          getText(CREATURE_FORM_DESCRIPTION_TEXT_ID, creatures[selectedCreature].forms[i].formTextId.description)
+        );
+      }
+    } else {
+      setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, '-');
+    }
+
     setText(CREATURE_NAME_TEXT_ID, newCreature.id, name);
     setText(CREATURE_DESCRIPTION_TEXT_ID, newCreature.id, descriptionRef.current.value);
-    setText(CREATURE_SPECIE_TEXT_ID, newCreature.id, '-');
     setText(CREATURE_FORM_NAME_TEXT_ID, newCreature.forms[0].formTextId.name, formNameRef.current.value || name);
 
     setCreature({ [dbSymbol]: newCreature }, { pokemon: { specie: dbSymbol, form: 0 } });
@@ -138,6 +178,20 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
           {dbSymbolErrorType === 'value' && <TextInputError>{tMove('incorrect_format')}</TextInputError>}
           {dbSymbolErrorType === 'duplicate' && <TextInputError>{tMove('db_symbol_already_used')}</TextInputError>}
         </InputWithTopLabelContainer>
+        <InputGroupCollapse title={t('other_data')} gap="16px" onClick={() => setImporting(!importing)}>
+          <ImportInfoContainer>
+            <ImportInfo>{t('creature_import_info')}</ImportInfo>
+          </ImportInfoContainer>
+          <InputWithTopLabelContainer>
+            <Label htmlFor="select-creature-to-import">{t('import_creature_from')}</Label>
+            <SelectPokemon
+              dbSymbol={selectedCreature}
+              onChange={(dbSymbol) => setSelectedCreature(dbSymbol)}
+              noLabel
+              undefValueOption={t('none_option')}
+            />
+          </InputWithTopLabelContainer>
+        </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={isDisabled ? tMove('fields_asterisk_required') : undefined}>
             <PrimaryButton onClick={onClickNew} disabled={isDisabled}>


### PR DESCRIPTION
## Description

The user can now create a new Pokémon by importing data from another existing Pokémon.
All forms' data will be the same as the imported Pokémon, except for the base form which will have the types chosen in the editor.

closes #457 

## Tests to perform

Open the "New Pokémon" editor

### Creating a new Pokémon without importing any data

- [x] Fill the basic data and create the Pokémon => only the basic data is filled for the new Pokémon, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, leave the selection on "None" and create the Pokémon => only the basic data is filled for the new Pokémon, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, select a Pokémon, re-collapse the "other data" component and create the Pokémon => only the basic data is filled for the new Pokémon, all other data are filled with default values

### Creating a new Pokémon by importing data
- [x] Fill the basic data, un-collapse the "other data" component, select a Pokémon and create the Pokémon => the basic data is filled for the new Pokémon with the information you entered **AND** all other data are filled with the same data as the chosen Pokémon
- [x] Test with a Pokémon that only has 1 base form
- [x] Test with a Pokémon that has multiple forms

