### PR TITLE
Fix the migration texts that are not displayed correctly

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1519,5 +1519,6 @@
   "none_option": "None",
   "import_data_from": "Import data from",
   "replace_creatures": "Replace Pokémon",
-  "battle_camera_3d": "Use 3D camera in battle"
+  "battle_camera_3d": "Use 3D camera in battle",
+  "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1519,5 +1519,6 @@
   "none_option": "None",
   "import_data_from": "Import data from",
   "replace_creatures": "Replace Pokémon",
-  "battle_camera_3d": "Use 3D camera in battle"
+  "battle_camera_3d": "Use 3D camera in battle",
+  "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1519,5 +1519,6 @@
   "none_option": "None",
   "import_data_from": "Import data from",
   "replace_creatures": "Reemplazar Pokémon",
-  "battle_camera_3d": "Use 3D camera in battle"
+  "battle_camera_3d": "Use 3D camera in battle",
+  "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1519,5 +1519,6 @@
   "none_option": "Aucun",
   "import_data_from": "Importer les données de",
   "replace_creatures": "Remplacer les Pokémon",
-  "battle_camera_3d": "Utiliser la caméra 3D en combat"
+  "battle_camera_3d": "Utiliser la caméra 3D en combat",
+  "add_battle_camera_3D_to_settings": "Ajout de la caméra 3D en combat dans les paramètres"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1519,5 +1519,6 @@
   "none_option": "None",
   "import_data_from": "Import data from",
   "replace_creatures": "Replace Pokémon",
-  "battle_camera_3d": "Use 3D camera in battle"
+  "battle_camera_3d": "Use 3D camera in battle",
+  "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1519,5 +1519,6 @@
   "none_option": "None",
   "import_data_from": "Import data from",
   "replace_creatures": "Replace Pokémon",
-  "battle_camera_3d": "Use 3D camera in battle"
+  "battle_camera_3d": "Use 3D camera in battle",
+  "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings"
 }

--- a/src/backendTasks/migrateData.ts
+++ b/src/backendTasks/migrateData.ts
@@ -23,7 +23,7 @@ const migrateData = async (payload: MigrateDataInput, event: IpcMainEvent, chann
     log.info('migrate-data', `Found ${migrationFound.length} migrations`);
     await migrationFound.reduce(async (prev, curr, index) => {
       await prev;
-      const message = i18n.t(curr.message, { ns: 'migration' });
+      const message = i18n.t(curr.message);
       log.info('migrate-data/progress', message);
       sendProgress(event, channels, { step: index + 1, total: migrationFound.length, stepText: message });
       await curr.migration(event, payload.projectPath, payload.studioSettings);

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -37,7 +37,7 @@ type MigrateConfigType = {
  * migration: The method that must be called to do the migration.
  * version: The version of the project where the migration is to take place. The migration will also run if the project has a lower version.
  * message: A message will be displayed for the user to understand what is happening.
- *          You need to enter the translation key used by i18n. The translations must be in the migration.json files.
+ *          You need to enter the translation key used by i18n.
  */
 
 export const MIGRATION_CONFIG: MigrateConfigType[] = [


### PR DESCRIPTION
## Description

Due to the major changes made to i18n management, the migration texts were not displayed. This PR fixes the issue. 
The translation key for adding the 3D camera setting in battle has also been added.

## Tests to perform

- [x] The migrations texts show correctly
- [x] The text for the migration of the 3d camera shows correctly
