### PR TITLE
Improve the page responsability of the zones database page

### DIFF
--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -258,12 +258,14 @@ export const useQuestPage = () => {
 
 export const useZonePage = () => {
   const { projectDataValues: zones, selectedDataIdentifier: zoneSelected, state } = useProjectDataReadonly('zones', 'zone');
+  const { projectDataValues: groups } = useProjectDataReadonly('groups', 'group');
   const zone = zones[zoneSelected];
   const zoneName = getEntityNameText(zone, state);
 
   return {
     zone,
     zoneName,
+    groups,
     cannotDelete: Object.keys(zones).length <= 1,
   };
 };

--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -255,3 +255,15 @@ export const useQuestPage = () => {
     cannotDelete: Object.keys(quests).length <= 1,
   };
 };
+
+export const useZonePage = () => {
+  const { projectDataValues: zones, selectedDataIdentifier: zoneSelected, state } = useProjectDataReadonly('zones', 'zone');
+  const zone = zones[zoneSelected];
+  const zoneName = getEntityNameText(zone, state);
+
+  return {
+    zone,
+    zoneName,
+    cannotDelete: Object.keys(zones).length <= 1,
+  };
+};

--- a/src/models/entities/zone.ts
+++ b/src/models/entities/zone.ts
@@ -7,6 +7,17 @@ const MAP_COORDINATE_VALIDATOR = z.object({
   y: z.union([POSITIVE_OR_ZERO_INT, z.null()]),
 });
 
+const FORCED_WEATHER_VALIDATOR = z.union([
+  z.null(),
+  z.literal(-1),
+  z.literal(0),
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+]);
+
 export const ZONE_VALIDATOR = z.object({
   klass: z.literal('Zone'),
   id: POSITIVE_OR_ZERO_INT,
@@ -18,10 +29,11 @@ export const ZONE_VALIDATOR = z.object({
   position: MAP_COORDINATE_VALIDATOR,
   isFlyAllowed: z.boolean(),
   isWarpDisallowed: z.boolean(),
-  forcedWeather: z.union([z.null(), z.literal(-1), z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)]),
+  forcedWeather: FORCED_WEATHER_VALIDATOR,
   wildGroups: z.array(DB_SYMBOL_VALIDATOR),
 });
 export type StudioZone = z.infer<typeof ZONE_VALIDATOR>;
+export type StudioZoneForcedWeather = z.infer<typeof FORCED_WEATHER_VALIDATOR>;
 
 export const ZONE_DESCRIPTION_TEXT_ID = 100064;
 export const ZONE_NAME_TEXT_ID = 100010;

--- a/src/views/components/database/zone/ZoneControlBar.tsx
+++ b/src/views/components/database/zone/ZoneControlBar.tsx
@@ -1,26 +1,39 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SelectChangeEvent } from '@components/SelectCustom/SelectCustomPropsInterface';
 import { ControlBar } from '@components/ControlBar';
 import { SelectZone } from '@components/selects';
 import { SecondaryButtonWithPlusIcon } from '@components/buttons';
-import { StudioZone } from '@modelEntities/zone';
 import { useSetCurrentDatabasePath } from '@hooks/useSetCurrentDatabasePage';
+import { ZoneDialogsRef } from './editors/ZoneEditorOverlay';
+import { useProjectZones } from '@src/hooks/useProjectData';
+import { StudioShortcutActions, useShortcut } from '@src/hooks/useShortcuts';
 
 type ZoneControlBarProps = {
-  onChange: SelectChangeEvent;
-  zone: StudioZone;
-  onClickNewZone: () => void;
+  dialogsRef?: ZoneDialogsRef;
 };
 
-export const ZoneControlBar = ({ onChange, zone, onClickNewZone }: ZoneControlBarProps) => {
+export const ZoneControlBar = ({ dialogsRef }: ZoneControlBarProps) => {
   const { t } = useTranslation('database_zones');
+  const { selectedDataIdentifier: zoneDbSymbol, setSelectedDataIdentifier, getPreviousDbSymbol, getNextDbSymbol } = useProjectZones();
   useSetCurrentDatabasePath();
+
+  const shortcutMap = useMemo<StudioShortcutActions>(() => {
+    const isShortcutEnabled = () => dialogsRef?.current?.currentDialog === undefined;
+    return {
+      db_previous: () => isShortcutEnabled() && setSelectedDataIdentifier({ zone: getPreviousDbSymbol('id') }),
+      db_next: () => isShortcutEnabled() && setSelectedDataIdentifier({ zone: getNextDbSymbol('id') }),
+      db_new: () => isShortcutEnabled() && dialogsRef?.current?.openDialog('new'),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zoneDbSymbol]);
+  useShortcut(shortcutMap);
+
+  const onClickNew = dialogsRef ? () => dialogsRef.current?.openDialog('new') : undefined;
 
   return (
     <ControlBar>
-      <SecondaryButtonWithPlusIcon onClick={onClickNewZone}>{t('new')}</SecondaryButtonWithPlusIcon>
-      <SelectZone dbSymbol={zone.dbSymbol} onChange={onChange} />
+      {onClickNew ? <SecondaryButtonWithPlusIcon onClick={onClickNew}>{t('new')}</SecondaryButtonWithPlusIcon> : <div />}
+      <SelectZone dbSymbol={zoneDbSymbol} onChange={(dbSymbol) => setSelectedDataIdentifier({ zone: dbSymbol })} />
     </ControlBar>
   );
 };

--- a/src/views/components/database/zone/ZoneFrame.tsx
+++ b/src/views/components/database/zone/ZoneFrame.tsx
@@ -5,6 +5,7 @@ import { padStr } from '@utils/PadStr';
 import { CopyIdentifier } from '@components/Copy';
 import { useGetEntityDescriptionText, useGetEntityNameText } from '@utils/ReadingProjectText';
 import { StudioZone } from '@modelEntities/zone';
+import { ZoneDialogsRef } from './editors/ZoneEditorOverlay';
 
 const DataZoneContainer = styled(DataInfoContainer)`
   gap: 8px;
@@ -12,14 +13,15 @@ const DataZoneContainer = styled(DataInfoContainer)`
 
 type ZoneFrameProps = {
   zone: StudioZone;
-  onClick: () => void;
+  dialogsRef: ZoneDialogsRef;
 };
 
-export const ZoneFrame = ({ zone, onClick }: ZoneFrameProps) => {
+export const ZoneFrame = ({ zone, dialogsRef }: ZoneFrameProps) => {
   const getZoneName = useGetEntityNameText();
   const getZoneDescription = useGetEntityDescriptionText();
+
   return (
-    <DataBlockContainer size="full" onClick={onClick}>
+    <DataBlockContainer size="full" onClick={() => dialogsRef.current?.openDialog('frame')}>
       <DataGrid columns="minmax(min-content, 1024px)">
         <DataZoneContainer>
           <DataInfoContainerHeaderTitle>

--- a/src/views/components/database/zone/ZoneGroups.tsx
+++ b/src/views/components/database/zone/ZoneGroups.tsx
@@ -4,28 +4,35 @@ import { DataBlockEditor } from '@components/editor';
 import { ProjectData } from '@src/GlobalStateProvider';
 import { ZoneGroupsTable } from './table';
 import { StudioZone } from '@modelEntities/zone';
+import { ZoneDialogsRef } from './editors/ZoneEditorOverlay';
 
 type ZoneGroupsProps = {
   zone: StudioZone;
   groups: ProjectData['groups'];
+  dialogsRef: ZoneDialogsRef;
+  setCurrentGroupIndex: (index: number) => void;
   onDelete: () => void;
-  onImport: () => void;
-  onNew: () => void;
-  onEdit: (index: number) => void;
 };
 
-export const ZoneGroups = ({ zone, groups, onDelete, onImport, onNew, onEdit }: ZoneGroupsProps) => {
+export const ZoneGroups = ({ zone, groups, dialogsRef, setCurrentGroupIndex, onDelete }: ZoneGroupsProps) => {
   const { t } = useTranslation('database_zones');
+  const groupLength = Object.keys(groups).length;
+
+  const onEdit = (index: number) => {
+    setCurrentGroupIndex(index);
+    dialogsRef.current?.openDialog('editGroup');
+  };
+
   return (
     <DataBlockEditor
       size="full"
       title={t('groups_of_zone')}
       onClickDelete={onDelete}
-      importation={{ label: t('import_groups'), onClick: onImport }}
-      add={{ label: t('add_group'), onClick: onNew }}
+      importation={{ label: t('import_groups'), onClick: () => dialogsRef.current?.openDialog('importGroup') }}
+      add={{ label: t('add_group'), onClick: () => dialogsRef.current?.openDialog('addGroup') }}
       disabledDeletion={zone.wildGroups.length === 0}
-      disabledImport={Object.entries(groups).length <= 1}
-      disabledAdd={Object.entries(groups).length <= zone.wildGroups.length}
+      disabledImport={groupLength <= 1}
+      disabledAdd={groupLength <= zone.wildGroups.length}
     >
       <ZoneGroupsTable zone={zone} groups={groups} onEdit={onEdit} />
     </DataBlockEditor>

--- a/src/views/components/database/zone/ZoneGroups.tsx
+++ b/src/views/components/database/zone/ZoneGroups.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataBlockEditor } from '@components/editor';
 import { ProjectData } from '@src/GlobalStateProvider';
@@ -11,12 +11,11 @@ type ZoneGroupsProps = {
   groups: ProjectData['groups'];
   dialogsRef: ZoneDialogsRef;
   setCurrentGroupIndex: (index: number) => void;
-  onDelete: () => void;
 };
 
-export const ZoneGroups = ({ zone, groups, dialogsRef, setCurrentGroupIndex, onDelete }: ZoneGroupsProps) => {
+export const ZoneGroups = ({ zone, groups, dialogsRef, setCurrentGroupIndex }: ZoneGroupsProps) => {
   const { t } = useTranslation('database_zones');
-  const groupLength = Object.keys(groups).length;
+  const groupLength = useMemo(() => Object.keys(groups).length, [groups]);
 
   const onEdit = (index: number) => {
     setCurrentGroupIndex(index);
@@ -27,7 +26,7 @@ export const ZoneGroups = ({ zone, groups, dialogsRef, setCurrentGroupIndex, onD
     <DataBlockEditor
       size="full"
       title={t('groups_of_zone')}
-      onClickDelete={onDelete}
+      onClickDelete={() => dialogsRef.current?.openDialog('deleteGroupsZone', true)}
       importation={{ label: t('import_groups'), onClick: () => dialogsRef.current?.openDialog('importGroup') }}
       add={{ label: t('add_group'), onClick: () => dialogsRef.current?.openDialog('addGroup') }}
       disabledDeletion={zone.wildGroups.length === 0}

--- a/src/views/components/database/zone/ZoneSettings.tsx
+++ b/src/views/components/database/zone/ZoneSettings.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Code } from '@components/Code';
 import { padStr } from '@utils/PadStr';
 import { StudioZone } from '@modelEntities/zone';
+import { ZoneDialogsRef } from './editors/ZoneEditorOverlay';
 
 const MapsListContainer = styled.div`
   display: flex;
@@ -16,14 +17,14 @@ const MapsListContainer = styled.div`
 
 type ZoneSettingsProps = {
   zone: StudioZone;
-  onClick: () => void;
+  dialogsRef: ZoneDialogsRef;
 };
 
-export const ZoneSettings = ({ zone, onClick }: ZoneSettingsProps) => {
+export const ZoneSettings = ({ zone, dialogsRef }: ZoneSettingsProps) => {
   const { t } = useTranslation('database_zones');
 
   return (
-    <DataBlockWithTitle size="half" title={t('settings')} onClick={onClick}>
+    <DataBlockWithTitle size="half" title={t('settings')} onClick={() => dialogsRef.current?.openDialog('settings')}>
       <DataGrid columns="1fr" rows="1fr 53px 42px">
         {zone.maps.length === 0 ? (
           <DataFieldsetField label={t('maps_list')} data={t('no_map')} disabled={true} />
@@ -41,7 +42,7 @@ export const ZoneSettings = ({ zone, onClick }: ZoneSettingsProps) => {
         <DataFieldsetFieldCode label={t('displayed_panel')} data={`#${padStr(zone.panelId, 2)}`} size="m" />
         <DataFieldsetField
           label={t('forced_weather')}
-          data={zone.forcedWeather === null ? t('weather-1') : t(`weather${zone.forcedWeather}` as never)}
+          data={zone.forcedWeather === null ? t('weather-1') : t(`weather${zone.forcedWeather}`)}
           disabled={zone.forcedWeather === null}
         />
       </DataGrid>

--- a/src/views/components/database/zone/ZoneTravel.tsx
+++ b/src/views/components/database/zone/ZoneTravel.tsx
@@ -3,20 +3,21 @@ import { DataBlockWithTitle, DataGrid } from '../dataBlocks';
 import { useTranslation } from 'react-i18next';
 import { DataFieldsetField, DataFieldsetFieldCode } from '../dataBlocks/DataFieldsetField';
 import { StudioZone } from '@modelEntities/zone';
+import { ZoneDialogsRef } from './editors/ZoneEditorOverlay';
 
 const isPositionUndefined = (zone: StudioZone) => zone.position.x === null || zone.position.y === null;
 const isWarpUndefined = (zone: StudioZone) => zone.warp.x === null || zone.warp.y === null;
 
 type ZoneTravelProps = {
   zone: StudioZone;
-  onClick: () => void;
+  dialogsRef: ZoneDialogsRef;
 };
 
-export const ZoneTravel = ({ zone, onClick }: ZoneTravelProps) => {
+export const ZoneTravel = ({ zone, dialogsRef }: ZoneTravelProps) => {
   const { t } = useTranslation('database_zones');
 
   return (
-    <DataBlockWithTitle size="half" title={t('travel')} onClick={onClick}>
+    <DataBlockWithTitle size="half" title={t('travel')} onClick={() => dialogsRef.current?.openDialog('travel')}>
       <DataGrid columns="136px 1fr" rows="53px 53px">
         <DataFieldsetField label={t('warp')} data={zone.isWarpDisallowed ? t('not_allowed') : t('allowed')} />
         <DataFieldsetField label={t('zone_type')} data={zone.isFlyAllowed ? t('outdoor') : t('indoor')} />

--- a/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
-import { Editor, useRefreshUI } from '@components/editor';
+import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectGroup } from '@components/selects';
@@ -10,9 +10,7 @@ import { DarkButton, PrimaryButton, SecondaryButton } from '@components/buttons'
 import { TagWithSelection } from '@components/Tag';
 import { TooltipWrapper } from '@ds/Tooltip';
 
-import { ProjectData } from '@src/GlobalStateProvider';
 import { useZonePage } from '@src/hooks/usePage';
-import { useProjectGroups, useProjectZones } from '@src/hooks/useProjectData';
 
 import { StudioGroup } from '@modelEntities/group';
 import { StudioZone } from '@modelEntities/zone';
@@ -21,6 +19,8 @@ import { DbSymbol } from '@modelEntities/dbSymbol';
 import { padStr } from '@utils/PadStr';
 import { cloneEntity } from '@utils/cloneEntity';
 import { defineRelationCustomCondition } from '@utils/GroupUtils';
+import { useUpdateZone } from './useUpdateZone';
+import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
 
 const GroupContainer = styled.div`
   display: flex;
@@ -50,6 +50,7 @@ const setAllTagsMapsOnByDefault = (group: StudioGroup, zone: StudioZone) => {
     const index = mapIdIndexInGroup(mapId, group);
     if (index === -1) group.customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
   });
+  return group;
 };
 
 type ZoneAddGroupEditorProps = {
@@ -58,35 +59,39 @@ type ZoneAddGroupEditorProps = {
 
 export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEditorProps>(({ closeDialog }, ref) => {
   const { t } = useTranslation(['database_zones', 'database_groups', 'database_trainers']);
-  const { projectDataValues: groups, setProjectDataValues: setGroup } = useProjectGroups();
-  const { setProjectDataValues: setZone } = useProjectZones();
-  const { zone } = useZonePage();
+  const { zone, groups } = useZonePage();
+  const updateZone = useUpdateZone(zone);
 
   const firstDbSymbol = Object.entries(groups)
     .map(([value, groupData]) => ({ value, index: groupData.id }))
     .filter((data) => !zone.wildGroups.includes(data.value as DbSymbol))
     .sort((a, b) => a.index - b.index)[0].value;
 
-  const [selectedGroup, setSelectedGroup] = useState(firstDbSymbol);
-  const group = groups[selectedGroup];
-  const currentEditedGroup = useMemo(() => cloneEntity(group), [group]);
-  const currentEditedZone = useMemo(() => cloneEntity(zone), [zone]);
-  useMemo(() => setAllTagsMapsOnByDefault(currentEditedGroup, zone), [currentEditedGroup, zone]);
+  const [group, setGroup] = useState<StudioGroup>(setAllTagsMapsOnByDefault(cloneEntity(groups[firstDbSymbol]), zone));
+  const updateGroup = useUpdateGroup(group);
 
-  const refreshUI = useRefreshUI();
-
-  const onClickTag = (mapId: number) => {
-    const index = mapIdIndexInGroup(mapId, currentEditedGroup);
-    if (index === -1) currentEditedGroup.customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
-    else currentEditedGroup.customConditions.splice(index, 1);
+  const onChange = (dbSymbol: string) => {
+    setGroup(setAllTagsMapsOnByDefault(cloneEntity(groups[dbSymbol]), zone));
   };
 
-  const onAddGroup = (editedGroup: StudioGroup) => {
-    currentEditedZone.wildGroups.push(editedGroup.dbSymbol);
-    editedGroup.customConditions = defineRelationCustomCondition(editedGroup.customConditions);
-    setZone({ [zone.dbSymbol]: currentEditedZone });
-    setGroup({ [editedGroup.dbSymbol]: editedGroup });
+  const onClickTag = (mapId: number) => {
+    const index = mapIdIndexInGroup(mapId, group);
+    const customConditions = cloneEntity(group.customConditions);
+    if (index === -1) {
+      customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
+    } else {
+      customConditions.splice(index, 1);
+    }
+    setGroup({ ...group, customConditions });
+  };
 
+  const onAddGroup = () => {
+    const wildGroups = cloneEntity(zone.wildGroups);
+    const customConditions = cloneEntity(group.customConditions);
+    wildGroups.push(group.dbSymbol);
+
+    updateZone({ wildGroups });
+    updateGroup({ customConditions: defineRelationCustomCondition(customConditions) });
     closeDialog();
   };
 
@@ -100,7 +105,7 @@ export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEd
           <GroupContainer>
             <SelectGroup
               dbSymbol={group.dbSymbol}
-              onChange={(dbSymbol) => setSelectedGroup(dbSymbol)}
+              onChange={onChange}
               filter={(dbSymbol) => !zone.wildGroups.includes(dbSymbol as DbSymbol)}
               noLabel
             />
@@ -116,7 +121,7 @@ export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEd
               {zone.maps
                 .sort((a, b) => a - b)
                 .map((id, index) => (
-                  <TagWithSelection key={index} onClick={() => refreshUI(onClickTag(id))} selected={mapIdIndexInGroup(id, currentEditedGroup) !== -1}>
+                  <TagWithSelection key={index} onClick={() => onClickTag(id)} selected={mapIdIndexInGroup(id, group) !== -1}>
                     <span className="map-id">{padStr(id, 2)}</span>
                   </TagWithSelection>
                 ))}
@@ -124,10 +129,11 @@ export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEd
           </InputWithTopLabelContainer>
         )}
         <ButtonContainer>
-          <PrimaryButton onClick={() => onAddGroup(currentEditedGroup)}>{t('database_zones:add_this_group')}</PrimaryButton>
+          <PrimaryButton onClick={onAddGroup}>{t('database_zones:add_this_group')}</PrimaryButton>
           <DarkButton onClick={closeDialog}>{t('database_zones:cancel')}</DarkButton>
         </ButtonContainer>
       </InputContainer>
     </Editor>
   );
 });
+ZoneAddGroupEditor.displayName = 'ZoneAddGroupEditor';

--- a/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
@@ -1,18 +1,26 @@
-import React, { useMemo, useState } from 'react';
+import React, { forwardRef, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+
 import { Editor, useRefreshUI } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectGroup } from '@components/selects';
-import { ProjectData } from '@src/GlobalStateProvider';
 import { DarkButton, PrimaryButton, SecondaryButton } from '@components/buttons';
 import { TagWithSelection } from '@components/Tag';
-import { padStr } from '@utils/PadStr';
-import { cloneEntity } from '@utils/cloneEntity';
+import { TooltipWrapper } from '@ds/Tooltip';
+
+import { ProjectData } from '@src/GlobalStateProvider';
+import { useZonePage } from '@src/hooks/usePage';
+import { useProjectGroups, useProjectZones } from '@src/hooks/useProjectData';
+
 import { StudioGroup } from '@modelEntities/group';
 import { StudioZone } from '@modelEntities/zone';
 import { DbSymbol } from '@modelEntities/dbSymbol';
-import { TooltipWrapper } from '@ds/Tooltip';
+
+import { padStr } from '@utils/PadStr';
+import { cloneEntity } from '@utils/cloneEntity';
+import { defineRelationCustomCondition } from '@utils/GroupUtils';
 
 const GroupContainer = styled.div`
   display: flex;
@@ -45,29 +53,44 @@ const setAllTagsMapsOnByDefault = (group: StudioGroup, zone: StudioZone) => {
 };
 
 type ZoneAddGroupEditorProps = {
-  zone: StudioZone;
-  groups: ProjectData['groups'];
-  onAddGroup: (group: StudioGroup) => void;
-  onClose: () => void;
+  closeDialog: () => void;
 };
 
-export const ZoneAddGroupEditor = ({ zone, groups, onAddGroup, onClose }: ZoneAddGroupEditorProps) => {
+export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEditorProps>(({ closeDialog }, ref) => {
   const { t } = useTranslation(['database_zones', 'database_groups', 'database_trainers']);
+  const { projectDataValues: groups, setProjectDataValues: setGroup } = useProjectGroups();
+  const { setProjectDataValues: setZone } = useProjectZones();
+  const { zone } = useZonePage();
+
   const firstDbSymbol = Object.entries(groups)
     .map(([value, groupData]) => ({ value, index: groupData.id }))
-    .filter((d) => !zone.wildGroups.includes(d.value as DbSymbol))
+    .filter((data) => !zone.wildGroups.includes(data.value as DbSymbol))
     .sort((a, b) => a.index - b.index)[0].value;
+
   const [selectedGroup, setSelectedGroup] = useState(firstDbSymbol);
   const group = groups[selectedGroup];
   const currentEditedGroup = useMemo(() => cloneEntity(group), [group]);
-  const refreshUI = useRefreshUI();
+  const currentEditedZone = useMemo(() => cloneEntity(zone), [zone]);
   useMemo(() => setAllTagsMapsOnByDefault(currentEditedGroup, zone), [currentEditedGroup, zone]);
+
+  const refreshUI = useRefreshUI();
 
   const onClickTag = (mapId: number) => {
     const index = mapIdIndexInGroup(mapId, currentEditedGroup);
     if (index === -1) currentEditedGroup.customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
     else currentEditedGroup.customConditions.splice(index, 1);
   };
+
+  const onAddGroup = (editedGroup: StudioGroup) => {
+    currentEditedZone.wildGroups.push(editedGroup.dbSymbol);
+    editedGroup.customConditions = defineRelationCustomCondition(editedGroup.customConditions);
+    setZone({ [zone.dbSymbol]: currentEditedZone });
+    setGroup({ [editedGroup.dbSymbol]: editedGroup });
+
+    closeDialog();
+  };
+
+  useEditorHandlingClose(ref);
 
   return (
     <Editor type="creation" title={t('database_groups:groups')}>
@@ -102,9 +125,9 @@ export const ZoneAddGroupEditor = ({ zone, groups, onAddGroup, onClose }: ZoneAd
         )}
         <ButtonContainer>
           <PrimaryButton onClick={() => onAddGroup(currentEditedGroup)}>{t('database_zones:add_this_group')}</PrimaryButton>
-          <DarkButton onClick={onClose}>{t('database_zones:cancel')}</DarkButton>
+          <DarkButton onClick={closeDialog}>{t('database_zones:cancel')}</DarkButton>
         </ButtonContainer>
       </InputContainer>
     </Editor>
   );
-};
+});

--- a/src/views/components/database/zone/editors/ZoneDeletion.tsx
+++ b/src/views/components/database/zone/editors/ZoneDeletion.tsx
@@ -1,0 +1,37 @@
+import { Deletion } from '@components/deletion';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { getEntityNameText } from '@utils/ReadingProjectText';
+import { useProjectZones } from '@hooks/useProjectData';
+import React, { forwardRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type ZoneDeletionProps = {
+  closeDialog: () => void;
+};
+
+/**
+ * Component responsive of asking the user if they really want to delete the zone before doing so.
+ */
+export const ZoneDeletion = forwardRef<EditorHandlingClose, ZoneDeletionProps>(({ closeDialog }, ref) => {
+  const { t } = useTranslation('database_zones');
+  const { projectDataValues: zones, selectedDataIdentifier: dbSymbol, removeProjectDataValue: deleteZone, state } = useProjectZones();
+  const zone = zones[dbSymbol];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const zoneName = useMemo(() => getEntityNameText(zone, state), []);
+
+  const onClickDelete = () => {
+    const firstDbSymbol = Object.entries(zones)
+      .map(([value, zoneData]) => ({ value, index: zoneData.id }))
+      .filter((d) => d.value !== dbSymbol)
+      .sort((a, b) => a.index - b.index)[0].value;
+    closeDialog();
+    deleteZone(dbSymbol, { zone: firstDbSymbol });
+  };
+
+  useEditorHandlingClose(ref);
+
+  return (
+    <Deletion title={t('deletion_of_zone')} message={t('deletion_message', { zone: zoneName })} onClickDelete={onClickDelete} onClose={closeDialog} />
+  );
+});
+ZoneDeletion.displayName = 'ZoneDeletion';

--- a/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+
 import { Editor, useRefreshUI } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectGroup } from '@components/selects';
-import { ProjectData } from '@src/GlobalStateProvider';
 import { TagWithSelection } from '@components/Tag';
+
+import { useZonePage } from '@src/hooks/usePage';
+
+import { StudioGroup } from '@modelEntities/group';
+import { DbSymbol } from '@modelEntities/dbSymbol';
+
 import { padStr } from '@utils/PadStr';
 import { cloneEntity } from '@utils/cloneEntity';
-import { StudioGroup } from '@modelEntities/group';
-import { StudioZone } from '@modelEntities/zone';
-import { DbSymbol } from '@modelEntities/dbSymbol';
 
 const MapsListContainer = styled.div`
   display: flex;
@@ -29,14 +33,9 @@ const rejectedGroup = (wildGroups: string[], group: StudioGroup) => {
   return wildGroupsCopy;
 };
 
-type ZoneEditGroupEditorProps = {
-  zone: StudioZone;
-  groups: ProjectData['groups'];
-  group: { data: StudioGroup } | undefined;
-  index: number;
-};
+export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose>((_, ref) => {
+  const { zone } = useZonePage();
 
-export const ZoneEditGroupEditor = ({ zone, groups, group, index }: ZoneEditGroupEditorProps) => {
   if (!group) throw new Error('group is undefined');
 
   const { t } = useTranslation(['database_zones', 'database_groups']);
@@ -52,6 +51,18 @@ export const ZoneEditGroupEditor = ({ zone, groups, group, index }: ZoneEditGrou
     if (mapIdIndex === -1) group.data.customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
     else group.data.customConditions.splice(mapIdIndex, 1);
   };
+
+  const canClose = () => {
+    const result = true;
+
+    return result;
+  };
+
+  const onClose = () => {
+    if (!canClose()) return;
+  };
+
+  useEditorHandlingClose(ref, onClose, canClose);
 
   return (
     <Editor type="creation" title={t('database_groups:groups')}>
@@ -82,4 +93,4 @@ export const ZoneEditGroupEditor = ({ zone, groups, group, index }: ZoneEditGrou
       </InputContainer>
     </Editor>
   );
-};
+});

--- a/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
-import { Editor, useRefreshUI } from '@components/editor';
+import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectGroup } from '@components/selects';
@@ -15,6 +15,9 @@ import { DbSymbol } from '@modelEntities/dbSymbol';
 
 import { padStr } from '@utils/PadStr';
 import { cloneEntity } from '@utils/cloneEntity';
+import { useUpdateZone } from './useUpdateZone';
+import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
+import { defineRelationCustomCondition } from '@utils/GroupUtils';
 
 const MapsListContainer = styled.div`
   display: flex;
@@ -33,36 +36,45 @@ const rejectedGroup = (wildGroups: string[], group: StudioGroup) => {
   return wildGroupsCopy;
 };
 
-export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose>((_, ref) => {
-  const { zone } = useZonePage();
+type ZoneEditGroupEditorProps = {
+  currentGroupIndex: number;
+};
 
-  if (!group) throw new Error('group is undefined');
-
+export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose, ZoneEditGroupEditorProps>(({ currentGroupIndex }, ref) => {
+  const { zone, groups } = useZonePage();
+  const updateZone = useUpdateZone(zone);
+  const [group, setGroup] = useState<StudioGroup>(cloneEntity(groups[zone.wildGroups[currentGroupIndex]]));
+  const updateGroup = useUpdateGroup(group);
+  const [wildGroups, setWildGroups] = useState(cloneEntity(zone.wildGroups));
   const { t } = useTranslation(['database_zones', 'database_groups']);
-  const refreshUI = useRefreshUI();
 
   const onChangeGroup = (dbSymbol: string) => {
-    group.data = cloneEntity(groups[dbSymbol]);
-    zone.wildGroups[index] = dbSymbol as DbSymbol;
+    setGroup(cloneEntity(groups[dbSymbol]));
+    const wildGroupsEdited = cloneEntity(wildGroups);
+    wildGroupsEdited[currentGroupIndex] = dbSymbol as DbSymbol;
+    setWildGroups(wildGroupsEdited);
   };
 
   const onClickTag = (mapId: number) => {
-    const mapIdIndex = mapIdIndexInGroup(mapId, group.data);
-    if (mapIdIndex === -1) group.data.customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
-    else group.data.customConditions.splice(mapIdIndex, 1);
-  };
-
-  const canClose = () => {
-    const result = true;
-
-    return result;
+    const mapIdIndex = mapIdIndexInGroup(mapId, group);
+    const customConditions = cloneEntity(group.customConditions);
+    if (mapIdIndex === -1) {
+      customConditions.push({ type: 'mapId', relationWithPreviousCondition: 'OR', value: mapId });
+    } else {
+      customConditions.splice(mapIdIndex, 1);
+    }
+    setGroup({ ...group, customConditions });
   };
 
   const onClose = () => {
-    if (!canClose()) return;
+    const customConditions = cloneEntity(group.customConditions);
+    updateZone({
+      wildGroups: wildGroups,
+    });
+    updateGroup({ customConditions: defineRelationCustomCondition(customConditions) });
   };
 
-  useEditorHandlingClose(ref, onClose, canClose);
+  useEditorHandlingClose(ref, onClose);
 
   return (
     <Editor type="creation" title={t('database_groups:groups')}>
@@ -70,9 +82,9 @@ export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose>((_, ref) => {
         <InputWithTopLabelContainer>
           <Label htmlFor="groups">{t('database_groups:group')}</Label>
           <SelectGroup
-            dbSymbol={group.data.dbSymbol}
-            onChange={(dbSymbol) => refreshUI(onChangeGroup(dbSymbol))}
-            filter={(dbSymbol) => !rejectedGroup(zone.wildGroups, group.data).includes(dbSymbol as DbSymbol)}
+            dbSymbol={group.dbSymbol}
+            onChange={(dbSymbol) => onChangeGroup(dbSymbol)}
+            filter={(dbSymbol) => !rejectedGroup(wildGroups, group).includes(dbSymbol as DbSymbol)}
             noLabel
           />
         </InputWithTopLabelContainer>
@@ -83,7 +95,7 @@ export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose>((_, ref) => {
               {zone.maps
                 .sort((a, b) => a - b)
                 .map((id, mapIdIndex) => (
-                  <TagWithSelection key={mapIdIndex} onClick={() => refreshUI(onClickTag(id))} selected={mapIdIndexInGroup(id, group.data) !== -1}>
+                  <TagWithSelection key={mapIdIndex} onClick={() => onClickTag(id)} selected={mapIdIndexInGroup(id, group) !== -1}>
                     <span className="map-id">{padStr(id, 2)}</span>
                   </TagWithSelection>
                 ))}
@@ -94,3 +106,4 @@ export const ZoneEditGroupEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     </Editor>
   );
 });
+ZoneEditGroupEditor.displayName = 'ZoneEditGroupEditor';

--- a/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
@@ -19,23 +19,26 @@ export type ZoneDialogsRef = React.RefObject<DialogRefData<ZoneEditorAndDeletion
  * Editor overlay for the zones.
  * This component uses the generic editor overlay to show the components based on what's called from dialogsRef.
  */
-export const ZoneEditorOverlay = defineEditorOverlay<ZoneEditorAndDeletionKeys>('ZoneEditorOverlay', (dialogToShow, handleCloseRef, closeDialog) => {
-  switch (dialogToShow) {
-    case 'new':
-      return <ZoneNewEditor closeDialog={closeDialog} ref={handleCloseRef} />;
-    case 'frame':
-      return <ZoneFrameEditor ref={handleCloseRef} />;
-    case 'settings':
-      return <ZoneSettingsEditor ref={handleCloseRef} />;
-    case 'travel':
-      return <ZoneTravelEditor ref={handleCloseRef} />;
-    case 'addGroup':
-      return <ZoneAddGroupEditor closeDialog={closeDialog} ref={handleCloseRef} />;
-    case 'editGroup':
-      return <ZoneEditGroupEditor ref={handleCloseRef} />;
-    case 'importGroup':
-      return <ZoneGroupImportEditor closeDialog={closeDialog} ref={handleCloseRef} />;
-    default:
-      assertUnreachable(dialogToShow);
+export const ZoneEditorOverlay = defineEditorOverlay<ZoneEditorAndDeletionKeys, { currentGroupIndex: number }>(
+  'ZoneEditorOverlay',
+  (dialogToShow, handleCloseRef, closeDialog, props) => {
+    switch (dialogToShow) {
+      case 'new':
+        return <ZoneNewEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+      case 'frame':
+        return <ZoneFrameEditor ref={handleCloseRef} />;
+      case 'settings':
+        return <ZoneSettingsEditor ref={handleCloseRef} />;
+      case 'travel':
+        return <ZoneTravelEditor ref={handleCloseRef} />;
+      case 'addGroup':
+        return <ZoneAddGroupEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+      case 'editGroup':
+        return <ZoneEditGroupEditor ref={handleCloseRef} currentGroupIndex={props.currentGroupIndex} />;
+      case 'importGroup':
+        return <ZoneGroupImportEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+      default:
+        assertUnreachable(dialogToShow);
+    }
   }
-});
+);

--- a/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
+import { DialogRefData } from '@hooks/useDialogsRef';
+import { assertUnreachable } from '@utils/assertUnreachable';
+import {
+  ZoneNewEditor,
+  ZoneFrameEditor,
+  ZoneSettingsEditor,
+  ZoneTravelEditor,
+  ZoneAddGroupEditor,
+  ZoneEditGroupEditor,
+  ZoneGroupImportEditor,
+} from '.';
+
+export type ZoneEditorAndDeletionKeys = 'new' | 'frame' | 'settings' | 'travel' | 'addGroup' | 'editGroup' | 'importGroup';
+export type ZoneDialogsRef = React.RefObject<DialogRefData<ZoneEditorAndDeletionKeys>>;
+
+/**
+ * Editor overlay for the zones.
+ * This component uses the generic editor overlay to show the components based on what's called from dialogsRef.
+ */
+export const ZoneEditorOverlay = defineEditorOverlay<ZoneEditorAndDeletionKeys>('ZoneEditorOverlay', (dialogToShow, handleCloseRef, closeDialog) => {
+  switch (dialogToShow) {
+    case 'new':
+      return <ZoneNewEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+    case 'frame':
+      return <ZoneFrameEditor ref={handleCloseRef} />;
+    case 'settings':
+      return <ZoneSettingsEditor ref={handleCloseRef} />;
+    case 'travel':
+      return <ZoneTravelEditor ref={handleCloseRef} />;
+    case 'addGroup':
+      return <ZoneAddGroupEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+    case 'editGroup':
+      return <ZoneEditGroupEditor ref={handleCloseRef} />;
+    case 'importGroup':
+      return <ZoneGroupImportEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+    default:
+      assertUnreachable(dialogToShow);
+  }
+});

--- a/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditorOverlay.tsx
@@ -10,9 +10,20 @@ import {
   ZoneAddGroupEditor,
   ZoneEditGroupEditor,
   ZoneGroupImportEditor,
+  ZoneDeletion,
+  ZoneGroupsDeletion,
 } from '.';
 
-export type ZoneEditorAndDeletionKeys = 'new' | 'frame' | 'settings' | 'travel' | 'addGroup' | 'editGroup' | 'importGroup';
+export type ZoneEditorAndDeletionKeys =
+  | 'new'
+  | 'frame'
+  | 'settings'
+  | 'travel'
+  | 'addGroup'
+  | 'editGroup'
+  | 'importGroup'
+  | 'deleteZone'
+  | 'deleteGroupsZone';
 export type ZoneDialogsRef = React.RefObject<DialogRefData<ZoneEditorAndDeletionKeys>>;
 
 /**
@@ -37,6 +48,10 @@ export const ZoneEditorOverlay = defineEditorOverlay<ZoneEditorAndDeletionKeys, 
         return <ZoneEditGroupEditor ref={handleCloseRef} currentGroupIndex={props.currentGroupIndex} />;
       case 'importGroup':
         return <ZoneGroupImportEditor closeDialog={closeDialog} ref={handleCloseRef} />;
+      case 'deleteZone':
+        return <ZoneDeletion closeDialog={closeDialog} ref={handleCloseRef} />;
+      case 'deleteGroupsZone':
+        return <ZoneGroupsDeletion closeDialog={closeDialog} ref={handleCloseRef} />;
       default:
         assertUnreachable(dialogToShow);
     }

--- a/src/views/components/database/zone/editors/ZoneFrameEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneFrameEditor.tsx
@@ -64,13 +64,13 @@ export const ZoneFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
           <Label htmlFor="name" required>
             {t('name')}
           </Label>
-          <TranslateInputContainer onTranslateClick={() => handleTranslateClick('translation_name')}>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_name')}>
             <Input type="text" name="zone-name" defaultValue={getText(ZONE_NAME_TEXT_ID, zone.id)} ref={nameRef} placeholder={t('example_name')} />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
           <Label htmlFor="descr">{t('description')}</Label>
-          <TranslateInputContainer onTranslateClick={() => handleTranslateClick('translation_description')}>
+          <TranslateInputContainer onTranslateClick={handleTranslateClick('translation_description')}>
             <MultiLineInput
               id="descr"
               defaultValue={getText(ZONE_DESCRIPTION_TEXT_ID, zone.id)}

--- a/src/views/components/database/zone/editors/ZoneFrameEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneFrameEditor.tsx
@@ -1,23 +1,61 @@
-import React from 'react';
-import { Editor } from '@components/editor';
-
+import React, { forwardRef, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { Input, InputContainer, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
-import type { OpenTranslationEditorFunction } from '@hooks/useTranslationEditor';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
-import { useGetEntityDescriptionText, useGetEntityNameText, useSetProjectText } from '@utils/ReadingProjectText';
-import { StudioZone, ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
 
-type ZoneFrameEditorProps = {
-  zone: StudioZone;
-  openTranslationEditor: OpenTranslationEditorFunction;
-};
+import { useZonePage } from '@src/hooks/usePage';
+import { useDialogsRef } from '@src/hooks/useDialogsRef';
 
-export const ZoneFrameEditor = ({ zone, openTranslationEditor }: ZoneFrameEditorProps) => {
+import { ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
+
+import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
+
+import { ZoneTranslationEditorTitle, ZoneTranslationOverlay } from './ZoneTranslationOverlay';
+
+export const ZoneFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
+  const dialogsRef = useDialogsRef<ZoneTranslationEditorTitle>();
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
   const { t } = useTranslation('database_zones');
   const setText = useSetProjectText();
-  const getZoneName = useGetEntityNameText();
-  const getZoneDescription = useGetEntityDescriptionText();
+  const getText = useGetProjectText();
+  const { zone } = useZonePage();
+
+  const saveTexts = () => {
+    if (!nameRef.current || !descriptionRef.current) return;
+
+    setText(ZONE_NAME_TEXT_ID, zone.id, nameRef.current.value);
+    setText(ZONE_DESCRIPTION_TEXT_ID, zone.id, descriptionRef.current.value);
+  };
+
+  const canClose = () => {
+    const result = !!nameRef.current?.value;
+    return result && !dialogsRef.current?.currentDialog;
+  };
+
+  const onClose = () => {
+    if (!canClose()) return;
+
+    saveTexts();
+  };
+
+  useEditorHandlingClose(ref, onClose, canClose);
+
+  const handleTranslateClick = (editorTitle: ZoneTranslationEditorTitle) => () => {
+    saveTexts();
+    setTimeout(() => dialogsRef.current?.openDialog(editorTitle), 0);
+  };
+
+  const onTranslationOverlayClose = () => {
+    if (!nameRef.current || !descriptionRef.current) return;
+
+    nameRef.current.value = nameRef.current.defaultValue;
+    descriptionRef.current.value = descriptionRef.current.defaultValue;
+  };
 
   return (
     <Editor type="edit" title={t('informations')}>
@@ -26,28 +64,24 @@ export const ZoneFrameEditor = ({ zone, openTranslationEditor }: ZoneFrameEditor
           <Label htmlFor="name" required>
             {t('name')}
           </Label>
-          <TranslateInputContainer onTranslateClick={() => openTranslationEditor('translation_name')}>
-            <Input
-              type="text"
-              name="name"
-              value={getZoneName(zone)}
-              onChange={(event) => setText(ZONE_NAME_TEXT_ID, zone.id, event.target.value)}
-              placeholder={t('example_name')}
-            />
+          <TranslateInputContainer onTranslateClick={() => handleTranslateClick('translation_name')}>
+            <Input type="text" name="zone-name" defaultValue={getText(ZONE_NAME_TEXT_ID, zone.id)} ref={nameRef} placeholder={t('example_name')} />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
           <Label htmlFor="descr">{t('description')}</Label>
-          <TranslateInputContainer onTranslateClick={() => openTranslationEditor('translation_description')}>
+          <TranslateInputContainer onTranslateClick={() => handleTranslateClick('translation_description')}>
             <MultiLineInput
               id="descr"
-              value={getZoneDescription(zone)}
-              onChange={(event) => setText(ZONE_DESCRIPTION_TEXT_ID, zone.id, event.target.value)}
+              defaultValue={getText(ZONE_DESCRIPTION_TEXT_ID, zone.id)}
+              ref={descriptionRef}
               placeholder={t('example_descr')}
             />
           </TranslateInputContainer>
         </InputWithTopLabelContainer>
+        <ZoneTranslationOverlay zone={zone} onClose={onTranslationOverlayClose} ref={dialogsRef} />
       </InputContainer>
     </Editor>
   );
-};
+});
+ZoneFrameEditor.displayName = 'ZoneFrameEditor';

--- a/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
@@ -1,15 +1,18 @@
-import React, { useState } from 'react';
-import { Editor, useRefreshUI } from '@components/editor';
-
+import React, { forwardRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
-
 import styled from 'styled-components';
+
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+
+import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
 import { SelectZone } from '@components/selects';
-import { useProjectZones } from '@hooks/useProjectData';
 import { DarkButton, PrimaryButton } from '@components/buttons';
+
+import { useProjectZones } from '@hooks/useProjectData';
+import { useZonePage } from '@src/hooks/usePage';
+
 import { cloneEntity } from '@utils/cloneEntity';
-import { StudioZone } from '@modelEntities/zone';
 
 const ZoneGroupImportInfo = styled.div`
   ${({ theme }) => theme.fonts.normalRegular};
@@ -25,27 +28,28 @@ const ButtonContainer = styled.div`
 `;
 
 type ZoneGroupImportEditorProps = {
-  zone: StudioZone;
-  onClose: () => void;
+  closeDialog: () => void;
 };
 
-export const ZoneGroupImportEditor = ({ zone, onClose }: ZoneGroupImportEditorProps) => {
+export const ZoneGroupImportEditor = forwardRef<EditorHandlingClose, ZoneGroupImportEditorProps>(({ closeDialog }, ref) => {
   const { projectDataValues: zones, setProjectDataValues: setZone } = useProjectZones();
+  const { t } = useTranslation('database_zones');
+  const { zone } = useZonePage();
   const firstDbSymbol = Object.entries(zones)
     .map(([value, zoneData]) => ({ value, index: zoneData.id }))
-    .filter((d) => d.value !== zone.dbSymbol)
+    .filter((data) => data.value !== zone.dbSymbol)
     .sort((a, b) => a.index - b.index)[0].value;
   const [selectedZone, setSelectedZone] = useState(firstDbSymbol);
-  const { t } = useTranslation('database_zones');
   const [override, setOverride] = useState(false);
-  const refreshUI = useRefreshUI();
 
   const onClickImport = () => {
     if (override) zone.wildGroups = cloneEntity(zones[selectedZone].wildGroups);
     else zone.wildGroups.push(...cloneEntity(zones[selectedZone].wildGroups));
     setZone({ [zone.dbSymbol]: zone });
-    onClose();
+    closeDialog();
   };
+
+  useEditorHandlingClose(ref);
 
   return (
     <Editor type="zone" title={t('import')}>
@@ -57,13 +61,13 @@ export const ZoneGroupImportEditor = ({ zone, onClose }: ZoneGroupImportEditorPr
         </InputWithTopLabelContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="override">{t('replace_group')}</Label>
-          <Toggle name="override" checked={override} onChange={(event) => refreshUI(setOverride(event.target.checked))} />
+          <Toggle name="override" checked={override} onChange={(event) => setOverride(event.target.checked)} />
         </InputWithLeftLabelContainer>
         <ButtonContainer>
           <PrimaryButton onClick={onClickImport}>{t('to_import')}</PrimaryButton>
-          <DarkButton onClick={onClose}>{t('cancel')}</DarkButton>
+          <DarkButton onClick={closeDialog}>{t('cancel')}</DarkButton>
         </ButtonContainer>
       </InputContainer>
     </Editor>
   );
-};
+});

--- a/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
@@ -57,7 +57,12 @@ export const ZoneGroupImportEditor = forwardRef<EditorHandlingClose, ZoneGroupIm
         <ZoneGroupImportInfo>{t('zone_group_import_info')}</ZoneGroupImportInfo>
         <InputWithTopLabelContainer>
           <Label htmlFor="zone">{t('import_group_from')}</Label>
-          <SelectZone dbSymbol={selectedZone} onChange={(selected) => setSelectedZone(selected.value)} rejected={[zone.dbSymbol]} noLabel />
+          <SelectZone
+            dbSymbol={selectedZone}
+            onChange={(dbSymbol) => setSelectedZone(dbSymbol)}
+            filter={(dbSymbol) => dbSymbol !== zone.dbSymbol}
+            noLabel
+          />
         </InputWithTopLabelContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="override">{t('replace_group')}</Label>
@@ -71,3 +76,4 @@ export const ZoneGroupImportEditor = forwardRef<EditorHandlingClose, ZoneGroupIm
     </Editor>
   );
 });
+ZoneGroupImportEditor.displayName = 'ZoneGroupImportEditor';

--- a/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneGroupImportEditor.tsx
@@ -43,9 +43,10 @@ export const ZoneGroupImportEditor = forwardRef<EditorHandlingClose, ZoneGroupIm
   const [override, setOverride] = useState(false);
 
   const onClickImport = () => {
-    if (override) zone.wildGroups = cloneEntity(zones[selectedZone].wildGroups);
-    else zone.wildGroups.push(...cloneEntity(zones[selectedZone].wildGroups));
-    setZone({ [zone.dbSymbol]: zone });
+    const zoneEdited = cloneEntity(zone);
+    if (override) zoneEdited.wildGroups = cloneEntity(zones[selectedZone].wildGroups);
+    else zoneEdited.wildGroups.push(...cloneEntity(zones[selectedZone].wildGroups));
+    setZone({ [zone.dbSymbol]: zoneEdited });
     closeDialog();
   };
 

--- a/src/views/components/database/zone/editors/ZoneGroupsDeletion.tsx
+++ b/src/views/components/database/zone/editors/ZoneGroupsDeletion.tsx
@@ -1,0 +1,38 @@
+import { Deletion } from '@components/deletion';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { useGetEntityNameText } from '@utils/ReadingProjectText';
+import { useTranslation } from 'react-i18next';
+import { useZonePage } from '@src/hooks/usePage';
+import { useUpdateZone } from './useUpdateZone';
+import React, { forwardRef } from 'react';
+
+type ZoneGroupsDeletionProps = {
+  closeDialog: () => void;
+};
+
+/**
+ * Component responsive of asking the user if they really want to delete the groups of a zone before doing so.
+ */
+export const ZoneGroupsDeletion = forwardRef<EditorHandlingClose, ZoneGroupsDeletionProps>(({ closeDialog }, ref) => {
+  const { t } = useTranslation('database_zones');
+  const { zone } = useZonePage();
+  const updateZone = useUpdateZone(zone);
+  const getZoneName = useGetEntityNameText();
+
+  const onClickDelete = () => {
+    updateZone({ wildGroups: [] });
+    closeDialog();
+  };
+
+  useEditorHandlingClose(ref);
+
+  return (
+    <Deletion
+      title={t('deletion_of_groups')}
+      message={t('deletion_groups_message', { zone: getZoneName(zone) })}
+      onClickDelete={onClickDelete}
+      onClose={closeDialog}
+    />
+  );
+});
+ZoneGroupsDeletion.displayName = 'ZoneGroupsDeletion';

--- a/src/views/components/database/zone/editors/ZoneNewEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneNewEditor.tsx
@@ -1,17 +1,21 @@
-import React, { useRef, useState } from 'react';
+import React, { forwardRef, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Editor } from '@components/editor';
-
 import { useTranslation } from 'react-i18next';
+
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { Input, InputContainer, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
-import { useProjectZones } from '@hooks/useProjectData';
 import { DarkButton, PrimaryButton } from '@components/buttons';
-import { useSetProjectText } from '@utils/ReadingProjectText';
+import { TooltipWrapper } from '@ds/Tooltip';
+
+import { useProjectZones } from '@hooks/useProjectData';
+
 import { ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
 import { DbSymbol } from '@modelEntities/dbSymbol';
+
+import { useSetProjectText } from '@utils/ReadingProjectText';
 import { findFirstAvailableId } from '@utils/ModelUtils';
 import { createZone } from '@utils/entityCreation';
-import { TooltipWrapper } from '@ds/Tooltip';
 
 const ButtonContainer = styled.div`
   display: flex;
@@ -21,15 +25,17 @@ const ButtonContainer = styled.div`
 `;
 
 type ZoneNewEditorProps = {
-  onClose: () => void;
+  closeDialog: () => void;
 };
 
-export const ZoneNewEditor = ({ onClose }: ZoneNewEditorProps) => {
+export const ZoneNewEditor = forwardRef<EditorHandlingClose, ZoneNewEditorProps>(({ closeDialog }, ref) => {
   const { projectDataValues: zones, setProjectDataValues: setZone } = useProjectZones();
   const { t } = useTranslation('database_zones');
   const setText = useSetProjectText();
-  const [name, setName] = useState(''); // We can't use a ref because of the button behavior
+  const [name, setName] = useState(''); // We use a state because synchronizing dbSymbol is easier with a state
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
+
+  useEditorHandlingClose(ref);
 
   const onClickNew = () => {
     if (!descriptionRef.current) return;
@@ -40,7 +46,8 @@ export const ZoneNewEditor = ({ onClose }: ZoneNewEditorProps) => {
     setText(ZONE_NAME_TEXT_ID, id, name);
     setText(ZONE_DESCRIPTION_TEXT_ID, id, descriptionRef.current.value);
     setZone({ [dbSymbol]: zone }, { zone: dbSymbol });
-    onClose();
+
+    closeDialog();
   };
 
   return (
@@ -62,9 +69,9 @@ export const ZoneNewEditor = ({ onClose }: ZoneNewEditorProps) => {
               {t('create_zone')}
             </PrimaryButton>
           </TooltipWrapper>
-          <DarkButton onClick={onClose}>{t('cancel')}</DarkButton>
+          <DarkButton onClick={closeDialog}>{t('cancel')}</DarkButton>
         </ButtonContainer>
       </InputContainer>
     </Editor>
   );
-};
+});

--- a/src/views/components/database/zone/editors/ZoneNewEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneNewEditor.tsx
@@ -75,3 +75,4 @@ export const ZoneNewEditor = forwardRef<EditorHandlingClose, ZoneNewEditorProps>
     </Editor>
   );
 });
+ZoneNewEditor.displayName = 'ZoneNewEditor';

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -18,9 +18,6 @@ import { StudioZoneForcedWeather } from '@modelEntities/zone';
 import { padStr } from '@utils/PadStr';
 import { cloneEntity } from '@utils/cloneEntity';
 
-// 6. Imports de fichiers locaux
-import { ZoneTranslationEditorTitle } from './ZoneTranslationOverlay';
-
 const InputMapsListContainer = styled(InputWithTopLabelContainer)`
   gap: 16px;
 `;

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -1,16 +1,25 @@
-import React, { useMemo, useRef, useState } from 'react';
-import { Editor, useRefreshUI } from '@components/editor';
-
+import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import styled from 'styled-components';
-import { TagWithDeletion, TagWithDeletionContainer } from '@components/Tag';
-import { padStr } from '@utils/PadStr';
-import { cleanNaNValue } from '@utils/cleanNaNValue';
-import { SelectCustomSimple } from '@components/SelectCustom';
+
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { TextInputError } from '@components/inputs/Input';
-import { StudioZone } from '@modelEntities/zone';
+import { TagWithDeletion, TagWithDeletionContainer } from '@components/Tag';
+import { Select } from '@ds/Select';
+
+import { useZonePage } from '@src/hooks/usePage';
+import { useUpdateZone } from './useUpdateZone';
+
+import { StudioZoneForcedWeather } from '@modelEntities/zone';
+
+import { padStr } from '@utils/PadStr';
+import { cloneEntity } from '@utils/cloneEntity';
+
+// 6. Imports de fichiers locaux
+import { ZoneTranslationEditorTitle } from './ZoneTranslationOverlay';
 
 const InputMapsListContainer = styled(InputWithTopLabelContainer)`
   gap: 16px;
@@ -47,16 +56,16 @@ const WeatherCategories = [-1, 0, 1, 2, 3, 4, 5] as const;
 const weatherCategoryEntries = (t: TFunction<'database_zones'>) =>
   WeatherCategories.map((category) => ({ value: category.toString(), label: t(`weather${category}`) }));
 
-type ZoneSettingsEditorProps = {
-  zone: StudioZone;
-};
-
-export const ZoneSettingsEditor = ({ zone }: ZoneSettingsEditorProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [errorNewMap, setErrorNewMap] = useState<number | false>(false);
+export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_zones');
+  const { zone } = useZonePage();
+  const updateZone = useUpdateZone(zone);
+  const forcedWeatherRef = useRef<string | undefined>();
+  const panelIdRef = useRef<HTMLInputElement>(null);
   const weatherOptions = useMemo(() => weatherCategoryEntries(t), [t]);
-  const refreshUI = useRefreshUI();
+  const [maps, setMaps] = useState<number[]>(cloneEntity(zone.maps));
+  const [errorNewMap, setErrorNewMap] = useState<number | false>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
     if (inputRef.current && inputRef.current.validity.valid && event.key === 'Enter') {
@@ -66,7 +75,7 @@ export const ZoneSettingsEditor = ({ zone }: ZoneSettingsEditorProps) => {
         .filter((v) => v.trim().length !== 0)
         .map((v) => Number(v))
         .filter((v, i, a) => i === a.indexOf(v));
-      const errorMapId = mapIds.find((mapId) => zone.maps.includes(mapId));
+      const errorMapId = mapIds.find((mapId) => maps.includes(mapId));
       if (errorMapId !== undefined) {
         setErrorNewMap(errorMapId);
         return;
@@ -74,17 +83,32 @@ export const ZoneSettingsEditor = ({ zone }: ZoneSettingsEditorProps) => {
 
       inputRef.current.value = '';
       if (errorNewMap !== false) setErrorNewMap(false);
-      refreshUI((zone.maps = zone.maps.concat(mapIds)));
+      setMaps(maps.concat(mapIds));
     }
   };
 
   const onDeleteMap = (index: number) => {
-    refreshUI(zone.maps.splice(index, 1));
+    setMaps(cloneEntity(maps).splice(index, 1));
   };
 
-  const onChangeForcedWeather = (value: number) => {
-    refreshUI((zone.forcedWeather = value === -1 ? null : (value as 1)));
+  const canClose = () => {
+    const result = !!panelIdRef?.current?.validity.valid;
+
+    return result;
   };
+
+  const onClose = () => {
+    if (!forcedWeatherRef?.current || !panelIdRef?.current || !canClose()) return;
+
+    const forcedWeather = forcedWeatherRef.current === '-1' ? null : (parseInt(forcedWeatherRef.current) as StudioZoneForcedWeather);
+
+    updateZone({
+      forcedWeather,
+      panelId: panelIdRef.current.valueAsNumber,
+    });
+  };
+
+  useEditorHandlingClose(ref, onClose, canClose);
 
   return (
     <Editor type="edit" title={t('settings')}>
@@ -96,7 +120,7 @@ export const ZoneSettingsEditor = ({ zone }: ZoneSettingsEditorProps) => {
             {errorNewMap !== false && <TextInputError>{t('map_already_exists', { mapId: padStr(errorNewMap, 2) })}</TextInputError>}
           </InputMapWithErrorContainer>
           <MapsListContainer>
-            {zone.maps
+            {maps
               .sort((a, b) => a - b)
               .map((id, index) => (
                 <TagWithDeletion key={index} index={index} onClickDelete={onDeleteMap}>
@@ -107,31 +131,19 @@ export const ZoneSettingsEditor = ({ zone }: ZoneSettingsEditorProps) => {
         </InputMapsListContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="panel-number">{t('panel_number')}</Label>
-          <Input
-            type="number"
-            name="panel-number"
-            min="0"
-            max="99999"
-            value={isNaN(zone.panelId) ? '' : zone.panelId}
-            onChange={(event) => {
-              const value = parseInt(event.target.value);
-              if (value < 0 || value > 99_999) return event.preventDefault();
-              refreshUI((zone.panelId = value));
-            }}
-            onBlur={() => refreshUI((zone.panelId = cleanNaNValue(zone.panelId)))}
-          />
+          <Input type="number" name="panel-number" min="0" max="99999" defaultValue={zone.panelId} ref={panelIdRef} />
         </InputWithLeftLabelContainer>
         <InputWithTopLabelContainer>
-          <Label htmlFor="weather">{t('forced_weather')}</Label>
-          <SelectCustomSimple
+          <Label htmlFor="select-weather">{t('forced_weather')}</Label>
+          <Select
             id="select-weather"
             options={weatherOptions}
-            onChange={(value) => onChangeForcedWeather(Number(value))}
-            value={String(zone.forcedWeather === null ? -1 : zone.forcedWeather)}
-            noTooltip
+            optionRef={forcedWeatherRef}
+            defaultValue={zone.forcedWeather === null ? '-1' : zone.forcedWeather.toString()}
           />
         </InputWithTopLabelContainer>
       </InputContainer>
     </Editor>
   );
-};
+});
+ZoneSettingsEditor.displayName = 'ZoneSettingsEditor';

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -85,7 +85,9 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
 
   const onDeleteMap = (index: number) => {
-    setMaps(cloneEntity(maps).splice(index, 1));
+    const mapsEdited = cloneEntity(maps);
+    mapsEdited.splice(index, 1);
+    setMaps(mapsEdited);
   };
 
   const canClose = () => {
@@ -102,6 +104,7 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     updateZone({
       forcedWeather,
       panelId: panelIdRef.current.valueAsNumber,
+      maps,
     });
   };
 

--- a/src/views/components/database/zone/editors/ZoneTranslationOverlay.tsx
+++ b/src/views/components/database/zone/editors/ZoneTranslationOverlay.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { defineEditorOverlay } from '@components/editor/EditorOverlayV2';
+import { TranslationEditorWithCloseHandling } from '@components/editor/TranslationEditorWithCloseHandling';
+import { StudioZone, ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
+import { assertUnreachable } from '@utils/assertUnreachable';
+
+export type ZoneTranslationEditorTitle = 'translation_name' | 'translation_description';
+
+type Props = {
+  onClose: () => void;
+  zone: StudioZone;
+};
+
+/**
+ * Editor overlay for the Translation of quest texts
+ */
+export const ZoneTranslationOverlay = defineEditorOverlay<ZoneTranslationEditorTitle, Props>(
+  'ZoneTranslationOverlay',
+  (dialogToShow, handleCloseRef, closeDialog, { onClose, zone }) => {
+    switch (dialogToShow) {
+      case 'translation_name':
+      case 'translation_description':
+        return (
+          <TranslationEditorWithCloseHandling
+            title={dialogToShow}
+            nameTextId={ZONE_NAME_TEXT_ID}
+            fileId={dialogToShow === 'translation_description' ? ZONE_DESCRIPTION_TEXT_ID : ZONE_NAME_TEXT_ID}
+            textIndex={zone.id}
+            isMultiline={dialogToShow === 'translation_description'}
+            closeDialog={closeDialog}
+            onClose={onClose}
+            ref={handleCloseRef}
+          />
+        );
+      default:
+        return assertUnreachable(dialogToShow);
+    }
+  }
+);

--- a/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
@@ -20,8 +20,8 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { zone } = useZonePage();
   const updateZone = useUpdateZone(zone);
 
-  const [isWarpDisallowed, setIsWarpDisallowed] = useState<boolean>(false);
-  const [isFlyAllowed, setIsFlyAllowed] = useState<boolean>(false);
+  const [isWarpDisallowed, setIsWarpDisallowed] = useState<boolean>(zone.isWarpDisallowed);
+  const [isFlyAllowed, setIsFlyAllowed] = useState<boolean>(zone.isFlyAllowed);
   const positionXRef = useRef<HTMLInputElement>(null);
   const positionYRef = useRef<HTMLInputElement>(null);
   const warpXRef = useRef<HTMLInputElement>(null);
@@ -35,23 +35,29 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   };
 
   const canClose = () => {
-    const result =
-      !!warpXRef?.current?.validity.valid &&
-      !warpYRef?.current?.validity.valid &&
-      !positionXRef?.current?.validity.valid &&
-      !positionYRef?.current?.validity.valid;
-
+    let result = true;
+    if (!isWarpDisallowed) {
+      result &&= !!positionXRef.current && !!positionYRef.current && positionXRef.current.validity.valid && positionYRef.current.validity.valid;
+    }
+    if (isFlyAllowed) {
+      result &&= !!warpXRef.current && !!warpYRef.current && warpXRef.current.validity.valid && warpYRef.current.validity.valid;
+    }
     return result;
   };
 
   const onClose = () => {
-    if (!warpXRef?.current || !warpYRef?.current || !positionXRef?.current || !positionYRef?.current || !canClose()) return;
+    if (!canClose()) return;
+
+    const warpX = !warpXRef.current ? null : isNaN(warpXRef.current.valueAsNumber) ? null : warpXRef.current.valueAsNumber;
+    const warpY = !warpYRef.current ? null : isNaN(warpYRef.current.valueAsNumber) ? null : warpYRef.current.valueAsNumber;
+    const posX = !positionXRef.current ? null : isNaN(positionXRef.current.valueAsNumber) ? null : positionXRef.current.valueAsNumber;
+    const posY = !positionYRef.current ? null : isNaN(positionYRef.current.valueAsNumber) ? null : positionYRef.current.valueAsNumber;
 
     updateZone({
-      warp: isWarpDisallowed ? { x: null, y: null } : { x: warpXRef.current.valueAsNumber, y: warpYRef.current.valueAsNumber },
-      position: { x: positionXRef.current.valueAsNumber, y: positionYRef.current.valueAsNumber },
-      isWarpDisallowed: isWarpDisallowed,
-      isFlyAllowed: isFlyAllowed,
+      warp: { x: warpX, y: warpY },
+      position: { x: posX, y: posY },
+      isWarpDisallowed,
+      isFlyAllowed,
     });
   };
 
@@ -62,7 +68,7 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       <InputContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="warp">{t('warp')}</Label>
-          <Toggle name="warp" checked={!zone.isWarpDisallowed} onChange={(event) => onChangeWarp(!event.target.checked)} />
+          <Toggle name="warp" checked={!isWarpDisallowed} onChange={(event) => onChangeWarp(!event.target.checked)} />
         </InputWithLeftLabelContainer>
         {isWarpDisallowed && !isFlyAllowed ? (
           <></>
@@ -71,7 +77,7 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
             {!isWarpDisallowed && (
               <InputWithLeftLabelContainer>
                 <Label htmlFor="outside-zone">{t('outdoor_zone')}</Label>
-                <Toggle name="outside-zone" checked={zone.isFlyAllowed} onChange={(event) => setIsFlyAllowed(event.target.checked)} />
+                <Toggle name="outside-zone" checked={isFlyAllowed} onChange={(event) => setIsFlyAllowed(event.target.checked)} />
               </InputWithLeftLabelContainer>
             )}
 
@@ -80,7 +86,7 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
                 <Label htmlFor="landing-coordinates">{t('landing_coordinates')}</Label>
                 <div className="coordinates">
                   <CoordinateInput type="number" unit="x" min="0" max="99999" defaultValue={zone.warp.x?.toString()} ref={warpXRef} />
-                  <CoordinateInput type="number" unit="y" min="0" max="99999" defaultValue={zone.warp.x?.toString()} ref={warpYRef} />
+                  <CoordinateInput type="number" unit="y" min="0" max="99999" defaultValue={zone.warp.y?.toString()} ref={warpYRef} />
                 </div>
               </InputWithCoordinateLabelContainer>
             )}

--- a/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { forwardRef, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Editor, useRefreshUI } from '@components/editor';
-import { CoordinateInput, InputContainer, InputWithLeftLabelContainer, InputWithCoordinateLabelContainer, Label, Toggle } from '@components/inputs';
 import { useTranslation } from 'react-i18next';
-import { cleaningNaNToNull } from '@utils/cleanNaNValue';
-import { StudioZone } from '@modelEntities/zone';
+
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { CoordinateInput, InputContainer, InputWithLeftLabelContainer, InputWithCoordinateLabelContainer, Label, Toggle } from '@components/inputs';
+
+import { useZonePage } from '@src/hooks/usePage';
+import { useUpdateZone } from './useUpdateZone';
 
 const OutsideContainer = styled.div`
   display: flex;
@@ -12,70 +15,72 @@ const OutsideContainer = styled.div`
   gap: 16px;
 `;
 
-type ZoneCoordinateInputProps = {
-  unit: string;
-  value: number | null;
-  setValue: (v: number | null) => void;
-  refreshUI: (_: unknown) => void;
-};
-
-const ZoneCoordinateInput = ({ unit, value, setValue, refreshUI }: ZoneCoordinateInputProps) => {
-  return (
-    <CoordinateInput
-      type="text"
-      unit={unit}
-      min="0"
-      max="99999"
-      value={value === null || isNaN(value) ? '' : value}
-      onChange={(event) => {
-        const val = parseInt(event.target.value);
-        if (val < 0 || val > 99_999) return event.preventDefault();
-        refreshUI(setValue(val));
-      }}
-      onBlur={() => refreshUI(setValue(cleaningNaNToNull(value)))}
-    />
-  );
-};
-
-type ZoneTravelEditorProps = {
-  zone: StudioZone;
-};
-
-export const ZoneTravelEditor = ({ zone }: ZoneTravelEditorProps) => {
+export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation('database_zones');
-  const refreshUI = useRefreshUI();
+  const { zone } = useZonePage();
+  const updateZone = useUpdateZone(zone);
 
-  const onChangeWarp = (b: boolean) => {
-    zone.isWarpDisallowed = b;
-    if (!b) return;
+  const [isWarpDisallowed, setIsWarpDisallowed] = useState<boolean>(false);
+  const [isFlyAllowed, setIsFlyAllowed] = useState<boolean>(false);
+  const positionXRef = useRef<HTMLInputElement>(null);
+  const positionYRef = useRef<HTMLInputElement>(null);
+  const warpXRef = useRef<HTMLInputElement>(null);
+  const warpYRef = useRef<HTMLInputElement>(null);
 
-    zone.warp = { x: null, y: null };
-    zone.isFlyAllowed = false;
+  const onChangeWarp = (checked: boolean) => {
+    setIsWarpDisallowed(checked);
+    if (!checked) return;
+
+    setIsFlyAllowed(false);
   };
+
+  const canClose = () => {
+    const result =
+      !!warpXRef?.current?.validity.valid &&
+      !warpYRef?.current?.validity.valid &&
+      !positionXRef?.current?.validity.valid &&
+      !positionYRef?.current?.validity.valid;
+
+    return result;
+  };
+
+  const onClose = () => {
+    if (!warpXRef?.current || !warpYRef?.current || !positionXRef?.current || !positionYRef?.current || !canClose()) return;
+
+    updateZone({
+      warp: isWarpDisallowed ? { x: null, y: null } : { x: warpXRef.current.valueAsNumber, y: warpYRef.current.valueAsNumber },
+      position: { x: positionXRef.current.valueAsNumber, y: positionYRef.current.valueAsNumber },
+      isWarpDisallowed: isWarpDisallowed,
+      isFlyAllowed: isFlyAllowed,
+    });
+  };
+
+  useEditorHandlingClose(ref, onClose, canClose);
 
   return (
     <Editor type="edit" title={t('travel')}>
       <InputContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="warp">{t('warp')}</Label>
-          <Toggle name="warp" checked={!zone.isWarpDisallowed} onChange={(event) => refreshUI(onChangeWarp(!event.target.checked))} />
+          <Toggle name="warp" checked={!zone.isWarpDisallowed} onChange={(event) => onChangeWarp(!event.target.checked)} />
         </InputWithLeftLabelContainer>
-        {zone.isWarpDisallowed && !zone.isFlyAllowed ? (
+        {isWarpDisallowed && !isFlyAllowed ? (
           <></>
         ) : (
           <OutsideContainer>
-            {!zone.isWarpDisallowed && (
+            {!isWarpDisallowed && (
               <InputWithLeftLabelContainer>
                 <Label htmlFor="outside-zone">{t('outdoor_zone')}</Label>
-                <Toggle name="outside-zone" checked={zone.isFlyAllowed} onChange={(event) => refreshUI((zone.isFlyAllowed = event.target.checked))} />
+                <Toggle name="outside-zone" checked={zone.isFlyAllowed} onChange={(event) => setIsFlyAllowed(event.target.checked)} />
               </InputWithLeftLabelContainer>
             )}
-            {zone.isFlyAllowed && (
+
+            {isFlyAllowed && (
               <InputWithCoordinateLabelContainer>
                 <Label htmlFor="landing-coordinates">{t('landing_coordinates')}</Label>
                 <div className="coordinates">
-                  <ZoneCoordinateInput unit="x" value={zone.warp.x} setValue={(value) => (zone.warp.x = value)} refreshUI={refreshUI} />
-                  <ZoneCoordinateInput unit="y" value={zone.warp.y} setValue={(value) => (zone.warp.y = value)} refreshUI={refreshUI} />
+                  <CoordinateInput type="number" unit="x" min="0" max="99999" defaultValue={zone.warp.x?.toString()} ref={warpXRef} />
+                  <CoordinateInput type="number" unit="y" min="0" max="99999" defaultValue={zone.warp.x?.toString()} ref={warpYRef} />
                 </div>
               </InputWithCoordinateLabelContainer>
             )}
@@ -84,11 +89,11 @@ export const ZoneTravelEditor = ({ zone }: ZoneTravelEditorProps) => {
         <InputWithCoordinateLabelContainer>
           <Label htmlFor="position-worldmap">{t('worldmap_coordinates')}</Label>
           <div className="coordinates">
-            <ZoneCoordinateInput unit="x" value={zone.position.x} setValue={(value) => (zone.position.x = value)} refreshUI={refreshUI} />
-            <ZoneCoordinateInput unit="y" value={zone.position.y} setValue={(value) => (zone.position.y = value)} refreshUI={refreshUI} />
+            <CoordinateInput type="number" unit="x" min="0" max="99999" defaultValue={zone.position.x?.toString()} ref={positionXRef} />
+            <CoordinateInput type="number" unit="y" min="0" max="99999" defaultValue={zone.position.y?.toString()} ref={positionYRef} />
           </div>
         </InputWithCoordinateLabelContainer>
       </InputContainer>
     </Editor>
   );
-};
+});

--- a/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneTravelEditor.tsx
@@ -97,3 +97,4 @@ export const ZoneTravelEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     </Editor>
   );
 });
+ZoneTravelEditor.displayName = 'ZoneTravelEditor';

--- a/src/views/components/database/zone/editors/index.tsx
+++ b/src/views/components/database/zone/editors/index.tsx
@@ -5,3 +5,5 @@ export { ZoneTravelEditor } from './ZoneTravelEditor';
 export { ZoneAddGroupEditor } from './ZoneAddGroupEditor';
 export { ZoneEditGroupEditor } from './ZoneEditGroupEditor';
 export { ZoneGroupImportEditor } from './ZoneGroupImportEditor';
+export { ZoneDeletion } from './ZoneDeletion';
+export { ZoneGroupsDeletion } from './ZoneGroupsDeletion';

--- a/src/views/components/database/zone/editors/useUpdateZone.tsx
+++ b/src/views/components/database/zone/editors/useUpdateZone.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+import { StudioZone } from '@modelEntities/zone';
+import { useProjectZones } from '@hooks/useProjectData';
+import { cloneEntity } from '@utils/cloneEntity';
+
+export const useUpdateZone = (zone: StudioZone) => {
+  const { setProjectDataValues: setZone } = useProjectZones();
+
+  return useCallback(
+    (updates: Partial<StudioZone>) => {
+      const updatedZone = {
+        ...cloneEntity(zone),
+        ...updates,
+      };
+      setZone({ [zone.dbSymbol]: updatedZone });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [zone]
+  );
+};

--- a/src/views/components/inputs/CoordinateInput.tsx
+++ b/src/views/components/inputs/CoordinateInput.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { forwardRef, InputHTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { Input } from '.';
 
@@ -24,9 +24,10 @@ type CoordinateInputProps = {
   unit?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const CoordinateInput = ({ unit, ...props }: CoordinateInputProps) => (
+export const CoordinateInput = forwardRef<HTMLInputElement, CoordinateInputProps>(({ unit, ...props }, ref) => (
   <CoordinateInputContainer>
-    <Input {...props} />
+    <Input ref={ref} {...props} />
     <span>{unit ?? 'x'}</span>
   </CoordinateInputContainer>
-);
+));
+CoordinateInput.displayName = 'CoordinateInput';

--- a/src/views/components/selects/SelectZone.tsx
+++ b/src/views/components/selects/SelectZone.tsx
@@ -1,54 +1,33 @@
 import React, { useMemo } from 'react';
-import { useGlobalState } from '@src/GlobalStateProvider';
 import { useTranslation } from 'react-i18next';
-import { getSelectDataOptionsOrderedById, SelectDataGeneric } from './SelectDataGeneric';
-import { SelectDataProps } from './SelectDataProps';
-import { useGetEntityNameText } from '@utils/ReadingProjectText';
+import { StudioDropDown, StudioDropDownFilter } from '@components/StudioDropDown';
+import { useSelectOptions } from '@src/hooks/useSelectOptions';
+import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 
-/**
- * Component to show a select zone.
- * @param dbSymbol The dbSymbol of the zone
- * @param onChange Set this function to get the value selected in the select
- * @param noLabel If true, the label is not shown
- * @param rejected List of dbSymbol who no must be show in the select
- * @param breakpoint Set the breakpoint for hide the label if necessary
- * @param noneValue Add on the top of the select 'None' value
- * @param noneValueIsError The noneValue is considered as error
- * @param overwriteNoneValue Overwrite the label of the 'None'
- */
-export const SelectZone = ({
-  dbSymbol,
-  onChange,
-  noLabel,
-  rejected,
-  breakpoint,
-  noneValue,
-  noneValueIsError,
-  overwriteNoneValue,
-}: SelectDataProps) => {
+type SelectZoneProps = {
+  dbSymbol: string;
+  onChange: (dbSymbol: string) => void;
+  undefValueOption?: string;
+  noLabel?: boolean;
+  filter?: StudioDropDownFilter;
+};
+
+export const SelectZone = ({ dbSymbol, onChange, noLabel, undefValueOption, filter }: SelectZoneProps) => {
   const { t } = useTranslation('database_zones');
-  const [state] = useGlobalState();
-  const getZoneName = useGetEntityNameText();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const options = useMemo(() => getSelectDataOptionsOrderedById(state.projectData, 'zones', getZoneName), [state.projectData]);
+  const zoneOptions = useSelectOptions('zones');
+  const options = useMemo(() => {
+    if (undefValueOption) return [{ value: '__undef__', label: undefValueOption }, ...zoneOptions];
+    return zoneOptions;
+  }, [zoneOptions, undefValueOption]);
 
-  const getData = () => {
-    const currentZone = state.projectData.zones[dbSymbol];
-    return { value: dbSymbol, label: currentZone ? getZoneName(currentZone) : t('zone_deleted') };
-  };
+  const optionals = { deletedOption: t('zone_deleted'), filter };
+
+  if (noLabel) return <StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />;
 
   return (
-    <SelectDataGeneric
-      data={getData()}
-      options={options}
-      label={noLabel ? undefined : t('zone')}
-      noOptionsText={t('no_option')}
-      error={!state.projectData.zones[dbSymbol] && (noneValueIsError ? true : dbSymbol !== '__undef__')}
-      onChange={onChange}
-      rejected={rejected}
-      breakpoint={breakpoint}
-      noneValue={noneValue}
-      overwriteNoneValue={overwriteNoneValue}
-    />
+    <SelectContainerWithLabel>
+      <span>{t('zone')}</span>
+      <StudioDropDown value={dbSymbol} options={options} onChange={onChange} optionals={optionals} />
+    </SelectContainerWithLabel>
   );
 };

--- a/src/views/pages/database/Zone.page.tsx
+++ b/src/views/pages/database/Zone.page.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DatabasePageStyle } from '@components/database/DatabasePageStyle';
@@ -6,69 +6,17 @@ import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerSty
 
 import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
 import { DeleteButtonWithIcon } from '@components/buttons';
-import { Deletion, DeletionOverlay } from '@components/deletion';
 import { ZoneControlBar, ZoneFrame, ZoneGroups, ZoneSettings, ZoneTravel, ZonePokemon } from '@components/database/zone';
 import { ZoneEditorOverlay, ZoneEditorAndDeletionKeys } from '@components/database/zone/editors/ZoneEditorOverlay';
 
 import { useDialogsRef } from '@src/hooks/useDialogsRef';
-import { useProjectGroups, useProjectZones } from '@hooks/useProjectData';
-
-import { useGetEntityNameText } from '@utils/ReadingProjectText';
-import { cloneEntity } from '@utils/cloneEntity';
 import { useZonePage } from '@src/hooks/usePage';
 
 export const ZonePage = () => {
   const dialogsRef = useDialogsRef<ZoneEditorAndDeletionKeys>();
   const { zone, groups, cannotDelete } = useZonePage();
-
-  const {
-    projectDataValues: zones,
-    selectedDataIdentifier: zoneDbSymbol,
-    setProjectDataValues: setZone,
-    removeProjectDataValue: deleteZone,
-  } = useProjectZones();
-
   const { t } = useTranslation('database_zones');
-  const getZoneName = useGetEntityNameText();
-
-  const currentEditedZone = useMemo(() => cloneEntity(zone), [zone]);
-  const [currentEditor, setCurrentEditor] = useState<string | undefined>(undefined);
-  const [currentDeletion, setCurrentDeletion] = useState<string | undefined>(undefined);
   const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
-
-  const onClickDelete = () => {
-    const firstDbSymbol = Object.entries(zones)
-      .map(([value, zoneData]) => ({ value, index: zoneData.id }))
-      .filter((d) => d.value !== zoneDbSymbol)
-      .sort((a, b) => a.index - b.index)[0].value;
-    deleteZone(zoneDbSymbol, { zone: firstDbSymbol });
-    setCurrentDeletion(undefined);
-  };
-
-  const onClickDeleteGroups = () => {
-    currentEditedZone.wildGroups = [];
-    setZone({ [zone.dbSymbol]: currentEditedZone });
-    setCurrentDeletion(undefined);
-  };
-
-  const deletions = {
-    zone: (
-      <Deletion
-        title={t('deletion_of_zone')}
-        message={t('deletion_message', { zone: getZoneName(zone) })}
-        onClickDelete={onClickDelete}
-        onClose={() => setCurrentDeletion(undefined)}
-      />
-    ),
-    groups: (
-      <Deletion
-        title={t('deletion_of_groups')}
-        message={t('deletion_groups_message', { zone: getZoneName(zone) })}
-        onClickDelete={onClickDeleteGroups}
-        onClose={() => setCurrentDeletion(undefined)}
-      />
-    ),
-  };
 
   return (
     <DatabasePageStyle>
@@ -81,26 +29,19 @@ export const ZonePage = () => {
             <ZoneTravel zone={zone} dialogsRef={dialogsRef} />
           </DataBlockWrapper>
           <DataBlockWrapper>
-            <ZoneGroups
-              zone={zone}
-              groups={groups}
-              dialogsRef={dialogsRef}
-              setCurrentGroupIndex={setCurrentGroupIndex}
-              onDelete={() => setCurrentDeletion('groups')}
-            />
+            <ZoneGroups zone={zone} groups={groups} dialogsRef={dialogsRef} setCurrentGroupIndex={setCurrentGroupIndex} />
           </DataBlockWrapper>
           <DataBlockWrapper>
             <ZonePokemon zone={zone} groups={groups} />
           </DataBlockWrapper>
           <DataBlockWrapper>
             <DataBlockWithAction size="full" title={t('deletion')}>
-              <DeleteButtonWithIcon onClick={() => setCurrentDeletion('zone')} disabled={cannotDelete}>
+              <DeleteButtonWithIcon onClick={() => dialogsRef.current?.openDialog('deleteZone', true)} disabled={cannotDelete}>
                 {t('delete_this_zone')}
               </DeleteButtonWithIcon>
             </DataBlockWithAction>
           </DataBlockWrapper>
           <ZoneEditorOverlay ref={dialogsRef} currentGroupIndex={currentGroupIndex} />
-          <DeletionOverlay currentDeletion={currentDeletion} deletions={deletions} onClose={() => setCurrentDeletion(undefined)} />
         </PageDataConstrainerStyle>
       </PageContainerStyle>
     </DatabasePageStyle>

--- a/src/views/pages/database/Zone.page.tsx
+++ b/src/views/pages/database/Zone.page.tsx
@@ -6,96 +6,35 @@ import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerSty
 
 import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
 import { DeleteButtonWithIcon } from '@components/buttons';
-import { EditorOverlay } from '@components/editor';
 import { Deletion, DeletionOverlay } from '@components/deletion';
-import { SelectChangeEvent } from '@components/SelectCustom/SelectCustomPropsInterface';
 import { ZoneControlBar, ZoneFrame, ZoneGroups, ZoneSettings, ZoneTravel, ZonePokemon } from '@components/database/zone';
 import { ZoneEditorOverlay, ZoneEditorAndDeletionKeys } from '@components/database/zone/editors/ZoneEditorOverlay';
-import {
-  ZoneAddGroupEditor,
-  ZoneEditGroupEditor,
-  ZoneFrameEditor,
-  ZoneGroupImportEditor,
-  ZoneNewEditor,
-  ZoneSettingsEditor,
-  ZoneTravelEditor,
-} from '@components/database/zone/editors';
 
 import { useDialogsRef } from '@src/hooks/useDialogsRef';
-import { useTranslationEditor } from '@hooks/useTranslationEditor';
 import { useProjectGroups, useProjectZones } from '@hooks/useProjectData';
-import { StudioShortcutActions, useShortcut } from '@hooks/useShortcuts';
-
-import { StudioGroup } from '@modelEntities/group';
-import { ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
 
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
-import { defineRelationCustomCondition } from '@utils/GroupUtils';
 import { cloneEntity } from '@utils/cloneEntity';
-import { cleaningZoneNaNValues } from '@utils/cleanNaNValue';
+import { useZonePage } from '@src/hooks/usePage';
 
 export const ZonePage = () => {
   const dialogsRef = useDialogsRef<ZoneEditorAndDeletionKeys>();
+  const { zone, groups, cannotDelete } = useZonePage();
 
   const {
     projectDataValues: zones,
     selectedDataIdentifier: zoneDbSymbol,
-    setSelectedDataIdentifier,
     setProjectDataValues: setZone,
     removeProjectDataValue: deleteZone,
-    getPreviousDbSymbol,
-    getNextDbSymbol,
   } = useProjectZones();
-  const { projectDataValues: groups, setProjectDataValues: setGroup } = useProjectGroups();
+
   const { t } = useTranslation('database_zones');
   const getZoneName = useGetEntityNameText();
-  const onChange: SelectChangeEvent = (selected) => setSelectedDataIdentifier({ zone: selected.value });
-  const zone = zones[zoneDbSymbol];
+
   const currentEditedZone = useMemo(() => cloneEntity(zone), [zone]);
   const [currentEditor, setCurrentEditor] = useState<string | undefined>(undefined);
   const [currentDeletion, setCurrentDeletion] = useState<string | undefined>(undefined);
   const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
-  const [currentEditedGroup, setCurrentEditedGroup] = useState<{ data: StudioGroup } | undefined>(undefined);
-  const shortcutMap = useMemo<StudioShortcutActions>(() => {
-    if (currentEditor !== undefined || currentDeletion !== undefined) return {};
-
-    return {
-      db_previous: () => setSelectedDataIdentifier({ zone: getPreviousDbSymbol('id') }),
-      db_next: () => setSelectedDataIdentifier({ zone: getNextDbSymbol('id') }),
-      db_new: () => setCurrentEditor('new'),
-    };
-  }, [currentEditor, currentDeletion, setSelectedDataIdentifier, getPreviousDbSymbol, getNextDbSymbol]);
-  useShortcut(shortcutMap);
-  const { translationEditor, openTranslationEditor, closeTranslationEditor } = useTranslationEditor(
-    {
-      translation_name: { fileId: ZONE_NAME_TEXT_ID },
-      translation_description: { fileId: ZONE_DESCRIPTION_TEXT_ID, isMultiline: true },
-    },
-    currentEditedZone.id,
-    getZoneName(currentEditedZone)
-  );
-
-  const onCloseEditor = () => {
-    if (currentEditor === 'frame' && getZoneName(currentEditedZone) === '') return;
-    if (currentEditor === 'new') return setCurrentEditor(undefined);
-    if (currentEditor === 'addGroup' || currentEditor === 'importGroup') return setCurrentEditor(undefined);
-    if (currentEditor === 'editGroup' && currentEditedGroup) {
-      currentEditedGroup.data.customConditions = defineRelationCustomCondition(currentEditedGroup.data.customConditions);
-      setZone({ [zone.dbSymbol]: currentEditedZone });
-      setGroup({ [currentEditedGroup.data.dbSymbol]: currentEditedGroup.data });
-      return setCurrentEditor(undefined);
-    }
-    cleaningZoneNaNValues(currentEditedZone);
-    setZone({ [zone.dbSymbol]: currentEditedZone });
-    setCurrentEditor(undefined);
-    closeTranslationEditor();
-  };
-
-  const onEditGroup = (index: number) => {
-    setCurrentGroupIndex(index);
-    setCurrentEditedGroup({ data: cloneEntity(groups[zone.wildGroups[index]]) });
-    setCurrentEditor('editGroup');
-  };
 
   const onClickDelete = () => {
     const firstDbSymbol = Object.entries(zones)
@@ -111,16 +50,6 @@ export const ZonePage = () => {
     setZone({ [zone.dbSymbol]: currentEditedZone });
     setCurrentDeletion(undefined);
   };
-
-  // const editors = {
-  //   new: <ZoneNewEditor onClose={() => setCurrentEditor(undefined)} />,
-  //   frame: <ZoneFrameEditor zone={currentEditedZone} openTranslationEditor={openTranslationEditor} />,
-  //   settings: <ZoneSettingsEditor zone={currentEditedZone} />,
-  //   travel: <ZoneTravelEditor zone={currentEditedZone} />,
-  //   addGroup: <ZoneAddGroupEditor zone={currentEditedZone} groups={groups} onAddGroup={onAddGroup} onClose={() => setCurrentEditor(undefined)} />,
-  //   editGroup: <ZoneEditGroupEditor zone={currentEditedZone} groups={groups} group={currentEditedGroup} index={currentGroupIndex} />,
-  //   importGroup: <ZoneGroupImportEditor zone={currentEditedZone} onClose={() => setCurrentEditor(undefined)} />,
-  // };
 
   const deletions = {
     zone: (
@@ -143,22 +72,21 @@ export const ZonePage = () => {
 
   return (
     <DatabasePageStyle>
-      <ZoneControlBar onChange={onChange} zone={zone} onClickNewZone={() => setCurrentEditor('new')} />
+      <ZoneControlBar dialogsRef={dialogsRef} />
       <PageContainerStyle>
         <PageDataConstrainerStyle>
           <DataBlockWrapper>
-            <ZoneFrame zone={zone} onClick={() => setCurrentEditor('frame')} />
-            <ZoneSettings zone={zone} onClick={() => setCurrentEditor('settings')} />
-            <ZoneTravel zone={zone} onClick={() => setCurrentEditor('travel')} />
+            <ZoneFrame zone={zone} dialogsRef={dialogsRef} />
+            <ZoneSettings zone={zone} dialogsRef={dialogsRef} />
+            <ZoneTravel zone={zone} dialogsRef={dialogsRef} />
           </DataBlockWrapper>
           <DataBlockWrapper>
             <ZoneGroups
               zone={zone}
               groups={groups}
+              dialogsRef={dialogsRef}
+              setCurrentGroupIndex={setCurrentGroupIndex}
               onDelete={() => setCurrentDeletion('groups')}
-              onImport={() => setCurrentEditor('importGroup')}
-              onNew={() => setCurrentEditor('addGroup')}
-              onEdit={onEditGroup}
             />
           </DataBlockWrapper>
           <DataBlockWrapper>
@@ -166,12 +94,12 @@ export const ZonePage = () => {
           </DataBlockWrapper>
           <DataBlockWrapper>
             <DataBlockWithAction size="full" title={t('deletion')}>
-              <DeleteButtonWithIcon onClick={() => setCurrentDeletion('zone')} disabled={Object.entries(zones).length === 1}>
+              <DeleteButtonWithIcon onClick={() => setCurrentDeletion('zone')} disabled={cannotDelete}>
                 {t('delete_this_zone')}
               </DeleteButtonWithIcon>
             </DataBlockWithAction>
           </DataBlockWrapper>
-          <ZoneEditorOverlay ref={dialogsRef} />
+          <ZoneEditorOverlay ref={dialogsRef} currentGroupIndex={currentGroupIndex} />
           <DeletionOverlay currentDeletion={currentDeletion} deletions={deletions} onClose={() => setCurrentDeletion(undefined)} />
         </PageDataConstrainerStyle>
       </PageContainerStyle>

--- a/src/views/pages/database/Zone.page.tsx
+++ b/src/views/pages/database/Zone.page.tsx
@@ -1,14 +1,16 @@
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DatabasePageStyle } from '@components/database/DatabasePageStyle';
+import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerStyle';
 
 import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
 import { DeleteButtonWithIcon } from '@components/buttons';
-import { DatabasePageStyle } from '@components/database/DatabasePageStyle';
-import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerStyle';
-import { useTranslation } from 'react-i18next';
-import { SelectChangeEvent } from '@components/SelectCustom/SelectCustomPropsInterface';
-import { Deletion, DeletionOverlay } from '@components/deletion';
 import { EditorOverlay } from '@components/editor';
+import { Deletion, DeletionOverlay } from '@components/deletion';
+import { SelectChangeEvent } from '@components/SelectCustom/SelectCustomPropsInterface';
 import { ZoneControlBar, ZoneFrame, ZoneGroups, ZoneSettings, ZoneTravel, ZonePokemon } from '@components/database/zone';
+import { ZoneEditorOverlay, ZoneEditorAndDeletionKeys } from '@components/database/zone/editors/ZoneEditorOverlay';
 import {
   ZoneAddGroupEditor,
   ZoneEditGroupEditor,
@@ -19,17 +21,22 @@ import {
   ZoneTravelEditor,
 } from '@components/database/zone/editors';
 
+import { useDialogsRef } from '@src/hooks/useDialogsRef';
 import { useTranslationEditor } from '@hooks/useTranslationEditor';
 import { useProjectGroups, useProjectZones } from '@hooks/useProjectData';
 import { StudioShortcutActions, useShortcut } from '@hooks/useShortcuts';
+
+import { StudioGroup } from '@modelEntities/group';
+import { ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
+
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
 import { defineRelationCustomCondition } from '@utils/GroupUtils';
 import { cloneEntity } from '@utils/cloneEntity';
-import { StudioGroup } from '@modelEntities/group';
 import { cleaningZoneNaNValues } from '@utils/cleanNaNValue';
-import { ZONE_DESCRIPTION_TEXT_ID, ZONE_NAME_TEXT_ID } from '@modelEntities/zone';
 
 export const ZonePage = () => {
+  const dialogsRef = useDialogsRef<ZoneEditorAndDeletionKeys>();
+
   const {
     projectDataValues: zones,
     selectedDataIdentifier: zoneDbSymbol,
@@ -84,14 +91,6 @@ export const ZonePage = () => {
     closeTranslationEditor();
   };
 
-  const onAddGroup = (editedGroup: StudioGroup) => {
-    currentEditedZone.wildGroups.push(editedGroup.dbSymbol);
-    editedGroup.customConditions = defineRelationCustomCondition(editedGroup.customConditions);
-    setZone({ [zone.dbSymbol]: currentEditedZone });
-    setGroup({ [editedGroup.dbSymbol]: editedGroup });
-    setCurrentEditor(undefined);
-  };
-
   const onEditGroup = (index: number) => {
     setCurrentGroupIndex(index);
     setCurrentEditedGroup({ data: cloneEntity(groups[zone.wildGroups[index]]) });
@@ -113,15 +112,15 @@ export const ZonePage = () => {
     setCurrentDeletion(undefined);
   };
 
-  const editors = {
-    new: <ZoneNewEditor onClose={() => setCurrentEditor(undefined)} />,
-    frame: <ZoneFrameEditor zone={currentEditedZone} openTranslationEditor={openTranslationEditor} />,
-    settings: <ZoneSettingsEditor zone={currentEditedZone} />,
-    travel: <ZoneTravelEditor zone={currentEditedZone} />,
-    addGroup: <ZoneAddGroupEditor zone={currentEditedZone} groups={groups} onAddGroup={onAddGroup} onClose={() => setCurrentEditor(undefined)} />,
-    editGroup: <ZoneEditGroupEditor zone={currentEditedZone} groups={groups} group={currentEditedGroup} index={currentGroupIndex} />,
-    importGroup: <ZoneGroupImportEditor zone={currentEditedZone} onClose={() => setCurrentEditor(undefined)} />,
-  };
+  // const editors = {
+  //   new: <ZoneNewEditor onClose={() => setCurrentEditor(undefined)} />,
+  //   frame: <ZoneFrameEditor zone={currentEditedZone} openTranslationEditor={openTranslationEditor} />,
+  //   settings: <ZoneSettingsEditor zone={currentEditedZone} />,
+  //   travel: <ZoneTravelEditor zone={currentEditedZone} />,
+  //   addGroup: <ZoneAddGroupEditor zone={currentEditedZone} groups={groups} onAddGroup={onAddGroup} onClose={() => setCurrentEditor(undefined)} />,
+  //   editGroup: <ZoneEditGroupEditor zone={currentEditedZone} groups={groups} group={currentEditedGroup} index={currentGroupIndex} />,
+  //   importGroup: <ZoneGroupImportEditor zone={currentEditedZone} onClose={() => setCurrentEditor(undefined)} />,
+  // };
 
   const deletions = {
     zone: (
@@ -172,7 +171,7 @@ export const ZonePage = () => {
               </DeleteButtonWithIcon>
             </DataBlockWithAction>
           </DataBlockWrapper>
-          <EditorOverlay currentEditor={currentEditor} editors={editors} subEditor={translationEditor} onClose={onCloseEditor} />
+          <ZoneEditorOverlay ref={dialogsRef} />
           <DeletionOverlay currentDeletion={currentDeletion} deletions={deletions} onClose={() => setCurrentDeletion(undefined)} />
         </PageDataConstrainerStyle>
       </PageContainerStyle>


### PR DESCRIPTION
## Description

This PR improves the page responsability of zones database page.
Zod form was not used, because the important point here was to integrate the page responsibility template so that the rework of the global state could be finalised.

At the same time, changes have been made to add better practices (use of refs) and improve the UX with inputs.

Closes #26 

## Tests to perform

- [x]  The user can create a zone
- [x]  The user can delete a zone
- [x]  The user can edit the travel data of a zone
- [x]  The user can edit the settings data of a zone
- [x]  The user can manage the groups (CRUD)
- [x]  Check in PSDK that the encounters conditions are correct