### PR TITLE
Remove is distance move tag

### DIFF
--- a/src/models/entities/move.ts
+++ b/src/models/entities/move.ts
@@ -90,7 +90,6 @@ export const MOVE_VALIDATOR = z.object({
   isCharge: z.boolean(),
   isDance: z.boolean(),
   isDirect: z.boolean(),
-  isDistance: z.boolean(),
   isEffectChance: z.boolean().default(false),
   isGravity: z.boolean(),
   isHeal: z.boolean(),

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -248,7 +248,6 @@ export const createMove = (allMoves: ProjectData['moves'], dbSymbol: DbSymbol, t
     isCharge: false,
     isDance: false,
     isDirect: false,
-    isDistance: false,
     isEffectChance: false,
     isGravity: false,
     isHeal: false,

--- a/src/views/components/database/move/MoveCharacteristics.tsx
+++ b/src/views/components/database/move/MoveCharacteristics.tsx
@@ -20,7 +20,6 @@ const NoCharacteristicContainer = styled.span`
 const atLeastOneCharacteristic = (move: StudioMove) => {
   return (
     move.isDirect ||
-    move.isDistance ||
     move.isBlocable ||
     move.isAuthentic ||
     move.isKingRockUtility ||
@@ -59,7 +58,6 @@ export const MoveCharacteristics = ({ move, dialogsRef }: MoveCharacteristicsPro
       {atLeastOneCharacteristic(move) ? (
         <MoveCharacteristicsContainer>
           {move.isDirect && <Tag>{t('contact')}</Tag>}
-          {move.isDistance && <Tag>{t('distance')}</Tag>}
           {move.isBlocable && <Tag>{t('blocable')}</Tag>}
           {move.isAuthentic && <Tag>{t('authentic')}</Tag>}
           {move.isKingRockUtility && <Tag>{t('king_rock')}</Tag>}

--- a/src/views/components/database/move/editors/MoveCharacteristicsEditor.tsx
+++ b/src/views/components/database/move/editors/MoveCharacteristicsEditor.tsx
@@ -24,7 +24,6 @@ const CHARACTERISTICS_EDITOR_SCHEMA = MOVE_VALIDATOR.pick({
   isCharge: true,
   isDance: true,
   isDirect: true,
-  isDistance: true,
   isEffectChance: true,
   isGravity: true,
   isHeal: true,
@@ -63,7 +62,6 @@ export const MoveCharacteristicsEditor = forwardRef<EditorHandlingClose>((_, ref
       <InputFormContainer ref={formRef} size="s">
         <CharactericticsInfoContainer>{t('characteristics_info')}</CharactericticsInfoContainer>
         <Toggle name="isDirect" label={t('description_contact')} />
-        <Toggle name="isDistance" label={t('description_distance')} />
         <Toggle name="isBlocable" label={t('description_blocable')} />
         <Toggle name="isAuthentic" label={t('description_authentic')} />
         <Toggle name="isKingRockUtility" label={t('description_king_rock')} />


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

This PR deletes from Studio the isDistance tag that has been removed in PSDK recently. As the tag was very specifically used by moves only, it was just about deleting lines here and there.
Note: this PR doesn't come with a migration to remove this flag from the move data, as Studio can properly load a project that still contains this flag. Studio will delete the flag itself when saving any move that was changed in Studio. Whether a migration should be implemented or not to delete the flag once and for all for all moves is up to discussions.

Closes #501 

## Tests to perform

- [x] Open any 2.5.0 project with this PR: the project should correctly be loaded without any issue
- [x] Open the Move UI and search a move that still has the isDistance tag in its data: it should have no visual reference to this flag and the edition modal should not have the isDistance toggle
- [x] Search a move that does not have the isDistance tag in its data: it should not have any visual reference to this flag and the edition modal should not have the isDistance toggle
- [x] Edit any move, save, then check this move's data in the json: the flag must have been deleted