### PR TITLE
Improve the way to make breeding impossible for a creature

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Use 3D camera in battle",
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
-  "tech_list": "List of technique items"
+  "tech_list": "List of technique items",
+  "dashboard_save": "Speichern"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Use 3D camera in battle",
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
-  "tech_list": "List of technique items"
+  "tech_list": "List of technique items",
+  "dashboard_save": "Save"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Use 3D camera in battle",
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
-  "tech_list": "List of technique items"
+  "tech_list": "List of technique items",
+  "dashboard_save": "Guardar"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -852,7 +852,7 @@
   "ditto": "Métamorph",
   "dragon": "Draconique",
   "unknown": "Inconnu",
-  "creature_deleted": "Pokémon deleted",
+  "creature_deleted": "Pokémon supprimé",
   "form_deleted": "Forme supprimée",
   "encounter": "Rencontre",
   "items_held": "Objets portés",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Utiliser la caméra 3D en combat",
   "add_battle_camera_3D_to_settings": "Ajout de la caméra 3D en combat dans les paramètres",
   "handle_tech_list": "Gérer la liste des techniques",
-  "tech_list": "Liste des techniques"
+  "tech_list": "Liste des techniques",
+  "dashboard_save": "Sauvegarde"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Use 3D camera in battle",
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
-  "tech_list": "List of technique items"
+  "tech_list": "List of technique items",
+  "dashboard_save": "Salvataggio"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1523,5 +1523,6 @@
   "battle_camera_3d": "Use 3D camera in battle",
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
-  "tech_list": "List of technique items"
+  "tech_list": "List of technique items",
+  "dashboard_save": "Save"
 }

--- a/src/views/components/dashboard/DashboardNavigation.tsx
+++ b/src/views/components/dashboard/DashboardNavigation.tsx
@@ -20,7 +20,7 @@ export const DashboardNavigation = () => {
         <NavigationDatabaseItem path="/dashboard/graphics" label={t('graphic_settings')} />
       </NavigationDatabaseGroup>
       <NavigationDatabaseGroup title={t('config')}>
-        <NavigationDatabaseItem path="/dashboard/save" label={t('save')} />
+        <NavigationDatabaseItem path="/dashboard/save" label={t('dashboard_save')} />
         <NavigationDatabaseItem path="/dashboard/gamestart" label={t('game_start')} />
         <NavigationDatabaseItem path="/dashboard/gameOptions" label={t('options')} />
         <NavigationDatabaseItem path="/dashboard/credits" label={t('credits')} />

--- a/src/views/components/dashboard/DashboardSave.tsx
+++ b/src/views/components/dashboard/DashboardSave.tsx
@@ -83,7 +83,7 @@ export const DashboardSave = () => {
   };
 
   return (
-    <PageEditor title={t('settings')} editorTitle={t('save')}>
+    <PageEditor title={t('settings')} editorTitle={t('dashboard_save')}>
       <InputWithTopLabelContainer>
         <Label htmlFor="base_filename">{t('save_filename')}</Label>
         <Input

--- a/src/views/components/database/pokemon/editors/BreedingEditor.tsx
+++ b/src/views/components/database/pokemon/editors/BreedingEditor.tsx
@@ -7,12 +7,12 @@ import { TFunction } from 'i18next';
 import React, { forwardRef, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUpdateForm } from './useUpdateForm';
-import { SelectPokemon2 } from '@components/selects/SelectPokemon';
 import { SelectCreatureForm } from '@components/selects/SelectPokemonForm';
 import { CREATURE_FORM_VALIDATOR } from '@modelEntities/creature';
 import { useZodForm } from '@hooks/useZodForm';
 import { InputFormContainer } from '@components/inputs/InputContainer';
 import { useInputAttrsWithLabel } from '@hooks/useInputAttrs';
+import { useSelectOptions } from '@src/hooks/useSelectOptions';
 
 const breedingGroupEntries = [
   'monster',
@@ -50,6 +50,8 @@ export const BreedingEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const updateForm = useUpdateForm(creature, form);
   const { canClose, getFormData, onInputTouched, defaults, formRef } = useZodForm(BREEDING_EDITOR_SCHEMA, form);
   const { Input, Select } = useInputAttrsWithLabel(BREEDING_EDITOR_SCHEMA, defaults);
+  const defaultCreatureOptions = useSelectOptions('creatures');
+  const creatureOptions = useMemo(() => [{ value: '__undef__', label: t('none') }, ...defaultCreatureOptions], [defaultCreatureOptions, t]);
   const breedingGroupOptions = useMemo(() => getBreedingGroupOptions(t), [t]);
   const [baby, setBaby] = useState(form.babyDbSymbol);
 
@@ -64,9 +66,15 @@ export const BreedingEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       <InputFormContainer ref={formRef}>
         <InputWithTopLabelContainer>
           <Label htmlFor="baby">{t('baby')}</Label>
-          <SelectPokemon2 name="babyDbSymbol" defaultValue={defaults.babyDbSymbol as DbSymbol} onChange={setBaby} />
+          <Select
+            name="babyDbSymbol"
+            defaultValue={defaults.babyDbSymbol as DbSymbol}
+            options={creatureOptions}
+            onChange={(dbSymbol) => setBaby(dbSymbol as DbSymbol)}
+            notFoundLabel={t('creature_deleted')}
+          />
         </InputWithTopLabelContainer>
-        <InputWithTopLabelContainer>
+        <InputWithTopLabelContainer style={baby === '__undef__' ? { display: 'none' } : undefined}>
           <Label htmlFor="form">{t('form')}</Label>
           <SelectCreatureForm dbSymbol={baby} name="babyForm" defaultValue={defaults.babyForm} />
         </InputWithTopLabelContainer>

--- a/src/views/components/database/pokemon/pokemonDataBlock/ReproductionDataBlock.tsx
+++ b/src/views/components/database/pokemon/pokemonDataBlock/ReproductionDataBlock.tsx
@@ -42,16 +42,17 @@ export const ReproductionDataBlock = ({ pokemonWithForm, dialogsRef }: PokemonDa
           label={t('baby')}
           data={
             form.babyDbSymbol === '__undef__'
-              ? '-'
+              ? t('none')
               : pokemons[form.babyDbSymbol]
               ? getCreatureName(pokemons[form.babyDbSymbol])
               : t('creature_deleted')
           }
-          error={!pokemons[form.babyDbSymbol]}
+          error={!pokemons[form.babyDbSymbol] && form.babyDbSymbol !== '__undef__'}
           clickable={{
             isClickable,
             callback: () => shortcutNavigation(form.babyDbSymbol, form.babyForm),
           }}
+          disabled={form.babyDbSymbol === '__undef__'}
         />
         <DataFieldsetField
           label={t('egg_groups')}

--- a/src/views/pages/dashboard/Dashboard.Save.page.tsx
+++ b/src/views/pages/dashboard/Dashboard.Save.page.tsx
@@ -5,7 +5,7 @@ import { DashboardTemplate, DashboardSave } from '@components/dashboard';
 export const DashboardSavePage = () => {
   const { t } = useTranslation();
   return (
-    <DashboardTemplate title={t('save')}>
+    <DashboardTemplate title={t('dashboard_save')}>
       <DashboardSave />
     </DashboardTemplate>
   );


### PR DESCRIPTION
## Description

This PR adds an option to choose None in the select of baby for the breeding. 
On the Pokémon page, if the user selects None, the display will show "None" instead of "-" (the colors have also been adjusted).

Texts have also been fixed in the DashboardSave.

Closes #515 

## Tests to perform

- [x] The user can choose None in the select of baby
- [x] The information is displayed correctly on the Pokémon page
- [x] The texts in the DashboardSave are correct

## Screenshot

Text issue:
![image](https://github.com/user-attachments/assets/86c5122d-cc20-428f-ab4c-a5586903c5b1)

![image](https://github.com/user-attachments/assets/58d9bf0d-5cf8-461f-aca4-054031cbcf08)
