### PR TITLE
The user would like to select a font into the font part of the text settings UI

### DIFF
--- a/src/backendTasks/getFilePathsFromFolder.ts
+++ b/src/backendTasks/getFilePathsFromFolder.ts
@@ -1,9 +1,9 @@
-import fs from 'fs';
 import log from 'electron-log';
-import { defineBackendServiceFunction } from './defineBackendServiceFunction';
+import fs from 'fs';
 import path from 'path';
+import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 
-export type GetFilePathsFromFolderInput = { folderPath: string; extensions?: string[]; isRecursive?: boolean };
+export type GetFilePathsFromFolderInput = { folderPath: string; extensions?: string[]; isRecursive?: boolean; isFileNameOnly?: boolean };
 export type GetFilePathsFromFolderOutput = { filePaths: string[] };
 
 const promiseReadFolder = async (folderPath: string): Promise<string[]> => {
@@ -59,7 +59,9 @@ const getFilePathsFromFolder = async (payload: GetFilePathsFromFolderInput): Pro
   const filesWithoutFolder = files.filter((files) => files !== '__FOLDER__');
   if (payload.extensions !== undefined) {
     const filesFiltered = filesWithoutFolder.filter((file) => payload.extensions?.includes(path.extname(file).toLowerCase()));
-    log.info('get-file-paths-from-folder/success');
+    if (payload.isFileNameOnly) {
+      return { filePaths: filesFiltered.map((file) => path.basename(file)) };
+    }
     return { filePaths: filesFiltered };
   }
 

--- a/src/views/components/dashboard/texts/editors/DashboardFontsEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsEditor.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Editor, useRefreshUI } from '@components/editor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { Select } from '@ds/Select';
 import { StudioTextConfig, StudioTextTtfFileConfig } from '@modelEntities/config';
+import { useGlobalState } from '@src/GlobalStateProvider';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type DashbordFontsEditorProps = {
   texts: StudioTextConfig;
@@ -14,6 +16,31 @@ export const DashboardFontsEditor = ({ texts, index, isAlternative }: DashbordFo
   const ttfFileOrAltSize = isAlternative ? texts.fonts.altSizes[index] : texts.fonts.ttfFiles[index];
   const { t } = useTranslation();
   const refreshUI = useRefreshUI();
+  const [fontOptions, setFontOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [state] = useGlobalState();
+
+  useEffect(() => {
+    if (isAlternative) return;
+
+    window.api.getFilePathsFromFolder(
+      {
+        folderPath: `${state.projectPath}/Fonts/`,
+        extensions: ['.ttf'],
+        isRecursive: false,
+        isFileNameOnly: true,
+      },
+      (filePaths) => {
+        const options = filePaths.filePaths.map((font) => ({
+          value: font.replace('.ttf', ''),
+          label: font,
+        }));
+        setFontOptions(options);
+      },
+      (error) => {
+        console.error('Error fetching fonts:', error);
+      }
+    );
+  }, [state.projectPath, isAlternative]);
 
   return (
     <Editor type="edit" title={isAlternative ? t('alt_sizes') : t('fonts')}>
@@ -33,10 +60,10 @@ export const DashboardFontsEditor = ({ texts, index, isAlternative }: DashbordFo
             <Label htmlFor="name" required>
               {t('font_name')}
             </Label>
-            <Input
-              type="text"
+            <Select
+              options={fontOptions}
               value={(ttfFileOrAltSize as StudioTextTtfFileConfig).name}
-              onChange={(event) => refreshUI(((ttfFileOrAltSize as StudioTextTtfFileConfig).name = event.target.value))}
+              onChange={(event) => refreshUI(((ttfFileOrAltSize as StudioTextTtfFileConfig).name = event))}
               placeholder="PokemonDS"
             />
           </InputWithTopLabelContainer>

--- a/src/views/components/dashboard/texts/editors/DashboardFontsEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsEditor.tsx
@@ -1,6 +1,7 @@
 import { Editor, useRefreshUI } from '@components/editor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { Select } from '@ds/Select';
+import { SelectOption } from '@ds/Select/types';
 import { StudioTextConfig, StudioTextTtfFileConfig } from '@modelEntities/config';
 import { useGlobalState } from '@src/GlobalStateProvider';
 import React, { useEffect, useState } from 'react';
@@ -16,7 +17,7 @@ export const DashboardFontsEditor = ({ texts, index, isAlternative }: DashbordFo
   const ttfFileOrAltSize = isAlternative ? texts.fonts.altSizes[index] : texts.fonts.ttfFiles[index];
   const { t } = useTranslation();
   const refreshUI = useRefreshUI();
-  const [fontOptions, setFontOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [fontOptions, setFontOptions] = useState<SelectOption<string>[]>([]);
   const [state] = useGlobalState();
 
   useEffect(() => {

--- a/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
@@ -25,7 +25,7 @@ const ButtonContainer = styled.div`
 export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFontsNewEditorProps) => {
   const { projectConfigValues: texts, setProjectConfigValues: setTexts } = useConfigTexts();
   const { t } = useTranslation();
-  const [name, setName] = useState(''); // We can't use a ref because of the button behavior
+  const [name, setName] = useState('');
   const idRef = useRef<HTMLInputElement>(null);
   const sizeRef = useRef<HTMLInputElement>(null);
   const lineHeightRef = useRef<HTMLInputElement>(null);
@@ -48,9 +48,10 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
           label: font,
         }));
         setFontOptions(options);
+        setName(options[0].value);
       },
-      (error) => {
-        console.error('Error fetching fonts:', error);
+      () => {
+        setFontOptions([]);
       }
     );
   }, [state.projectPath, isAlternative]);
@@ -105,7 +106,13 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
             <Label htmlFor="name" required>
               {t('font_name')}
             </Label>
-            <Select options={fontOptions} value={name} onChange={(event) => setName(event)} placeholder="PokemonDS" />
+            <Select
+              defaultValue={fontOptions[0]?.value}
+              options={fontOptions}
+              value={name}
+              onChange={(event) => setName(event)}
+              placeholder={fontOptions.length > 0 ? fontOptions[0]?.label : t('none')}
+            />
           </InputWithTopLabelContainer>
         )}
         <InputWithLeftLabelContainer>

--- a/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
@@ -1,12 +1,14 @@
-import React, { useRef, useState } from 'react';
+import { DarkButton, PrimaryButton } from '@components/buttons';
+import { Editor } from '@components/editor';
+import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { Select } from '@ds/Select';
+import { TooltipWrapper } from '@ds/Tooltip';
+import { useConfigTexts } from '@hooks/useProjectConfig';
+import { useGlobalState } from '@src/GlobalStateProvider';
+import { cloneEntity } from '@utils/cloneEntity';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import { Editor } from '@components/editor';
-import { DarkButton, PrimaryButton } from '@components/buttons';
-import { useConfigTexts } from '@hooks/useProjectConfig';
-import { cloneEntity } from '@utils/cloneEntity';
-import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
-import { TooltipWrapper } from '@ds/Tooltip';
 
 type DashbordFontsNewEditorProps = {
   isAlternative: boolean;
@@ -27,6 +29,31 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
   const idRef = useRef<HTMLInputElement>(null);
   const sizeRef = useRef<HTMLInputElement>(null);
   const lineHeightRef = useRef<HTMLInputElement>(null);
+  const [fontOptions, setFontOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [state] = useGlobalState();
+
+  useEffect(() => {
+    if (isAlternative) return;
+
+    window.api.getFilePathsFromFolder(
+      {
+        folderPath: `${state.projectPath}/Fonts/`,
+        extensions: ['.ttf'],
+        isRecursive: false,
+        isFileNameOnly: true,
+      },
+      (filePaths) => {
+        const options = filePaths.filePaths.map((font) => ({
+          value: font.replace('.ttf', ''),
+          label: font,
+        }));
+        setFontOptions(options);
+      },
+      (error) => {
+        console.error('Error fetching fonts:', error);
+      }
+    );
+  }, [state.projectPath, isAlternative]);
 
   const onClickNew = () => {
     if (!idRef.current || (!isAlternative && !name) || !sizeRef.current || !lineHeightRef.current) return;
@@ -78,7 +105,7 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
             <Label htmlFor="name" required>
               {t('font_name')}
             </Label>
-            <Input type="text" value={name} onChange={(event) => setName(event.target.value)} placeholder="PokemonDS" />
+            <Select options={fontOptions} value={name} onChange={(event) => setName(event)} placeholder="PokemonDS" />
           </InputWithTopLabelContainer>
         )}
         <InputWithLeftLabelContainer>

--- a/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
+++ b/src/views/components/dashboard/texts/editors/DashboardFontsNewEditor.tsx
@@ -2,6 +2,7 @@ import { DarkButton, PrimaryButton } from '@components/buttons';
 import { Editor } from '@components/editor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { Select } from '@ds/Select';
+import { SelectOption } from '@ds/Select/types';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { useConfigTexts } from '@hooks/useProjectConfig';
 import { useGlobalState } from '@src/GlobalStateProvider';
@@ -29,7 +30,7 @@ export const DashboardFontsNewEditor = ({ isAlternative, onClose }: DashbordFont
   const idRef = useRef<HTMLInputElement>(null);
   const sizeRef = useRef<HTMLInputElement>(null);
   const lineHeightRef = useRef<HTMLInputElement>(null);
-  const [fontOptions, setFontOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [fontOptions, setFontOptions] = useState<SelectOption<string>[]>([]);
   const [state] = useGlobalState();
 
   useEffect(() => {


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Modification du utils qui permet de lister les chemins d’un dossier : j’ai rajouté une option qui permet d’obtenir seulement les noms de fichiers et non le chemin complet.

J’ai donc adapté ensuite en modifiant l’input existant par un select DS, dans le nouvel éditeur et l’éditeur classique.

Seule interrogation : est-ce que je dois réellement mettre une notification si on ne trouve pas la police quand je fais appel à getFilePathsFromFolder ?

## Note before testing

<!-- Optional but can be useful if the tester has to update a lib for example. -->

## Tests to perform

Modifier une police
Ajouter une police
Tester de confirmer le formulaire si aucun option n'a été sélectionné
