### PR TITLE
Fix the issue where a female-only Pokemon's icon are not displayed in lists if no male icon is set

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -123,8 +123,9 @@ export const pokemonSpritePath = (form: StudioCreatureForm) => {
 
 export const pokemonIconPath = (specie: StudioCreature, formId?: number, icon?: 'icon' | 'iconF' | 'iconShiny' | 'iconShinyF') => {
   const form = specie.forms.find((f) => f.form === formId) ?? specie.forms[0];
-  if (!form?.resources[icon ?? 'icon']) return formResourcesPath(form, 'icon');
-  return formResourcesPath(form, icon ?? 'icon');
+  const resource = form.femaleRate === 100 ? 'iconF' : 'icon';
+  if (!form?.resources[icon ?? resource]) return formResourcesPath(form, resource);
+  return formResourcesPath(form, icon ?? resource);
 };
 
 export const itemIconPath = (icon: string) => {


### PR DESCRIPTION
## Description

This PR fixes an issue where a Pokémon's icon would not display in some lists when it has no male icon set even if it is female-only.

## Note before testing

- Go to a female-only Pokémon database page (like Nidoqueen)
- Set the female encounter rate to less than 100%
- Go to the Resource tab
- Remove the male icon in the Icons section
- Set the female rate back to 100%

## Tests to perform

- [x] The Pokémon's icon should be displayed in the Pokédex page
- [x] The Pokémon's icon should be displayed in the "Pokémon with the abitlity X" page
- [x] The Pokémon's icon should be displayed in the "Pokémon with the move Y" page
- [x] The Pokémon's icon should be displayed in the "Pokémon with the type Z" page
