### PR TITLE
Fix the alternative fonts creation button

### DIFF
--- a/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
@@ -29,7 +29,8 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
   const lineHeightRef = useRef<HTMLInputElement>(null);
 
   const onClickNew = () => {
-    if (!idRef.current || !name || !sizeRef.current || !lineHeightRef.current) return;
+    if (!idRef.current || (!isAlternative && !name) || !sizeRef.current || !lineHeightRef.current) return;
+
     const data = {
       id: parseInt(idRef.current.value),
       size: parseInt(sizeRef.current.value),


### PR DESCRIPTION
## Description

This PR fixes an issue with the creation of the alternative fonts (wrong condition in the `onClickNew` function).

Closes #487

## Tests to perform

- [x] The user can create an alternative font
- [x] The user can create a font


