### PR TITLE
Quest goals can be hidden by default

### DIFF
--- a/assets/i18n/en/database_quests.json
+++ b/assets/i18n/en/database_quests.json
@@ -99,5 +99,6 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "none_option": "None",
   "other_data": "Other data",
-  "import_quest_from": "Import data from"
+  "import_quest_from": "Import data from",
+  "hidden_default": "Hidden by default"
 }

--- a/assets/i18n/fr/database_quests.json
+++ b/assets/i18n/fr/database_quests.json
@@ -99,5 +99,6 @@
   "quest_import_info": "Vous pouvez créer cette nouvelle quête en copiant les données d'une autre quête déjà existante.",
   "none_option": "Aucun",
   "other_data": "Autres données",
-  "import_quest_from": "Importer les données de"
+  "import_quest_from": "Importer les données de",
+  "hidden_default": "Masqué par défaut"
 }

--- a/src/views/components/database/quest/editors/goals/QuestGoalBeatNpc.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalBeatNpc.tsx
@@ -21,7 +21,7 @@ export const QuestGoalBeatNpc = ({ objective, refs, checkIsValid }: QuestGoalPro
           name="text-beat-npc"
           defaultValue={objective.objectiveMethodArgs[1] as string}
           onChange={() => checkIsValid && checkIsValid()}
-          placeholder={t('examPple_beat_npc')}
+          placeholder={t('example_beat_npc')}
         />
       </InputWithTopLabelContainer>
       <InputWithLeftLabelContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalBeatNpc.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalBeatNpc.tsx
@@ -1,12 +1,14 @@
-import { Input, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
+import { Input, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputNumber2 } from './InputNumber';
 import { QuestGoalProps } from './QuestGoalProps';
-import React from 'react';
 
 export const QuestGoalBeatNpc = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
   const { t } = useTranslation('database_quests');
 
+  console.log('hiddenByDefault', refs);
   return (
     <PaddedInputContainer>
       <InputWithTopLabelContainer>
@@ -19,7 +21,7 @@ export const QuestGoalBeatNpc = ({ objective, refs, checkIsValid }: QuestGoalPro
           name="text-beat-npc"
           defaultValue={objective.objectiveMethodArgs[1] as string}
           onChange={() => checkIsValid && checkIsValid()}
-          placeholder={t('example_beat_npc')}
+          placeholder={t('examPple_beat_npc')}
         />
       </InputWithTopLabelContainer>
       <InputWithLeftLabelContainer>
@@ -29,6 +31,19 @@ export const QuestGoalBeatNpc = ({ objective, refs, checkIsValid }: QuestGoalPro
           name="amount-beat-npc"
           defaultValue={objective.objectiveMethodArgs[2] as number}
           onChange={() => checkIsValid && checkIsValid()}
+        />
+      </InputWithLeftLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
         />
       </InputWithLeftLabelContainer>
     </PaddedInputContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalBeatPokemon.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalBeatPokemon.tsx
@@ -1,14 +1,15 @@
-import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
+import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
+import { SelectPokemon2 } from '@components/selects/SelectPokemon';
+import { DbSymbol } from '@modelEntities/dbSymbol';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputNumber2 } from './InputNumber';
 import { QuestGoalProps } from './QuestGoalProps';
-import { SelectPokemon2 } from '@components/selects/SelectPokemon';
-import { DbSymbol } from '@modelEntities/dbSymbol';
-import React from 'react';
 
 export const QuestGoalBeatPokemon = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
   const { t } = useTranslation(['database_pokemon', 'database_quests']);
   const defaultCreature = objective.objectiveMethodArgs[0] === '__undef__' ? undefined : (objective.objectiveMethodArgs[0] as DbSymbol);
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
 
   return (
     <PaddedInputContainer>
@@ -23,6 +24,19 @@ export const QuestGoalBeatPokemon = ({ objective, refs, checkIsValid }: QuestGoa
           ref={refs.valueRef}
           defaultValue={objective.objectiveMethodArgs[1] as number}
           onChange={() => checkIsValid && checkIsValid()}
+        />
+      </InputWithLeftLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
         />
       </InputWithLeftLabelContainer>
     </PaddedInputContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalCatchPokemon.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalCatchPokemon.tsx
@@ -1,10 +1,10 @@
-import { InputContainer, InputWithLeftLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
+import { InputContainer, InputWithLeftLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
+import { StudioQuestObjective } from '@modelEntities/quest';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { InputNumber2 } from './InputNumber';
 import { QuestGoalConditions } from './QuestGoalConditions';
 import { QuestGoalProps } from './QuestGoalProps';
-import { InputNumber2 } from './InputNumber';
-import { useTranslation } from 'react-i18next';
-import { StudioQuestObjective } from '@modelEntities/quest';
-import React from 'react';
 
 type QuestGoalCatchPokemonProps = {
   setObjective: (objective: StudioQuestObjective) => void;
@@ -12,6 +12,8 @@ type QuestGoalCatchPokemonProps = {
 
 export const QuestGoalCatchPokemon = ({ objective, refs, checkIsValid, setObjective }: QuestGoalCatchPokemonProps) => {
   const { t } = useTranslation('database_quests');
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
+
   return (
     <InputContainer>
       <PaddedInputContainer>
@@ -22,6 +24,19 @@ export const QuestGoalCatchPokemon = ({ objective, refs, checkIsValid, setObject
             ref={refs.valueRef}
             defaultValue={objective.objectiveMethodArgs[1] as number}
             onChange={() => checkIsValid && checkIsValid()}
+          />
+        </InputWithLeftLabelContainer>
+        <InputWithLeftLabelContainer>
+          <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+          <Toggle
+            ref={refs.valueRef}
+            name="hidden-by-default"
+            checked={hiddenByDefault}
+            onChange={(event) => {
+              objective.hiddenByDefault = event.target.checked;
+              setHiddenByDefault(event.target.checked);
+              checkIsValid?.();
+            }}
           />
         </InputWithLeftLabelContainer>
       </PaddedInputContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalEgg.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalEgg.tsx
@@ -1,13 +1,14 @@
-import { InputWithLeftLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
+import { InputWithLeftLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
+import { ObjectiveEggIndex, ObjectivesEgg } from '@utils/QuestUtils';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputNumber2 } from './InputNumber';
 import { QuestGoalProps } from './QuestGoalProps';
-import { ObjectiveEggIndex, ObjectivesEgg } from '@utils/QuestUtils';
-import React from 'react';
 
 export const QuestGoalEgg = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
   const { t } = useTranslation('database_quests');
   const eggMethodName = objective.objectiveMethodName as ObjectivesEgg;
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
 
   return (
     <PaddedInputContainer>
@@ -18,6 +19,19 @@ export const QuestGoalEgg = ({ objective, refs, checkIsValid }: QuestGoalProps) 
           ref={refs.valueRef}
           defaultValue={objective.objectiveMethodArgs[ObjectiveEggIndex[eggMethodName]] as number}
           onChange={() => checkIsValid && checkIsValid()}
+        />
+      </InputWithLeftLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
         />
       </InputWithLeftLabelContainer>
     </PaddedInputContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalObtainItem.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalObtainItem.tsx
@@ -1,12 +1,13 @@
-import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
+import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
 import { SelectItem2 } from '@components/selects/SelectItem';
+import { DbSymbol } from '@modelEntities/dbSymbol';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputNumber2 } from './InputNumber';
 import { QuestGoalProps } from './QuestGoalProps';
-import { DbSymbol } from '@modelEntities/dbSymbol';
-import React from 'react';
 
 export const QuestGoalObtainItem = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
   const { t } = useTranslation(['database_items', 'database_quests']);
   const defaultItem = objective.objectiveMethodArgs[0] === '__undef__' ? undefined : (objective.objectiveMethodArgs[0] as DbSymbol);
 
@@ -23,6 +24,19 @@ export const QuestGoalObtainItem = ({ objective, refs, checkIsValid }: QuestGoal
           ref={refs.valueRef}
           defaultValue={objective.objectiveMethodArgs[1] as number}
           onChange={() => checkIsValid && checkIsValid()}
+        />
+      </InputWithLeftLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
         />
       </InputWithLeftLabelContainer>
     </PaddedInputContainer>

--- a/src/views/components/database/quest/editors/goals/QuestGoalSeePokemon.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalSeePokemon.tsx
@@ -1,13 +1,14 @@
-import { InputWithTopLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
-import { useTranslation } from 'react-i18next';
-import { QuestGoalProps } from './QuestGoalProps';
+import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
 import { SelectPokemon2 } from '@components/selects/SelectPokemon';
 import { DbSymbol } from '@modelEntities/dbSymbol';
-import React from 'react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { QuestGoalProps } from './QuestGoalProps';
 
-export const QuestGoalSeePokemon = ({ objective, refs }: QuestGoalProps) => {
+export const QuestGoalSeePokemon = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
   const { t } = useTranslation('database_pokemon');
   const defaultCreature = objective.objectiveMethodArgs[0] === '__undef__' ? undefined : (objective.objectiveMethodArgs[0] as DbSymbol);
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
 
   return (
     <PaddedInputContainer>
@@ -15,6 +16,19 @@ export const QuestGoalSeePokemon = ({ objective, refs }: QuestGoalProps) => {
         <Label htmlFor="select-pokemon">{t('pokemon')}</Label>
         <SelectPokemon2 name="select-pokemon" optionRef={refs.entityRef} defaultValue={defaultCreature} />
       </InputWithTopLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
+        />
+      </InputWithLeftLabelContainer>
     </PaddedInputContainer>
   );
 };

--- a/src/views/components/database/quest/editors/goals/QuestGoalSpeakTo.tsx
+++ b/src/views/components/database/quest/editors/goals/QuestGoalSpeakTo.tsx
@@ -1,9 +1,10 @@
-import { Input, InputWithTopLabelContainer, Label, PaddedInputContainer } from '@components/inputs';
-import React from 'react';
+import { Input, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, PaddedInputContainer, Toggle } from '@components/inputs';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { QuestGoalProps } from './QuestGoalProps';
 
 export const QuestGoalSpeakTo = ({ objective, refs, checkIsValid }: QuestGoalProps) => {
+  const [hiddenByDefault, setHiddenByDefault] = useState(objective.hiddenByDefault);
   const { t } = useTranslation('database_quests');
 
   return (
@@ -21,6 +22,19 @@ export const QuestGoalSpeakTo = ({ objective, refs, checkIsValid }: QuestGoalPro
           placeholder={t('example_speak_to')}
         />
       </InputWithTopLabelContainer>
+      <InputWithLeftLabelContainer>
+        <Label htmlFor="hidden-by-default">{t('hidden_default')}</Label>
+        <Toggle
+          ref={refs.valueRef}
+          name="hidden-by-default"
+          checked={hiddenByDefault}
+          onChange={(event) => {
+            objective.hiddenByDefault = event.target.checked;
+            setHiddenByDefault(event.target.checked);
+            checkIsValid?.();
+          }}
+        />
+      </InputWithLeftLabelContainer>
     </PaddedInputContainer>
   );
 };


### PR DESCRIPTION
Quest goals can be hidden by default
[#467](https://github.com/PokemonWorkshop/PokemonStudio/issues/467)

Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x ] Your code builds clean without any errors or warnings
- [x ] You are following the [Code guidelines](../CodeGuidelines.md)
- [ x] You tested your code to make sure it does what it is supposed to do

## Description
Put the toggle quest can be hidden by default, the data was already exist in the goalType

## Tests to perform

Test for each types of quests
