### PR TITLE
Fix: Prevent duplicate creature in the national dex when the user creates a new creature

### DIFF
--- a/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonNewEditor.tsx
@@ -110,8 +110,10 @@ export const PokemonNewEditor = forwardRef<EditorHandlingClose, Props>(({ closeD
 
     setCreature({ [dbSymbol]: newCreature }, { pokemon: { specie: dbSymbol, form: 0 } });
     const editedDex = cloneEntity(dex.national);
-    editedDex.creatures.push({ dbSymbol, form: 0 });
-    setDex({ [editedDex.dbSymbol]: editedDex });
+    if (!editedDex.creatures.find(({ dbSymbol }) => dbSymbol === newCreature.dbSymbol)) {
+      editedDex.creatures.push({ dbSymbol, form: 0 });
+      setDex({ [editedDex.dbSymbol]: editedDex });
+    }
     setEvolutionIndex(0);
     closeDialog();
   };


### PR DESCRIPTION
## Description

This PR fixes an issue with the national dex and the creature creation.

When a creature is created, it automaticaly added in the creature list of the national dex. But if the creature is deleted and created again, the creature is added again in the creature list of the dex, so it's duplicate. (delete a creature don't remove the creature of the dex list, it's a normal behaviour)

## How reproduce

1. Create a creature name Test with dbSymbol test
2. Remove the creature test
3. Create a creature name Test with dbSymbol test

The creatures list contains 2 Test. The Test creature appears twice in the national dex.

## Tests to perform

- [x] When a creature is created, the creature list in the national dex must not contain any duplicates under any circumstances

## Screenshot

![image](https://github.com/user-attachments/assets/8fc11d14-0d2e-497f-bfe2-ffff1f3243f2)

