### PR TITLE
Feature: Make the 3v3 battle mode accessible for trainer or group battles

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -476,6 +476,7 @@
   "activation_custom": "Benutzerdefiniert",
   "simple": "Einfach",
   "double": "Doppel",
+  "triple": "Dreifach",
   "RegularGround": "Normaler Boden",
   "Grass": "Hohes Gras",
   "TallGrass": "Sehr hohes Gras",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
-  "dashboard_save": "Speichern"
+  "dashboard_save": "Speichern",
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
 }

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Kampfart",
   "vs_type1": "Einzel",
   "vs_type2": "Doppel",
+  "vs_type3": "Dreifach",
   "battle_id": "Szenarisierter Kampf",
   "battle_id_tooltip": "Diese Daten beziehen sich auf die Kennung eines szenarisierten Kampfes",
   "trainer_party": "Team",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -476,6 +476,7 @@
   "activation_custom": "Custom",
   "simple": "Simple",
   "double": "Double",
+  "triple": "Triple",
   "RegularGround": "Regular ground",
   "Grass": "Tall grass",
   "TallGrass": "Very tall grass",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
-  "dashboard_save": "Save"
+  "dashboard_save": "Save",
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Battle type",
   "vs_type1": "Simple",
   "vs_type2": "Double",
+  "vs_type3": "Triple",
   "battle_id": "Scenarized battle",
   "battle_id_tooltip": "This data refers to the identifier of a scenarized battle",
   "trainer_party": "Party",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -476,6 +476,7 @@
   "activation_custom": "Personalizado",
   "simple": "Simple",
   "double": "Doble",
+  "triple": "Triple",
   "RegularGround": "Terreno normal",
   "Grass": "Hierba alta",
   "TallGrass": "Hierba muy alta",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
-  "dashboard_save": "Guardar"
+  "dashboard_save": "Guardar",
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Tipo de combate",
   "vs_type1": "Individual",
   "vs_type2": "Doble",
+  "vs_type3": "Triple",
   "battle_id": "Combate escenificado",
   "battle_id_tooltip": "Estos datos hacen referencia al identificador de un combate escenificado.",
   "trainer_party": "Equipo",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -476,6 +476,7 @@
   "activation_custom": "Personnalisée",
   "simple": "Simple",
   "double": "Double",
+  "triple": "Triple",
   "RegularGround": "Chemin classique",
   "Grass": "Hautes herbes",
   "TallGrass": "Très hautes herbes",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Ajout de la caméra 3D en combat dans les paramètres",
   "handle_tech_list": "Gérer la liste des techniques",
   "tech_list": "Liste des techniques",
-  "dashboard_save": "Sauvegarde"
+  "dashboard_save": "Sauvegarde",
+  "migrate_groups_for_3v3_battle_mode": "Migration des groupes pour le support du mode de combat 3v3"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Type de combat",
   "vs_type1": "Simple",
   "vs_type2": "Double",
+  "vs_type3": "Triple",
   "battle_id": "Combat scénarisé",
   "battle_id_tooltip": "Cette donnée fait référence à l'identifiant d'un combat scripté",
   "trainer_party": "Équipe",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -476,6 +476,7 @@
   "activation_custom": "Personalizzato",
   "simple": "In singolo",
   "double": "In doppio",
+  "triple": "In triplo",
   "RegularGround": "Terreno regolare",
   "Grass": "Erba alta",
   "TallGrass": "Erba molto alta",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
-  "dashboard_save": "Salvataggio"
+  "dashboard_save": "Salvataggio",
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Tipo di battaglia",
   "vs_type1": "In singolo",
   "vs_type2": "In doppio",
+  "vs_type3": "In triplo",
   "battle_id": "Battaglia inscenata",
   "battle_id_tooltip": "Questo dato si riferisce all'identificatore di una battaglia inscenata",
   "trainer_party": "Squadra",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1058,6 +1058,7 @@
   "vs_type": "Tipo de combate",
   "vs_type1": "Simple",
   "vs_type2": "Dobro",
+  "vs_type3": "Triplo",
   "battle_id": "Combate cenarizado",
   "battle_id_tooltip": "Este dado refere-se ao identificador de um combate cenarizado",
   "trainer_party": "Equipa",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -476,6 +476,7 @@
   "activation_custom": "Personalizado",
   "simple": "Simples",
   "double": "Duplo",
+  "triple": "Triplo",
   "RegularGround": "Caminho clássico",
   "Grass": "Relva alta",
   "TallGrass": "Relva muita alta",
@@ -1528,5 +1529,6 @@
   "add_battle_camera_3D_to_settings": "Add 3D camera in battle in the settings",
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
-  "dashboard_save": "Save"
+  "dashboard_save": "Save",
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-studio",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-studio",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@electron-forge/publisher-github": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/migrations/migrateGroupsFor3v3BattleMode.ts
+++ b/src/migrations/migrateGroupsFor3v3BattleMode.ts
@@ -4,23 +4,33 @@ import { readProjectFolder } from '@src/backendTasks/readProjectData';
 import fsPromise from 'fs/promises';
 import { z } from 'zod';
 import { deletePSDKDatFile } from './migrateUtils';
-import { GROUP_VALIDATOR, StudioGroup } from '@modelEntities/group';
+import { GROUP_VALIDATOR, StudioGroup, StudioGroupVsType } from '@modelEntities/group';
 import { parseJSON } from '@utils/json/parse';
 
-const PRE_MIGRATION_GROUP_VALIDATOR = GROUP_VALIDATOR.omit({ stepsAverage: true }).extend({
+const PRE_MIGRATION_GROUP_VALIDATOR = GROUP_VALIDATOR.omit({ vsType: true }).extend({
   isDoubleBattle: z.boolean().default(false),
   isHordeBattle: z.boolean().default(false),
 });
 type StudioGroupDataBeforeMigration = z.infer<typeof PRE_MIGRATION_GROUP_VALIDATOR>;
 
-const addStepsAverage = (group: StudioGroupDataBeforeMigration): StudioGroup => {
+const determineVsType = (group: StudioGroupDataBeforeMigration): StudioGroupVsType => {
+  if (group.isDoubleBattle) return 'double';
+  if (group.isHordeBattle) return 'horde';
+
+  return 'simple';
+};
+
+const addVsType = (group: StudioGroupDataBeforeMigration): StudioGroup => {
+  const vsType = determineVsType(group);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { isDoubleBattle, isHordeBattle, ...newGroup } = group;
   return {
-    ...group,
-    stepsAverage: 0,
+    ...newGroup,
+    vsType,
   };
 };
 
-export const addStepsAverageToGroup = async (_: IpcMainEvent, projectPath: string) => {
+export const migrateGroupsFor3v3BattleMode = async (_: IpcMainEvent, projectPath: string) => {
   deletePSDKDatFile(projectPath);
 
   const groups = await readProjectFolder(projectPath, 'groups');
@@ -28,7 +38,7 @@ export const addStepsAverageToGroup = async (_: IpcMainEvent, projectPath: strin
     await lastPromise;
     const groupParsed = PRE_MIGRATION_GROUP_VALIDATOR.safeParse(parseJSON<StudioGroup>(group.data, group.filename));
     if (groupParsed.success) {
-      const newGroup = addStepsAverage(groupParsed.data);
+      const newGroup = addVsType(groupParsed.data);
       return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/groups', `${newGroup.dbSymbol}.json`), JSON.stringify(newGroup, null, 2));
     }
   }, Promise.resolve());

--- a/src/migrations/migrateHeadbutt.ts
+++ b/src/migrations/migrateHeadbutt.ts
@@ -9,6 +9,8 @@ import { parseJSON } from '@utils/json/parse';
 
 const PRE_MIGRATION_GROUP_VALIDATOR = GROUP_VALIDATOR.extend({
   tool: GROUP_TOOL_VALIDATOR.or(z.literal('HeadButt')),
+  isDoubleBattle: z.boolean().default(false),
+  isHordeBattle: z.boolean().default(false),
 });
 type StudioGroupDataBeforeMigration = z.infer<typeof PRE_MIGRATION_GROUP_VALIDATOR>;
 

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -17,6 +17,7 @@ import { migrateQuestsEarnings } from './migrateQuestsEarnings';
 import { addCsvForQuestsCustomObjectives } from './addCsvForQuestsCustomObjectives';
 import { addEggInCreatureResources } from './addEggInCreatureResources';
 import { addBattleCamera3dToSettings } from './addBattleCamera3dToSettings';
+import { migrateGroupsFor3v3BattleMode } from './migrateGroupsFor3v3BattleMode';
 
 type MigrateConfigType = {
   migration: MigrationTask;
@@ -130,5 +131,10 @@ export const MIGRATION_CONFIG: MigrateConfigType[] = [
     migration: addBattleCamera3dToSettings,
     version: '2.4.3',
     message: 'add_battle_camera_3D_to_settings',
+  },
+  {
+    migration: migrateGroupsFor3v3BattleMode,
+    version: '2.5.0',
+    message: 'migrate_groups_for_3v3_battle_mode',
   },
 ];

--- a/src/models/entities/group.ts
+++ b/src/models/entities/group.ts
@@ -55,6 +55,9 @@ export type StudioGroupDefaultSystemTag = (typeof GROUP_SYSTEM_TAGS)[number];
 export const GROUP_TOOL_VALIDATOR = z.union([z.null(), z.literal('OldRod'), z.literal('GoodRod'), z.literal('SuperRod'), z.literal('RockSmash')]);
 export type StudioGroupTool = z.infer<typeof GROUP_TOOL_VALIDATOR>;
 
+export const GROUP_VS_TYPE = z.union([z.literal('simple'), z.literal('double'), z.literal('triple'), z.literal('horde')]);
+export type StudioGroupVsType = z.infer<typeof GROUP_VS_TYPE>;
+
 export const GROUP_VALIDATOR = z.object({
   klass: z.literal('Group'),
   id: POSITIVE_OR_ZERO_INT,
@@ -62,8 +65,7 @@ export const GROUP_VALIDATOR = z.object({
   systemTag: GROUP_SYSTEM_TAG_VALIDATOR,
   terrainTag: POSITIVE_OR_ZERO_INT,
   tool: GROUP_TOOL_VALIDATOR.default(null),
-  isDoubleBattle: z.boolean().default(false),
-  isHordeBattle: z.boolean().default(false),
+  vsType: GROUP_VS_TYPE,
   customConditions: z.array(CUSTOM_GROUP_CONDITION_VALIDATOR),
   encounters: z.array(ENCOUNTER_VALIDATOR),
   stepsAverage: POSITIVE_OR_ZERO_INT,
@@ -71,3 +73,4 @@ export const GROUP_VALIDATOR = z.object({
 export type StudioGroup = z.infer<typeof GROUP_VALIDATOR>;
 
 export const GROUP_NAME_TEXT_ID = 100061;
+export const GROUP_VS_TYPE_CATEGORIES = ['simple', 'double', 'triple'] as const;

--- a/src/models/entities/trainer.ts
+++ b/src/models/entities/trainer.ts
@@ -74,7 +74,7 @@ export const TRAINER_AI_CATEGORIES = [
   { value: '7', label: 'champion' },
 ];
 export type StudioTrainerAICategoryType = (typeof TRAINER_AI_CATEGORIES)[number]['value'] | 'custom';
-export const TRAINER_VS_TYPE_CATEGORIES = [1, 2] as const;
+export const TRAINER_VS_TYPE_CATEGORIES = [1, 2, 3] as const;
 export const TRAINER_ADDITIONAL_DIALOGS_CONDITION = [
   'before_creature_send',
   'after_creature_send',

--- a/src/utils/GroupUtils.ts
+++ b/src/utils/GroupUtils.ts
@@ -26,7 +26,6 @@ export const GroupToolMap = [
   { value: 'SuperRod', label: 'SuperRod' },
   { value: 'RockSmash', label: 'RockSmash' },
 ] as const;
-export const GroupBattleTypes = ['simple', 'double'] as const;
 export type StudioGroupActivationType = (typeof GroupActivationsMap)[number]['value'] | 'custom';
 
 export const getActivationValue = (newGroup: StudioGroup) => {

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -1,13 +1,13 @@
-import { StudioAbility } from '@modelEntities/ability';
-import { StudioCreature, StudioCreatureForm } from '@modelEntities/creature';
-import { DbSymbol } from '@modelEntities/dbSymbol';
+import type { StudioAbility } from '@modelEntities/ability';
+import type { StudioCreature, StudioCreatureForm } from '@modelEntities/creature';
+import type { DbSymbol } from '@modelEntities/dbSymbol';
 import { DEX_DEFAULT_NAME_TEXT_ID, StudioDex, StudioDexCreature } from '@modelEntities/dex';
-import { StudioCustomGroupCondition, StudioGroup, StudioGroupSystemTag, StudioGroupTool } from '@modelEntities/group';
+import type { StudioCustomGroupCondition, StudioGroup, StudioGroupSystemTag, StudioGroupTool, StudioGroupVsType } from '@modelEntities/group';
 import { createExpandPokemonSetup, StudioGroupEncounter } from '@modelEntities/groupEncounter';
-import { StudioItem, StudioItemStatusCondition } from '@modelEntities/item';
-import { StudioMapLink } from '@modelEntities/mapLink';
-import { StudioMove, StudioMoveCategory } from '@modelEntities/move';
-import {
+import type { StudioItem, StudioItemStatusCondition } from '@modelEntities/item';
+import type { StudioMapLink } from '@modelEntities/mapLink';
+import type { StudioMove, StudioMoveCategory } from '@modelEntities/move';
+import type {
   StudioCreatureQuestCondition,
   StudioCreatureQuestConditionType,
   StudioQuest,
@@ -17,17 +17,17 @@ import {
   StudioQuestObjectiveType,
   StudioQuestResolution,
 } from '@modelEntities/quest';
-import { StudioTrainer, StudioTrainerVsType } from '@modelEntities/trainer';
-import { StudioType } from '@modelEntities/type';
-import { StudioZone } from '@modelEntities/zone';
+import type { StudioTrainer, StudioTrainerVsType } from '@modelEntities/trainer';
+import type { StudioType } from '@modelEntities/type';
+import type { StudioZone } from '@modelEntities/zone';
 import { ProjectData } from '@src/GlobalStateProvider';
 import { assertUnreachable } from './assertUnreachable';
 import { findFirstAvailableCustomObjectiveTextId, findFirstAvailableFormTextId, findFirstAvailableId, findFirstAvailableTextId } from './ModelUtils';
 import { padStr } from './PadStr';
-import { StudioTextInfo } from '@modelEntities/textInfo';
-import { StudioMap, StudioMapAudio } from '@modelEntities/map';
-import { StudioMapInfo, StudioMapInfoMap } from '@modelEntities/mapInfo';
-import { StudioNature } from '@modelEntities/nature';
+import type { StudioTextInfo } from '@modelEntities/textInfo';
+import type { StudioMap, StudioMapAudio } from '@modelEntities/map';
+import type { StudioMapInfo, StudioMapInfoMap } from '@modelEntities/mapInfo';
+import type { StudioNature } from '@modelEntities/nature';
 import { mapInfoFindFirstAvailableId, mapInfoFindFirstAvailableTextId } from './MapInfoUtils';
 import { cloneEntity } from './cloneEntity';
 
@@ -285,7 +285,7 @@ export const createGroup = (
   systemTag: StudioGroupSystemTag,
   terrainTag: number,
   tool: StudioGroupTool,
-  isDoubleBattle: boolean,
+  vsType: StudioGroupVsType,
   customCondition: StudioCustomGroupCondition | undefined,
   stepsAverage: number
 ): StudioGroup => ({
@@ -293,12 +293,11 @@ export const createGroup = (
   id,
   dbSymbol,
   encounters: [],
-  isDoubleBattle,
+  vsType,
   systemTag,
   terrainTag,
   customConditions: customCondition ? [customCondition] : [],
   tool,
-  isHordeBattle: false,
   stepsAverage,
 });
 

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -86,7 +86,6 @@ export const importGroupData = (group: StudioGroup, dataToImport: StudioGroup): 
 
   return {
     ...group,
-    isHordeBattle: cloneData.isHordeBattle,
     encounters: cloneData.encounters,
   };
 };

--- a/src/views/components/categories/TrainerCategory.tsx
+++ b/src/views/components/categories/TrainerCategory.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Category } from './Category';
 
-type TrainerCategoryProps = { category: 'double' };
+type TrainerCategoryProps = { category: 'double' | 'triple' };
 
 export const TrainerCategory = styled(Category).attrs<TrainerCategoryProps>((props) => ({
   'data-category': props.category,
@@ -9,5 +9,9 @@ export const TrainerCategory = styled(Category).attrs<TrainerCategoryProps>((pro
   &[data-category='double'] {
     background: rgba(178, 146, 247, 0.12);
     color: rgba(178, 146, 247, 1);
+  }
+  &[data-category='triple'] {
+    background: rgba(245, 171, 61, 0.12);
+    color: rgba(245, 171, 61, 1);
   }
 `;

--- a/src/views/components/database/group/GroupFrame.tsx
+++ b/src/views/components/database/group/GroupFrame.tsx
@@ -60,7 +60,7 @@ export const GroupFrame = ({ group, dialogsRef }: GroupFrameProps) => {
           </DataInfoContainerHeaderTitle>
           <GroupSubInfoContainer>
             <DataFieldsetField label={t('activation')} data={t(getActivationLabel(group) as never)} disabled={false} />
-            <DataFieldsetField label={t('battle_type')} data={group.isDoubleBattle ? t('double') : t('simple')} disabled={false} />
+            <DataFieldsetField label={t('battle_type')} data={t(group.vsType)} disabled={false} />
             <DataFieldsetFieldWithChild label={t('environment')}>
               <EnvironmentContainer>
                 <span>{isCustomEnvironment(group.systemTag) ? t('custom') : t(group.systemTag as StudioGroupDefaultSystemTag)}</span>

--- a/src/views/components/database/group/editors/GroupFrameEditor.tsx
+++ b/src/views/components/database/group/editors/GroupFrameEditor.tsx
@@ -12,7 +12,6 @@ import {
   getSwitchValue,
   GroupActivationsMap,
   StudioGroupActivationType,
-  GroupBattleTypes,
   GroupVariationsMap,
   updateActivation,
   GroupToolMap,
@@ -23,7 +22,14 @@ import {
 } from '@utils/GroupUtils';
 import { TranslateInputContainer } from '@components/inputs/TranslateInputContainer';
 import { useGetEntityNameText, useSetProjectText } from '@utils/ReadingProjectText';
-import { GROUP_NAME_TEXT_ID, GROUP_SYSTEM_TAGS, StudioGroupSystemTag, StudioGroupTool } from '@modelEntities/group';
+import {
+  GROUP_NAME_TEXT_ID,
+  GROUP_SYSTEM_TAGS,
+  GROUP_VS_TYPE_CATEGORIES,
+  StudioGroupSystemTag,
+  StudioGroupTool,
+  StudioGroupVsType,
+} from '@modelEntities/group';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { useGroupPage } from '@hooks/usePage';
 import { useUpdateGroup } from './useUpdateGroup';
@@ -32,7 +38,7 @@ import { GroupTranslationEditorTitle, GroupTranslationOverlay } from './GroupTra
 import { TextInputError } from '@components/inputs/Input';
 
 const groupActivationEntries = (t: TFunction) => GroupActivationsMap.map((option) => ({ value: option.value, label: t(option.label as never) }));
-const groupBattleTypeEntries = (t: TFunction) => GroupBattleTypes.map((type) => ({ value: type, label: t(type) }));
+const groupBattleTypeEntries = (t: TFunction) => GROUP_VS_TYPE_CATEGORIES.map((type) => ({ value: type, label: t(type) }));
 const systemTagsEntries = (t: TFunction) => [...GROUP_SYSTEM_TAGS, 'custom' as const].map((tag) => ({ value: tag, label: t(tag) }));
 const groupVariationEntries = (t: TFunction) => GroupVariationsMap.map((variation) => ({ value: variation.value, label: t(variation.label) }));
 const groupToolEntries = (t: TFunction) => GroupToolMap.map((option) => ({ value: option.value, label: t(option.label) }));
@@ -52,7 +58,7 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const nameRef = useRef<HTMLInputElement>(null);
   const stepsAverageRef = useRef<HTMLInputElement>(null);
   const [activation, setActivation] = useState<StudioGroupActivationType>(getActivationValue(group));
-  const [battleType, setBattleType] = useState<(typeof battleTypeOptions)[number]['value']>(group.isDoubleBattle ? 'double' : 'simple');
+  const [battleType, setBattleType] = useState<StudioGroupVsType>(group.vsType);
   const [systemTag, setSystemTag] = useState<StudioGroupSystemTag>(getCustomEnvironment(group.systemTag) ?? 'RegularGround');
   const [variation, setVariation] = useState(group.terrainTag.toString());
   const [tool, setTool] = useState(group.tool || 'none');
@@ -80,11 +86,10 @@ export const GroupFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
     const customConditions = defineRelationCustomCondition(updateActivation(activation, group, switchValue));
     const newTool = tool === 'none' ? null : (tool as StudioGroupTool);
-    const isDoubleBattle = battleType === 'double';
     const stepsAverage = isNaN(stepsAverageRef.current.valueAsNumber) ? group.stepsAverage : stepsAverageRef.current.valueAsNumber;
     const newSystemTag = isCustomEnvironment ? setCustomEnvironment(systemTag) : systemTag;
 
-    updateGroup({ customConditions, systemTag: newSystemTag, tool: newTool, terrainTag: Number(variation), isDoubleBattle, stepsAverage });
+    updateGroup({ customConditions, systemTag: newSystemTag, tool: newTool, terrainTag: Number(variation), vsType: battleType, stepsAverage });
     saveTexts();
   };
   useEditorHandlingClose(ref, onClose, canClose);

--- a/src/views/components/database/group/editors/GroupNewEditor.tsx
+++ b/src/views/components/database/group/editors/GroupNewEditor.tsx
@@ -12,14 +12,13 @@ import {
   defineRelationCustomCondition,
   GroupActivationsMap,
   StudioGroupActivationType,
-  GroupBattleTypes,
   GroupVariationsMap,
   getSwitchValue,
   isCustomEnvironment as isCustomEnvironmentFunc,
   setCustomEnvironment,
   wrongEnvironment,
 } from '@utils/GroupUtils';
-import { GROUP_NAME_TEXT_ID, GROUP_SYSTEM_TAGS, StudioGroupSystemTag, StudioGroupTool } from '@modelEntities/group';
+import { GROUP_NAME_TEXT_ID, GROUP_SYSTEM_TAGS, GROUP_VS_TYPE_CATEGORIES, StudioGroupSystemTag, StudioGroupTool } from '@modelEntities/group';
 import { useSetProjectText } from '@utils/ReadingProjectText';
 import { createGroup } from '@utils/entityCreation';
 import { DbSymbol } from '@modelEntities/dbSymbol';
@@ -32,7 +31,7 @@ import { SelectGroup } from '@components/selects';
 import { importGroupData } from '@utils/importEntityDataUtils';
 
 const groupActivationEntries = (t: TFunction) => GroupActivationsMap.map((activation) => ({ value: activation.value, label: t(activation.label) }));
-const groupBattleTypeEntries = (t: TFunction) => GroupBattleTypes.map((type) => ({ value: type, label: t(type) }));
+const groupBattleTypeEntries = (t: TFunction) => GROUP_VS_TYPE_CATEGORIES.map((type) => ({ value: type, label: t(type) }));
 const systemTagsEntries = (t: TFunction) => [...GROUP_SYSTEM_TAGS, 'custom' as const].map((tag) => ({ value: tag, label: t(tag) }));
 const groupVariationEntries = (t: TFunction) => GroupVariationsMap.map((variation) => ({ value: variation.value, label: t(variation.label) }));
 const isTool = (variation: unknown): variation is StudioGroupTool => ['OldRod', 'GoodRod', 'SuperRod', 'RockSmash'].includes(variation as string);
@@ -97,7 +96,7 @@ export const GroupNewEditor = forwardRef<EditorHandlingClose, GroupNewEditorProp
       newSystemTag,
       terrainTag,
       tool,
-      battleType === 'double',
+      battleType,
       activation === 'always' ? undefined : { value: activationSwitchId, type: 'enabledSwitch', relationWithPreviousCondition: 'AND' },
       stepsAverage
     );

--- a/src/views/components/database/trainer/TrainerFrame.tsx
+++ b/src/views/components/database/trainer/TrainerFrame.tsx
@@ -103,7 +103,7 @@ export const TrainerFrame = ({ trainer, dialogsRef }: TrainerFrameProps) => {
               </h1>
             </DataInfoContainerHeaderTitle>
             {trainer.vsType === 2 && <TrainerCategory category="double">{t('vs_type2')}</TrainerCategory>}
-            {trainer.vsType === 3 && <TrainerCategory category="double">{t('vs_type3')}</TrainerCategory>}
+            {trainer.vsType === 3 && <TrainerCategory category="triple">{t('vs_type3')}</TrainerCategory>}
           </DataInfoContainerHeader>
           <TrainerSubInfoContainer>
             <DataFieldsetField label={t('trainer_class')} data={trainerClass} />

--- a/src/views/components/database/trainer/TrainerFrame.tsx
+++ b/src/views/components/database/trainer/TrainerFrame.tsx
@@ -103,6 +103,7 @@ export const TrainerFrame = ({ trainer, dialogsRef }: TrainerFrameProps) => {
               </h1>
             </DataInfoContainerHeaderTitle>
             {trainer.vsType === 2 && <TrainerCategory category="double">{t('vs_type2')}</TrainerCategory>}
+            {trainer.vsType === 3 && <TrainerCategory category="double">{t('vs_type3')}</TrainerCategory>}
           </DataInfoContainerHeader>
           <TrainerSubInfoContainer>
             <DataFieldsetField label={t('trainer_class')} data={trainerClass} />


### PR DESCRIPTION
## Description

This PR adds the 3v3 battle mode accessible for trainer and group battles.

For the groups, the data structure has been modified. The properties `isDoubleBattle` and `isHordeBattle` has been removed. A new properties `vsType` has been created instead.

Closes #510

Change for PSDK: https://gitlab.com/pokemonsdk/pokemonsdk/-/merge_requests/1588

## Tests to perform

- [x] The user can choose the 3v3 mode for the trainer
- [x] The user can choose the 3v3 mode for the group
- [x] The migration works correctly
