### PR TITLE
New groups can be created by importing data from another group

### DIFF
--- a/assets/i18n/en/database_groups.json
+++ b/assets/i18n/en/database_groups.json
@@ -73,5 +73,9 @@
   "title_data_modification": "Data modification",
   "warning_headbutt_data_change": "Headbutt should now be set in the Environment list.",
   "custom_environment": "Custom environment",
-  "invalid_format": "Invalid format"
+  "invalid_format": "Invalid format",
+  "group_import_info": "You can create this new group by importing data from another existing group.",
+  "none_option": "None",
+  "other_data": "Other data",
+  "import_group_from": "Import data from"
 }

--- a/assets/i18n/fr/database_groups.json
+++ b/assets/i18n/fr/database_groups.json
@@ -73,5 +73,9 @@
   "title_data_modification": "Modification de données",
   "warning_headbutt_data_change": "Coup d'Boule doit désormais être paramétrée dans la liste Environnement.",
   "custom_environment": "Environnement personnalisé",
-  "invalid_format": "Format non valide"
+  "invalid_format": "Format non valide",
+  "group_import_info": "Vous pouvez créer ce nouveau groupe en copiant les données d'un autre groupe déjà existant.",
+  "none_option": "Aucun",
+  "other_data": "Autres données",
+  "import_group_from": "Importer les données de"
 }

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -4,6 +4,7 @@ import { StudioCreature } from '@modelEntities/creature';
 import { cloneEntity } from './cloneEntity';
 import { findFirstAvailableFormTextId } from './ModelUtils';
 import { ProjectData } from '@src/GlobalStateProvider';
+import { StudioGroup } from '@modelEntities/group';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -27,7 +28,7 @@ export const importMoveData = (move: StudioMove, dataToImport: StudioMove): Stud
     type: move.type,
     category: move.category,
   };
-}
+};
 
 export const importCreatureData = (creature: StudioCreature, dataToImport: StudioCreature, allPokemon: ProjectData['pokemon']): StudioCreature => {
   const cloneData = cloneEntity(dataToImport);
@@ -55,4 +56,14 @@ export const importCreatureData = (creature: StudioCreature, dataToImport: Studi
   });
 
   return newCreature;
+};
+
+export const importGroupData = (group: StudioGroup, dataToImport: StudioGroup): StudioGroup => {
+  const cloneData = cloneEntity(dataToImport);
+
+  return {
+    ...group,
+    isHordeBattle: cloneData.isHordeBattle,
+    encounters: cloneData.encounters,
+  };
 };

--- a/src/views/components/database/group/editors/GroupNewEditor.tsx
+++ b/src/views/components/database/group/editors/GroupNewEditor.tsx
@@ -27,6 +27,9 @@ import { findFirstAvailableId } from '@utils/ModelUtils';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { TextInputError } from '@components/inputs/Input';
+import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
+import { SelectGroup } from '@components/selects';
+import { importGroupData } from '@utils/importEntityDataUtils';
 
 const groupActivationEntries = (t: TFunction<'database_groups'>) =>
   GroupActivationsMap.map((activation) => ({ value: activation.value, label: t(activation.label) }));
@@ -42,6 +45,18 @@ const ButtonContainer = styled.div`
   flex-direction: column;
   padding: 16px 0 0 0;
   gap: 8px;
+`;
+
+const ImportInfo = styled.div`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+`;
+
+const ImportInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 
 type GroupNewEditorProps = {
@@ -66,6 +81,8 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
   const [stepsAverage, setStepsAverage] = useState<number>(30);
   const isCustomEnvironment = useMemo(() => isCustomEnvironmentFunc(systemTag), [systemTag]);
   const customEnvironmentError = systemTag !== '' && wrongEnvironment(systemTag);
+  const [selectedGroup, setSelectedGroup] = useState('__undef__');
+  const [importing, setImporting] = useState(false);
 
   useEditorHandlingClose(ref);
 
@@ -77,7 +94,7 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
     const activationSwitchId = activation === 'custom' ? switchId : Number(activation);
     const newSystemTag = isCustomEnvironment ? setCustomEnvironment(systemTag) : systemTag;
 
-    const group = createGroup(
+    let group = createGroup(
       dbSymbol,
       id,
       newSystemTag,
@@ -87,6 +104,11 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
       activation === 'always' ? undefined : { value: activationSwitchId, type: 'enabledSwitch', relationWithPreviousCondition: 'AND' },
       stepsAverage
     );
+
+    if (importing && selectedGroup !== '__undef__') {
+      group = importGroupData(group, groups[selectedGroup]);
+    }
+
     group.customConditions = defineRelationCustomCondition(group.customConditions);
     setText(GROUP_NAME_TEXT_ID, group.id, name);
     setGroup({ [dbSymbol]: group }, { group: dbSymbol });
@@ -189,6 +211,15 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
             onChange={(event) => setStepsAverage(event.target.valueAsNumber)}
           />
         </InputWithLeftLabelContainer>
+        <InputGroupCollapse title={t('other_data')} gap="16px" onClick={() => setImporting(!importing)}>
+          <ImportInfoContainer>
+            <ImportInfo>{t('group_import_info')}</ImportInfo>
+          </ImportInfoContainer>
+          <InputWithTopLabelContainer>
+            <Label htmlFor="select-group-to-import">{t('import_group_from')}</Label>
+            <SelectGroup dbSymbol={selectedGroup} onChange={(dbSymbol) => setSelectedGroup(dbSymbol)} noLabel undefValueOption={t('none_option')} />
+          </InputWithTopLabelContainer>
+        </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={!canNew() ? t('fields_asterisk_required') : undefined}>
             <PrimaryButton onClick={onClickNew} disabled={!canNew()}>


### PR DESCRIPTION
## Description

The user can now create a new group by importing data from another existing group.

closes #465   

## Tests to perform

Open the "New Group" editor

### Creating a new group without importing any data

- [x] Fill the basic data and create the group => only the basic data is filled for the new group, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, leave the selection on "None" and create the group => only the basic data is filled for the new group, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, select a group, re-collapse the "other data" component and create the group => only the basic data is filled for the new group, all other data are filled with default values

### Creating a new group by importing data
- [x] Fill the basic data, un-collapse the "other data" component, select a group and create the group => the basic data is filled for the new group with the information you entered **AND** all other data are filled with the same data as the chosen group

