### PR TITLE
Update upload-artifact action to v4 since v3 is deprecated

### DIFF
--- a/.github/actions/publish_studio/action.yml
+++ b/.github/actions/publish_studio/action.yml
@@ -19,7 +19,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Save to Github Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: studio_${{ env.BRANCH_NAME }}_${{ runner.os }}
         path: ./out/make


### PR DESCRIPTION
## Description

This PR updates our publish github action to make sure artifacts are properly created.

## Note before testing

See the github communication about deprecated version 3 of artifact related actions: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Tests to perform

- [x] Running `Production - CI Build` action properly creates Windows & Linux artifacts for the 2.4.2 release.
