### PR TITLE
New quests can be created by importing data from another quest

### DIFF
--- a/assets/i18n/en/database_quests.json
+++ b/assets/i18n/en/database_quests.json
@@ -95,5 +95,9 @@
   "earning_pokemon": "Pokémon",
   "earning_egg": "Egg",
   "earning": "Earning",
-  "example_custom_objective": "Text for a custom objective"
+  "example_custom_objective": "Text for a custom objective",
+  "quest_import_info": "You can create this new quest by importing data from another existing quest.",
+  "none_option": "None",
+  "other_data": "Other data",
+  "import_quest_from": "Import data from"
 }

--- a/assets/i18n/fr/database_quests.json
+++ b/assets/i18n/fr/database_quests.json
@@ -95,5 +95,9 @@
   "earning_pokemon": "Pokémon",
   "earning_egg": "Œuf",
   "earning": "Récompense",
-  "example_custom_objective": "Texte pour un objectif personnalisé"
+  "example_custom_objective": "Texte pour un objectif personnalisé",
+  "quest_import_info": "Vous pouvez créer cette nouvelle quête en copiant les données d'une autre quête déjà existante.",
+  "none_option": "Aucun",
+  "other_data": "Autres données",
+  "import_quest_from": "Importer les données de"
 }

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -4,6 +4,7 @@ import { StudioCreature } from '@modelEntities/creature';
 import { cloneEntity } from './cloneEntity';
 import { findFirstAvailableFormTextId } from './ModelUtils';
 import { ProjectData } from '@src/GlobalStateProvider';
+import { StudioQuest } from '@modelEntities/quest';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -27,7 +28,7 @@ export const importMoveData = (move: StudioMove, dataToImport: StudioMove): Stud
     type: move.type,
     category: move.category,
   };
-}
+};
 
 export const importCreatureData = (creature: StudioCreature, dataToImport: StudioCreature, allPokemon: ProjectData['pokemon']): StudioCreature => {
   const cloneData = cloneEntity(dataToImport);
@@ -55,4 +56,15 @@ export const importCreatureData = (creature: StudioCreature, dataToImport: Studi
   });
 
   return newCreature;
+};
+
+export const importQuestData = (quest: StudioQuest, dataToImport: StudioQuest): StudioQuest => {
+  const cloneData = cloneEntity(dataToImport);
+
+  return {
+    ...cloneData,
+    id: quest.id,
+    dbSymbol: quest.dbSymbol,
+    isPrimary: quest.isPrimary,
+  };
 };

--- a/src/views/components/database/quest/editors/QuestNewEditor.tsx
+++ b/src/views/components/database/quest/editors/QuestNewEditor.tsx
@@ -12,6 +12,9 @@ import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/
 import styled from 'styled-components';
 import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { Select } from '@ds/Select';
+import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
+import { SelectQuest } from '@components/selects';
+import { importQuestData } from '@utils/importEntityDataUtils';
 
 const questCategoryEntries = (t: TFunction<'database_quests'>) => QUEST_CATEGORIES.map((category) => ({ value: category, label: t(category) }));
 
@@ -23,6 +26,18 @@ const ButtonContainer = styled.div`
   flex-direction: column;
   padding: 16px 0 0 0;
   gap: 8px;
+`;
+
+const ImportInfo = styled.div`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+`;
+
+const ImportInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 
 type QuestNewEditorProps = {
@@ -39,13 +54,20 @@ export const QuestNewEditor = forwardRef<EditorHandlingClose, QuestNewEditorProp
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const categoryRef = useRef<string | undefined>();
   //const resolutionRef = useRef<string | undefined>();
+  const [selectedQuest, setSelectedQuest] = useState('__undef__');
+  const [importing, setImporting] = useState(false);
 
   useEditorHandlingClose(ref);
 
   const onClickNew = () => {
     if (!descriptionRef.current || !categoryRef.current) return;
 
-    const newQuest = createQuest(quests, categoryRef.current === 'primary', 'default');
+    let newQuest = createQuest(quests, categoryRef.current === 'primary', 'default');
+
+    if (importing && selectedQuest !== '__undef__') {
+      newQuest = importQuestData(newQuest, quests[selectedQuest]);
+    }
+
     setText(QUEST_NAME_TEXT_ID, newQuest.id, name);
     setText(QUEST_DESCRIPTION_TEXT_ID, newQuest.id, descriptionRef.current.value);
     setQuest({ [newQuest.dbSymbol]: newQuest }, { quest: newQuest.dbSymbol });
@@ -73,6 +95,15 @@ export const QuestNewEditor = forwardRef<EditorHandlingClose, QuestNewEditorProp
           <Label htmlFor="descr">{t('description')}</Label>
           <MultiLineInput id="descr" ref={descriptionRef} placeholder={t('example_descr')} />
         </InputWithTopLabelContainer>
+        <InputGroupCollapse title={t('other_data')} gap="16px" onClick={() => setImporting(!importing)}>
+          <ImportInfoContainer>
+            <ImportInfo>{t('quest_import_info')}</ImportInfo>
+          </ImportInfoContainer>
+          <InputWithTopLabelContainer>
+            <Label htmlFor="select-quest-to-import">{t('import_quest_from')}</Label>
+            <SelectQuest dbSymbol={selectedQuest} onChange={(dbSymbol) => setSelectedQuest(dbSymbol)} noLabel undefValueOption={t('none_option')} />
+          </InputWithTopLabelContainer>
+        </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={!name ? t('fields_asterisk_required') : undefined}>
             <PrimaryButton onClick={onClickNew} disabled={!name}>


### PR DESCRIPTION
## Description

The user can now create a new quest by importing data from another existing quest.

closes #466  

## Tests to perform

Open the "New Quest" editor

### Creating a new quest without importing any data

- [x] Fill the basic data and create the quest => only the basic data is filled for the new quest, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, leave the selection on "None" and create the quest => only the basic data is filled for the new quest, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, select a quest, re-collapse the "other data" component and create the quest => only the basic data is filled for the new quest, all other data are filled with default values

### Creating a new quest by importing data
- [x] Fill the basic data, un-collapse the "other data" component, select a quest and create the quest => the basic data is filled for the new quest with the information you entered **AND** all other data are filled with the same data as the chosen quest

