### PR TITLE
Feature: The user would like to update the egg sprites of a creature

### DIFF
--- a/assets/i18n/en/database_pokemon.json
+++ b/assets/i18n/en/database_pokemon.json
@@ -209,6 +209,8 @@
   "iconShiny_alt": "Icon - Male Shiny",
   "iconF": "Icon - Female",
   "iconShinyF": "Icon - Female Shiny",
+  "iconEgg": "Icon - Egg",
+  "egg": "Egg",
   "footprint": "Footprint",
   "character": "Characters",
   "character_alt": "Characters - Male",

--- a/assets/i18n/en/migration.json
+++ b/assets/i18n/en/migration.json
@@ -14,5 +14,6 @@
   "migrate_breeding_group": "Migrate undefined breeding group to unknown breeding group",
   "add_trainer_additional_dialogs": "Additional dialogue added for trainers",
   "migrate_quests_earnings": "Migrate quest earnings",
-  "add_csv_quests_custom_objectives": "Add a CSV file for the quests custom objectives"
+  "add_csv_quests_custom_objectives": "Add a CSV file for the quests custom objectives",
+  "add_egg_in_creature_resources": "Add egg in the creatures resources"
 }

--- a/assets/i18n/fr/database_pokemon.json
+++ b/assets/i18n/fr/database_pokemon.json
@@ -209,6 +209,8 @@
   "iconShiny_alt": "Icône - Mâle Chromatique",
   "iconF": "Icône - Femelle",
   "iconShinyF": "Icône - Femelle Chromatique",
+  "iconEgg": "Icône - Œuf",
+  "egg": "Œuf",
   "footprint": "Empreintes",
   "character": "Characters",
   "character_alt": "Characters - Mâle",

--- a/assets/i18n/fr/migration.json
+++ b/assets/i18n/fr/migration.json
@@ -14,5 +14,6 @@
   "migrate_breeding_group": "Migration du groupe d'œuf «\u00a0Non défini\u00a0» en «\u00a0Inconnu\u00a0»",
   "add_trainer_additional_dialogs": "Ajout des dialogues additionnels pour les dresseurs",
   "migrate_quests_earnings": "Migration des récompenses de quêtes",
-  "add_csv_quests_custom_objectives": "Ajout d'un fichier CSV pour les objectives personnalisés des quêtes"
+  "add_csv_quests_custom_objectives": "Ajout d'un fichier CSV pour les objectives personnalisés des quêtes",
+  "add_egg_in_creature_resources": "Ajout de l'œuf dans les ressources des créatures"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-studio",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-studio",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@electron-forge/publisher-github": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/migrations/addEggInCreatureResources.ts
+++ b/src/migrations/addEggInCreatureResources.ts
@@ -18,7 +18,11 @@ type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_V
 
 const GRAPHICS_FRONT_PATH = 'graphics/pokedex/pokefront';
 const GRAPHICS_ICON_PATH = 'graphics/pokedex/pokeicon';
-const DEFAULT_EGG_RESOURCE = 'egg.png';
+const DEFAULT_EGG_RESOURCE = 'egg';
+
+const resourceExists = (resourcePath: string) => {
+  return fs.existsSync(`${resourcePath}.gif`) || fs.existsSync(`${resourcePath}.png`);
+};
 
 const addEggResource = async (
   creature: StudioCreatureDataBeforeMigration,
@@ -26,9 +30,9 @@ const addEggResource = async (
   hasDefaultEggSprite: boolean,
   hasDefaultEggIcon: boolean
 ) => {
-  const filename = `egg_${padStr(creature.id, 3)}.png`;
-  const hasCustomEggSprite = fs.existsSync(path.join(projectPath, GRAPHICS_FRONT_PATH, filename));
-  const hasCustomEggIcon = fs.existsSync(path.join(projectPath, GRAPHICS_ICON_PATH, filename));
+  const filename = `${DEFAULT_EGG_RESOURCE}_${padStr(creature.id, 3)}`;
+  const hasCustomEggSprite = resourceExists(path.join(projectPath, GRAPHICS_FRONT_PATH, filename));
+  const hasCustomEggIcon = resourceExists(path.join(projectPath, GRAPHICS_ICON_PATH, filename));
 
   await creature.forms.reduce(async (lastPromise, form) => {
     await lastPromise;
@@ -44,8 +48,8 @@ const addEggResource = async (
 export const addEggInCreatureResources = async (_: IpcMainEvent, projectPath: string) => {
   deletePSDKDatFile(projectPath);
 
-  const hasDefaultEggSprite = fs.existsSync(path.join(projectPath, GRAPHICS_FRONT_PATH, DEFAULT_EGG_RESOURCE));
-  const hasDefaultEggIcon = fs.existsSync(path.join(projectPath, GRAPHICS_ICON_PATH, DEFAULT_EGG_RESOURCE));
+  const hasDefaultEggSprite = resourceExists(path.join(projectPath, GRAPHICS_FRONT_PATH, DEFAULT_EGG_RESOURCE));
+  const hasDefaultEggIcon = resourceExists(path.join(projectPath, GRAPHICS_ICON_PATH, DEFAULT_EGG_RESOURCE));
 
   const creatures = await readProjectFolder(projectPath, 'pokemon');
   await creatures.reduce(async (lastPromise, creature) => {

--- a/src/migrations/addEggInCreatureResources.ts
+++ b/src/migrations/addEggInCreatureResources.ts
@@ -1,0 +1,62 @@
+import { IpcMainEvent } from 'electron';
+import path from 'path';
+import { readProjectFolder } from '@src/backendTasks/readProjectData';
+import fsPromise from 'fs/promises';
+import fs from 'fs';
+import { z } from 'zod';
+import { deletePSDKDatFile } from './migrateUtils';
+import { CREATURE_FORM_VALIDATOR, CREATURE_RESOURCES_VALIDATOR, CREATURE_VALIDATOR, StudioCreatureResources } from '@modelEntities/creature';
+import { parseJSON } from '@utils/json/parse';
+import { padStr } from '@utils/PadStr';
+
+const PRE_MIGRATION_CREATURE_FORM_VALIDATOR = CREATURE_FORM_VALIDATOR.extend({
+  resources: CREATURE_RESOURCES_VALIDATOR.omit({ egg: true, iconEgg: true }),
+});
+const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({ forms: z.array(PRE_MIGRATION_CREATURE_FORM_VALIDATOR).nonempty() });
+
+type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;
+
+const GRAPHICS_FRONT_PATH = 'graphics/pokedex/pokefront';
+const GRAPHICS_ICON_PATH = 'graphics/pokedex/pokeicon';
+const DEFAULT_EGG_RESOURCE = 'egg.png';
+
+const addEggResource = async (
+  creature: StudioCreatureDataBeforeMigration,
+  projectPath: string,
+  hasDefaultEggSprite: boolean,
+  hasDefaultEggIcon: boolean
+) => {
+  const filename = `egg_${padStr(creature.id, 3)}.png`;
+  const hasCustomEggSprite = fs.existsSync(path.join(projectPath, GRAPHICS_FRONT_PATH, filename));
+  const hasCustomEggIcon = fs.existsSync(path.join(projectPath, GRAPHICS_ICON_PATH, filename));
+
+  await creature.forms.reduce(async (lastPromise, form) => {
+    await lastPromise;
+
+    form.resources = {
+      ...form.resources,
+      egg: hasCustomEggSprite ? filename : hasDefaultEggSprite ? DEFAULT_EGG_RESOURCE : '',
+      iconEgg: hasCustomEggIcon ? filename : hasDefaultEggIcon ? DEFAULT_EGG_RESOURCE : '',
+    } as StudioCreatureResources;
+  }, Promise.resolve());
+};
+
+export const addEggInCreatureResources = async (_: IpcMainEvent, projectPath: string) => {
+  deletePSDKDatFile(projectPath);
+
+  const hasDefaultEggSprite = fs.existsSync(path.join(projectPath, GRAPHICS_FRONT_PATH, DEFAULT_EGG_RESOURCE));
+  const hasDefaultEggIcon = fs.existsSync(path.join(projectPath, GRAPHICS_ICON_PATH, DEFAULT_EGG_RESOURCE));
+
+  const creatures = await readProjectFolder(projectPath, 'pokemon');
+  await creatures.reduce(async (lastPromise, creature) => {
+    await lastPromise;
+    const creatureParsed = PRE_MIGRATION_CREATURE_VALIDATOR.safeParse(parseJSON(creature.data, creature.filename));
+    if (creatureParsed.success) {
+      await addEggResource(creatureParsed.data, projectPath, hasDefaultEggSprite, hasDefaultEggIcon);
+      return fsPromise.writeFile(
+        path.join(projectPath, 'Data/Studio/pokemon', `${creatureParsed.data.dbSymbol}.json`),
+        JSON.stringify(creatureParsed.data, null, 2)
+      );
+    }
+  }, Promise.resolve());
+};

--- a/src/migrations/linkResourcesToCreatures.ts
+++ b/src/migrations/linkResourcesToCreatures.ts
@@ -4,13 +4,7 @@ import path from 'path';
 import { readProjectFolder } from '@src/backendTasks/readProjectData';
 import { padStr } from '@utils/PadStr';
 import fsPromise from 'fs/promises';
-import {
-  StudioCreatureResources,
-  StudioCreatureForm,
-  CREATURE_VALIDATOR,
-  CREATURE_FORM_VALIDATOR,
-  CREATURE_RESOURCES_VALIDATOR,
-} from '@modelEntities/creature';
+import { StudioCreatureForm, CREATURE_VALIDATOR, CREATURE_FORM_VALIDATOR, CREATURE_RESOURCES_VALIDATOR } from '@modelEntities/creature';
 import { z } from 'zod';
 import { deletePSDKDatFile } from './migrateUtils';
 import { parseJSON } from '@utils/json/parse';
@@ -19,8 +13,16 @@ const PRE_MIGRATION_CREATURE_VALIDATOR = CREATURE_VALIDATOR.extend({
   forms: z.array(CREATURE_FORM_VALIDATOR.omit({ resources: true, formTextId: true })).nonempty(),
 });
 type StudioCreatureDataBeforeMigration = z.infer<typeof PRE_MIGRATION_CREATURE_VALIDATOR>;
-type ComputedCreatureResources = Partial<Omit<Exclude<StudioCreatureResources, { hasFemale: false }>, 'hasFemale'>>;
-const DEFAULT_CREATURE_RESOURCE: StudioCreatureResources = {
+
+const DEFAULT_CREATURE_RESOURCES_VALIDATOR = CREATURE_RESOURCES_VALIDATOR.omit({ egg: true, iconEgg: true });
+type StudioDefaultCreatureResources = z.infer<typeof DEFAULT_CREATURE_RESOURCES_VALIDATOR>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const CREATURE_FORM_WITHOUT_EGG_VALIDATOR = CREATURE_FORM_VALIDATOR.extend({ resources: DEFAULT_CREATURE_RESOURCES_VALIDATOR });
+type StudioCreatureFormWithoutEgg = z.infer<typeof CREATURE_FORM_WITHOUT_EGG_VALIDATOR>;
+
+type ComputedCreatureResources = Partial<Omit<Exclude<StudioDefaultCreatureResources, { hasFemale: false }>, 'hasFemale'>>;
+const DEFAULT_CREATURE_RESOURCE: StudioDefaultCreatureResources = {
   hasFemale: false,
   icon: '000',
   iconShiny: '000',
@@ -92,9 +94,12 @@ const hasFemale = (resources: ComputedCreatureResources) => {
   );
 };
 
-const fixResourcesForFemaleOnly = (form: Pick<StudioCreatureForm, 'femaleRate'>, resources: ComputedCreatureResources): StudioCreatureResources => {
+const fixResourcesForFemaleOnly = (
+  form: Pick<StudioCreatureForm, 'femaleRate'>,
+  resources: ComputedCreatureResources
+): StudioDefaultCreatureResources => {
   if (form.femaleRate !== 100) {
-    const resourcesValidated = CREATURE_RESOURCES_VALIDATOR.safeParse({ ...resources, hasFemale: hasFemale(resources) });
+    const resourcesValidated = DEFAULT_CREATURE_RESOURCES_VALIDATOR.safeParse({ ...resources, hasFemale: hasFemale(resources) });
     if (resourcesValidated.success) return resourcesValidated.data;
   }
 
@@ -107,7 +112,7 @@ const fixResourcesForFemaleOnly = (form: Pick<StudioCreatureForm, 'femaleRate'>,
   if (resources.icon) resources.iconF ??= resources.icon;
   if (resources.iconShiny) resources.iconShinyF ??= resources.iconShiny;
 
-  const resourcesValidated = CREATURE_RESOURCES_VALIDATOR.safeParse({ ...resources, hasFemale: true });
+  const resourcesValidated = DEFAULT_CREATURE_RESOURCES_VALIDATOR.safeParse({ ...resources, hasFemale: true });
   if (resourcesValidated.success) return resourcesValidated.data;
 
   return { ...DEFAULT_CREATURE_RESOURCE, ...resources, hasFemale: true };
@@ -136,7 +141,7 @@ const linkResources = (creature: StudioCreatureDataBeforeMigration, projectPath:
       characterShinyF: searchCharacterResource(creature.id, form.form, projectPath, true, true),
       cry: searchCry(creature.id, projectPath),
     };
-    (form as StudioCreatureForm).resources = fixResourcesForFemaleOnly(form, resources);
+    (form as StudioCreatureFormWithoutEgg).resources = fixResourcesForFemaleOnly(form, resources);
   });
 };
 

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -15,6 +15,7 @@ import { migrateUndefinedBreedingGroupToUnknown } from './migrateUndefinedBreedi
 import { addTrainerAdditionalDialogs } from './addTrainerAdditionalDialogs';
 import { migrateQuestsEarnings } from './migrateQuestsEarnings';
 import { addCsvForQuestsCustomObjectives } from './addCsvForQuestsCustomObjectives';
+import { addEggInCreatureResources } from './addEggInCreatureResources';
 
 type MigrateConfigType = {
   migration: MigrationTask;
@@ -118,5 +119,10 @@ export const MIGRATION_CONFIG: MigrateConfigType[] = [
     migration: addCsvForQuestsCustomObjectives,
     version: '2.4.2',
     message: 'add_csv_quests_custom_objectives',
+  },
+  {
+    migration: addEggInCreatureResources,
+    version: '2.4.3',
+    message: 'add_egg_in_creature_resources',
   },
 ];

--- a/src/models/entities/creature.ts
+++ b/src/models/entities/creature.ts
@@ -94,6 +94,8 @@ export const CREATURE_RESOURCES_VALIDATOR = z.object({
   characterF: z.string().optional(),
   characterShiny: z.string(),
   characterShinyF: z.string().optional(),
+  egg: z.string(),
+  iconEgg: z.string(),
   cry: z.string(),
   hasFemale: z.boolean(),
 });

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -144,6 +144,8 @@ export const createCreature = (allPokemon: ProjectData['pokemon'], dbSymbol: DbS
           footprint: '',
           character: '',
           characterShiny: '',
+          egg: '',
+          iconEgg: '',
           cry: '',
           hasFemale: false,
         },

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -73,6 +73,8 @@ export type CreatureFormResourcesPath =
   | 'character'
   | 'characterShiny'
   | 'cry'
+  | 'egg'
+  | 'iconEgg'
   | CreatureFormResourcesFemalePath;
 
 export const formResourcesPath = (form: StudioCreatureForm, resource: CreatureFormResourcesPath) => {
@@ -88,9 +90,11 @@ export const formResourcesPath = (form: StudioCreatureForm, resource: CreatureFo
     case 'iconF':
     case 'iconShiny':
     case 'iconShinyF':
+    case 'iconEgg':
       return `graphics/pokedex/pokeicon/${resources[resource] ?? ''}`;
     case 'front':
     case 'frontF':
+    case 'egg':
       return `graphics/pokedex/pokefront/${resources[resource] ?? ''}`;
     case 'frontShiny':
     case 'frontShinyF':

--- a/src/views/components/database/pokemon/resources/BattlersResources.tsx
+++ b/src/views/components/database/pokemon/resources/BattlersResources.tsx
@@ -49,6 +49,15 @@ export const BattlersResources = ({ creature, form, canShowFemale }: BattlersRes
               key={resource}
             />
           ))}
+        <SpriteResource
+          type="creature"
+          title={t('egg')}
+          resourcePath={formResourcesPath(form, 'egg')}
+          extensions={['png', 'gif']}
+          onResourceChoosen={(resourcePath) => onResourceChoosen(resourcePath, 'egg')}
+          onResourceClean={() => onResourceClean('egg')}
+          key="egg"
+        />
       </ResourceWrapper>
     </ResourcesContainer>
   );

--- a/src/views/components/database/pokemon/resources/IconsResources.tsx
+++ b/src/views/components/database/pokemon/resources/IconsResources.tsx
@@ -45,22 +45,17 @@ export const IconsResources = ({ creature, form, canShowFemale }: IconsResources
               key={resource}
             />
           ))}
-        <OtherResource
-          type="icon"
-          title={t('iconEgg')}
-          resourcePath={formResourcesPath(form, 'iconEgg')}
-          extensions={['png', 'gif']}
-          onResourceChoosen={(resourcePath) => onResourceChoosen(resourcePath, 'iconEgg')}
-          onResourceClean={() => onResourceClean('iconEgg')}
-        />
-        <OtherResource
-          type="icon"
-          title={t('footprint')}
-          resourcePath={formResourcesPath(form, 'footprint')}
-          extensions={['png']}
-          onResourceChoosen={(resourcePath) => onResourceChoosen(resourcePath, 'footprint')}
-          onResourceClean={() => onResourceClean('footprint')}
-        />
+        {(['iconEgg', 'footprint'] as CreatureFormResourcesPath[]).map((resource) => (
+          <OtherResource
+            type="icon"
+            title={t(resource)}
+            resourcePath={formResourcesPath(form, resource)}
+            extensions={resource === 'iconEgg' ? ['png', 'gif'] : ['png']}
+            onResourceChoosen={(resourcePath) => onResourceChoosen(resourcePath, resource)}
+            onResourceClean={() => onResourceClean(resource)}
+            key={resource}
+          />
+        ))}
       </ResourceWrapper>
     </ResourcesContainer>
   );

--- a/src/views/components/database/pokemon/resources/IconsResources.tsx
+++ b/src/views/components/database/pokemon/resources/IconsResources.tsx
@@ -47,6 +47,14 @@ export const IconsResources = ({ creature, form, canShowFemale }: IconsResources
           ))}
         <OtherResource
           type="icon"
+          title={t('iconEgg')}
+          resourcePath={formResourcesPath(form, 'iconEgg')}
+          extensions={['png', 'gif']}
+          onResourceChoosen={(resourcePath) => onResourceChoosen(resourcePath, 'iconEgg')}
+          onResourceClean={() => onResourceClean('iconEgg')}
+        />
+        <OtherResource
+          type="icon"
           title={t('footprint')}
           resourcePath={formResourcesPath(form, 'footprint')}
           extensions={['png']}


### PR DESCRIPTION
## Description

This PR allows users to update the resources for creature eggs.
An update is required in PSDK to use the resources.

Closes #69

## Tests to perform

- [x] The migration works correctly (check Bulbasaur for example and Manaphy)
- [x] The user can choose the resources for the eggs ("front" and icon)

## Screenshot

![image](https://github.com/user-attachments/assets/d1aa4ee1-1832-43bc-a77d-1622f511ad4c)

