### PR TITLE
Feature: The Pokedex import feature should let the user chose to replace the entire list or not

### DIFF
--- a/assets/i18n/en/database_dex.json
+++ b/assets/i18n/en/database_dex.json
@@ -36,5 +36,6 @@
   "add_all_evolution": "Add evolutions",
   "free_slot": "Free slot",
   "creatures_already_in_dex": "All the evolutions of {{name}} have already been added.",
-  "creature_no_evolution": "{{name}} has no evolution."
+  "creature_no_evolution": "{{name}} has no evolution.",
+  "replace_creatures": "Replace Pokémon"
 }

--- a/assets/i18n/fr/database_dex.json
+++ b/assets/i18n/fr/database_dex.json
@@ -36,5 +36,6 @@
   "add_all_evolution": "Ajouter les évolutions",
   "free_slot": "Emplacement libre",
   "creatures_already_in_dex": "Toutes les évolutions de {{name}} ont déjà été ajoutées.",
-  "creature_no_evolution": "{{name}} n'a pas d'évolution."
+  "creature_no_evolution": "{{name}} n'a pas d'évolution.",
+  "replace_creatures": "Remplacer les Pokémon"
 }

--- a/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
+++ b/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
@@ -12,6 +12,7 @@ import { cloneEntity } from '@utils/cloneEntity';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useDexPage } from '@hooks/usePage';
 import { useUpdateDex } from './useUpdateDex';
+import type { StudioDexCreature } from '@modelEntities/dex';
 
 const DexImportInfo = styled.div`
   ${({ theme }) => theme.fonts.normalRegular};
@@ -24,6 +25,15 @@ const ButtonContainer = styled.div`
   flex-direction: column;
   gap: 8px;
 `;
+
+const addNewCreaturesInList = (creatures: StudioDexCreature[], newCreatures: StudioDexCreature[]): StudioDexCreature[] => {
+  return newCreatures.reduce((newCreaturesList, newCreature) => {
+    if (newCreaturesList.findIndex((creature) => creature.dbSymbol === newCreature.dbSymbol) === -1) {
+      return [...newCreaturesList, newCreature];
+    }
+    return newCreaturesList;
+  }, cloneEntity(creatures));
+};
 
 type DexPokemonListImportEditorProps = {
   closeDialog: () => void;
@@ -44,11 +54,11 @@ export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPok
   useEditorHandlingClose(ref);
 
   const onClickImport = () => {
-    const creatures = cloneEntity(allDex[selectedDexImport].creatures);
+    const newCreatures = cloneEntity(allDex[selectedDexImport].creatures);
     if (overrideRef.current?.checked) {
-      updateDex({ creatures });
+      updateDex({ creatures: newCreatures });
     } else {
-      updateDex({ creatures: [...dex.creatures, ...creatures] });
+      updateDex({ creatures: addNewCreaturesInList(dex.creatures, newCreatures) });
     }
     closeDialog();
   };

--- a/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
+++ b/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
@@ -45,7 +45,7 @@ export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPok
 
   const onClickImport = () => {
     const creatures = cloneEntity(allDex[selectedDexImport].creatures);
-    if (overrideRef.current && overrideRef.current.checked) {
+    if (overrideRef.current?.checked) {
       updateDex({ creatures });
     } else {
       updateDex({ creatures: [...dex.creatures, ...creatures] });

--- a/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
+++ b/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
@@ -27,12 +27,9 @@ const ButtonContainer = styled.div`
 `;
 
 const addNewCreaturesInList = (creatures: StudioDexCreature[], newCreatures: StudioDexCreature[]): StudioDexCreature[] => {
-  return newCreatures.reduce((newCreaturesList, newCreature) => {
-    if (newCreaturesList.findIndex((creature) => creature.dbSymbol === newCreature.dbSymbol) === -1) {
-      return [...newCreaturesList, newCreature];
-    }
-    return newCreaturesList;
-  }, cloneEntity(creatures));
+  const existingSymbols = new Set(creatures.map((creature) => creature.dbSymbol));
+  const newCreaturesToAdd = newCreatures.filter((newCreature) => !existingSymbols.has(newCreature.dbSymbol));
+  return [...creatures, ...newCreaturesToAdd];
 };
 
 type DexPokemonListImportEditorProps = {

--- a/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
+++ b/src/views/components/database/dex/editors/DexPokemonListImportEditor.tsx
@@ -1,9 +1,9 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Editor } from '@components/editor';
 
 import { useTranslation } from 'react-i18next';
-import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
 
 import { useProjectDex } from '@hooks/useProjectData';
 import { DarkButton, PrimaryButton } from '@components/buttons';
@@ -39,12 +39,17 @@ export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPok
     .filter((d) => d.value !== dex.dbSymbol)
     .sort((a, b) => a.index - b.index)[0].value;
   const [selectedDexImport, setSelectedDexImport] = useState<string>(firstDbSymbol);
+  const overrideRef = useRef<HTMLInputElement>(null);
 
   useEditorHandlingClose(ref);
 
   const onClickImport = () => {
     const creatures = cloneEntity(allDex[selectedDexImport].creatures);
-    updateDex({ creatures });
+    if (overrideRef.current && overrideRef.current.checked) {
+      updateDex({ creatures });
+    } else {
+      updateDex({ creatures: [...dex.creatures, ...creatures] });
+    }
     closeDialog();
   };
 
@@ -62,6 +67,10 @@ export const DexPokemonListImportEditor = forwardRef<EditorHandlingClose, DexPok
               noLabel
             />
           </InputWithTopLabelContainer>
+          <InputWithLeftLabelContainer>
+            <Label htmlFor="override">{t('replace_creatures')}</Label>
+            <Toggle name="override" ref={overrideRef} />
+          </InputWithLeftLabelContainer>
         </InputContainer>
         <ButtonContainer>
           <PrimaryButton onClick={onClickImport}>{t('import_the_list')}</PrimaryButton>


### PR DESCRIPTION
## Description

This PR adds a feature to permit at users to replace the entire list or not in the Pokémon list import in the Pokédex.

Closes #481 

## Tests to perform

- [x] The user can import a Pokémon list by replacing all the list
- [x] The user can import a Pokémon list without replacing all the list
- [x] No duplicate creatures in the list

## Screenshot

![image](https://github.com/user-attachments/assets/bee3b437-2635-4676-83c6-33cc663273e6)