### PR TITLE
New items can be created by importing data from another item

### DIFF
--- a/assets/i18n/en/database_items.json
+++ b/assets/i18n/en/database_items.json
@@ -115,5 +115,9 @@
   "deletion_of": "Deletion of the item {{item}}",
   "deletion_message": "You are about to permanently delete the item {{item}}.",
   "item_deleted": "Item deleted",
-  "no_parameter": "No parameter"
+  "no_parameter": "No parameter",
+  "item_import_info": "You can create this new item by importing data from another existing item.",
+  "none_option": "None",
+  "other_data": "Other data",
+  "import_item_from": "Import data from"
 }

--- a/assets/i18n/fr/database_items.json
+++ b/assets/i18n/fr/database_items.json
@@ -115,5 +115,9 @@
   "deletion_of": "Suppression de l'objet {{item}}",
   "deletion_message": "Vous êtes sur le point de supprimer définitivement l'objet {{item}}.",
   "item_deleted": "Objet supprimé",
-  "no_parameter": "Aucun paramètre"
+  "no_parameter": "Aucun paramètre",
+  "item_import_info": "Vous pouvez créer ce nouvel objet en copiant les données d'un autre objet déjà existant.",
+  "none_option": "Aucun",
+  "other_data": "Autres données",
+  "import_item_from": "Importer les données de"
 }

--- a/src/hooks/useSelectOptions.ts
+++ b/src/hooks/useSelectOptions.ts
@@ -27,6 +27,12 @@ const OPTION_SOURCE_KEYS = [
   'itemStone',
   'itemGem',
   'itemBall',
+  'itemEvent',
+  'itemFleeing',
+  'itemGeneric',
+  'itemRepel',
+  'itemTech',
+  'itemHealing',
   'moves',
   'abilities',
   'dex',
@@ -48,6 +54,12 @@ const OptionSources: Record<OptionSourceKey, SelectOption[]> = {
   itemStone: [],
   itemGem: [],
   itemBall: [],
+  itemEvent: [],
+  itemFleeing: [],
+  itemGeneric: [],
+  itemRepel: [],
+  itemTech: [],
+  itemHealing: [],
   moves: [],
   abilities: [],
   dex: [],
@@ -85,6 +97,12 @@ const OptionToTextKey: Record<OptionSourceKey, TextSourceKey> = {
   itemStone: 'items',
   itemGem: 'items',
   itemBall: 'items',
+  itemEvent: 'items',
+  itemFleeing: 'items',
+  itemGeneric: 'items',
+  itemRepel: 'items',
+  itemTech: 'items',
+  itemHealing: 'items',
   moves: 'moves',
   abilities: 'abilities',
   dex: 'dex',
@@ -232,6 +250,21 @@ const adjustSelectOptionValue = (option: SelectOption, value: string) => {
   return option;
 };
 
+const HEAL_ITEM_KLASSES = [
+  'AllPPHealItem',
+  'ConstantHealItem',
+  'EVBoostItem',
+  'HealingItem',
+  'LevelIncreaseItem',
+  'ExpGiveItem',
+  'ExpGiveItem',
+  'PPIncreaseItem',
+  'RateHealItem',
+  'StatBoostItem',
+  'StatusConstantHealItem',
+  'StatusHealItem',
+  'StatusRateHealItem',
+];
 const buildSelectOptionsFromKey = (key: OptionSourceKey, state: State) => {
   const textKey = OptionToTextKey[key];
   const originalObjects = TextSources[textKey];
@@ -263,6 +296,36 @@ const buildSelectOptionsFromKey = (key: OptionSourceKey, state: State) => {
     case 'itemBall':
       return Object.values(state.projectData.items)
         .filter((data) => data.klass === 'BallItem')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemEvent':
+      return Object.values(state.projectData.items)
+        .filter((data) => data.klass === 'EventItem')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemFleeing':
+      return Object.values(state.projectData.items)
+        .filter((data) => data.klass === 'FleeingItem')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemGeneric':
+      return Object.values(state.projectData.items)
+        .filter((data) => data.klass === 'Item')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemRepel':
+      return Object.values(state.projectData.items)
+        .filter((data) => data.klass === 'RepelItem')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemTech':
+      return Object.values(state.projectData.items)
+        .filter((data) => data.klass === 'TechItem')
+        .sort((a, b) => a.id - b.id)
+        .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
+    case 'itemHealing':
+      return Object.values(state.projectData.items)
+        .filter((data) => HEAL_ITEM_KLASSES.includes(data.klass))
         .sort((a, b) => a.id - b.id)
         .map((data) => adjustSelectOptionValue(originalObjects[data.id] || cloneEntity(originalObjects[0]), data.dbSymbol));
     case 'moves':

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -4,6 +4,7 @@ import { StudioCreature } from '@modelEntities/creature';
 import { cloneEntity } from './cloneEntity';
 import { findFirstAvailableFormTextId } from './ModelUtils';
 import { ProjectData } from '@src/GlobalStateProvider';
+import { StudioItem } from '@modelEntities/item';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -27,7 +28,7 @@ export const importMoveData = (move: StudioMove, dataToImport: StudioMove): Stud
     type: move.type,
     category: move.category,
   };
-}
+};
 
 export const importCreatureData = (creature: StudioCreature, dataToImport: StudioCreature, allPokemon: ProjectData['pokemon']): StudioCreature => {
   const cloneData = cloneEntity(dataToImport);
@@ -55,4 +56,14 @@ export const importCreatureData = (creature: StudioCreature, dataToImport: Studi
   });
 
   return newCreature;
+};
+
+export const importItemData = (item: StudioItem, dataToImport: StudioItem): StudioItem => {
+  const cloneData = cloneEntity(dataToImport);
+
+  return {
+    ...cloneData,
+    id: item.id,
+    dbSymbol: item.dbSymbol,
+  };
 };

--- a/src/views/components/database/item/editors/ItemNewEditor.tsx
+++ b/src/views/components/database/item/editors/ItemNewEditor.tsx
@@ -26,6 +26,9 @@ import { useSetProjectText } from '@utils/ReadingProjectText';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useItemPage } from '@hooks/usePage';
 import { TooltipWrapper } from '@ds/Tooltip';
+import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
+import { SelectItem } from '@components/selects';
+import { importItemData } from '@utils/importEntityDataUtils';
 
 const itemCategoryEntries = (t: TFunction<('database_items' | 'database_types' | 'database_moves')[]>) =>
   StudioItemCategories.map((category) => ({ value: category, label: t(`database_types:${category}`) })).sort((a, b) =>
@@ -43,6 +46,18 @@ const ButtonContainer = styled.div`
   gap: 8px;
 `;
 
+const ImportInfo = styled.div`
+  ${({ theme }) => theme.fonts.normalSmall};
+  color: ${({ theme }) => theme.colors.text400};
+  user-select: none;
+`;
+
+const ImportInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
 export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>(({ closeDialog }, ref) => {
   const { setProjectDataValues: setItem } = useProjectItems();
   const { items } = useItemPage();
@@ -56,6 +71,8 @@ export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>
   const [dbSymbolErrorType, setDbSymbolErrorType] = useState<'value' | 'duplicate' | undefined>(undefined);
   const [itemCategory, setItemCategory] = useState<StudioItemCategory>('generic');
   const [icon, setIcon] = useState('');
+  const [selectedItem, setSelectedItem] = useState('__undef__');
+  const [importing, setImporting] = useState(false);
 
   useEditorHandlingClose(ref);
 
@@ -64,7 +81,12 @@ export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>
 
     const dbSymbol = dbSymbolRef.current.value as DbSymbol;
     const id = findFirstAvailableId(items, 1);
-    const newItem = createItem(ITEM_CATEGORY_INITIAL_CLASSES[itemCategory], dbSymbol, id);
+    let newItem = createItem(ITEM_CATEGORY_INITIAL_CLASSES[itemCategory], dbSymbol, id);
+
+    if (importing && selectedItem !== '__undef__') {
+      newItem = importItemData(newItem, items[selectedItem]);
+    }
+
     newItem.icon = icon;
     setText(ITEM_NAME_TEXT_ID, newItem.id, name);
     setText(ITEM_DESCRIPTION_TEXT_ID, newItem.id, descriptionRef.current.value);
@@ -158,6 +180,15 @@ export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>
           {dbSymbolErrorType == 'value' && <TextInputError>{t('database_moves:incorrect_format')}</TextInputError>}
           {dbSymbolErrorType == 'duplicate' && <TextInputError>{t('database_moves:db_symbol_already_used')}</TextInputError>}
         </InputWithTopLabelContainer>
+        <InputGroupCollapse title={t('other_data')} gap="16px" onClick={() => setImporting(!importing)}>
+          <ImportInfoContainer>
+            <ImportInfo>{t('item_import_info')}</ImportInfo>
+          </ImportInfoContainer>
+          <InputWithTopLabelContainer>
+            <Label htmlFor="select-item-to-import">{t('import_item_from')}</Label>
+            <SelectItem dbSymbol={selectedItem} onChange={(dbSymbol) => setSelectedItem(dbSymbol)} noLabel undefValueOption={t('none_option')} />
+          </InputWithTopLabelContainer>
+        </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={checkDisabled() ? t('database_moves:fields_asterisk_required') : undefined}>
             <PrimaryButton onClick={onClickNew} disabled={checkDisabled()}>

--- a/src/views/components/database/item/editors/ItemNewEditor.tsx
+++ b/src/views/components/database/item/editors/ItemNewEditor.tsx
@@ -29,6 +29,7 @@ import { TooltipWrapper } from '@ds/Tooltip';
 import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
 import { SelectItem } from '@components/selects';
 import { importItemData } from '@utils/importEntityDataUtils';
+import { OptionSourceKey } from '@src/hooks/useSelectOptions';
 
 const itemCategoryEntries = (t: TFunction<('database_items' | 'database_types' | 'database_moves')[]>) =>
   StudioItemCategories.map((category) => ({ value: category, label: t(`database_types:${category}`) })).sort((a, b) =>
@@ -57,6 +58,17 @@ const ImportInfoContainer = styled.div`
   flex-direction: column;
   gap: 4px;
 `;
+
+const CATEGORY_TO_OPTION = {
+  ball: 'itemBall',
+  event: 'itemEvent',
+  fleeing: 'itemFleeing',
+  generic: 'itemGeneric',
+  heal: 'itemHealing',
+  repel: 'itemRepel',
+  stone: 'itemStone',
+  tech: 'itemTech',
+};
 
 export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>(({ closeDialog }, ref) => {
   const { setProjectDataValues: setItem } = useProjectItems();
@@ -186,7 +198,13 @@ export const ItemNewEditor = forwardRef<EditorHandlingClose, ItemNewEditorProps>
           </ImportInfoContainer>
           <InputWithTopLabelContainer>
             <Label htmlFor="select-item-to-import">{t('import_item_from')}</Label>
-            <SelectItem dbSymbol={selectedItem} onChange={(dbSymbol) => setSelectedItem(dbSymbol)} noLabel undefValueOption={t('none_option')} />
+            <SelectItem
+              dbSymbol={selectedItem}
+              onChange={(dbSymbol) => setSelectedItem(dbSymbol)}
+              noLabel
+              undefValueOption={t('none_option')}
+              klassFilter={CATEGORY_TO_OPTION[itemCategory] as OptionSourceKey}
+            />
           </InputWithTopLabelContainer>
         </InputGroupCollapse>
         <ButtonContainer>

--- a/src/views/components/selects/SelectItem.tsx
+++ b/src/views/components/selects/SelectItem.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelectOptions } from '@hooks/useSelectOptions';
+import { OptionSourceKey, useSelectOptions } from '@hooks/useSelectOptions';
 import { StudioDropDown } from '@components/StudioDropDown';
 import { SelectContainerWithLabel } from './SelectContainerWithLabel';
 import { DbSymbol } from '@modelEntities/dbSymbol';
@@ -13,11 +13,12 @@ type SelectItemProps = {
   undefValueOption?: string;
   noLabel?: boolean;
   noneValue?: boolean;
+  klassFilter?: OptionSourceKey;
 };
 
-export const SelectItem = ({ dbSymbol, onChange, noLabel, noneValue, undefValueOption }: SelectItemProps) => {
+export const SelectItem = ({ dbSymbol, onChange, noLabel, noneValue, undefValueOption, klassFilter }: SelectItemProps) => {
   const { t } = useTranslation(['database_items', 'select']);
-  const typeOptions = useSelectOptions('items');
+  const typeOptions = useSelectOptions(klassFilter || 'items');
 
   const options = useMemo(() => {
     if (undefValueOption) return [{ value: '__undef__', label: undefValueOption }, ...typeOptions];


### PR DESCRIPTION
## Description

The user can now create a new group by importing data from another existing group.

closes #464 

## Tests to perform

Open the "New Item" editor

### Creating a new item without importing any data
- [x] Fill the basic data and create the item => only the basic data is filled for the new item, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, leave the selection on "None" and create the item => only the basic data is filled for the new item, all other data are filled with default values
- [x] Fill the basic data, un-collapse the "other data" component, select an item, re-collapse the "other data" component and create the item => only the basic data is filled for the new item, all other data are filled with default values

### Creating a new item by importing data
- [x] Fill the basic data, un-collapse the "other data" component, select an item and create the item => the basic data is filled for the new item with the information you entered **AND** all other data are filled with the same data as the chosen item

### Verifying the "Other Data" Select content is properly pre-filtered
- [x] When you select a category in the main part of the New Item modal, available options in the "Other Data" Select are correctly pre-filtered to only show existing items that share the chosen category

