### PR TITLE
Fix a rollback in the trainer page

### DIFF
--- a/src/views/components/bagEntry/BagEntryList.tsx
+++ b/src/views/components/bagEntry/BagEntryList.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import React, { useState } from 'react';
 import { DarkButtonImportResponsive, SecondaryButtonWithPlusIconResponsive } from '@components/buttons';
 import { ItemBagEntry } from './ItemBagEntry';
-import { StudioTrainerBagEntry } from '@modelEntities/trainer';
+import { StudioTrainer } from '@modelEntities/trainer';
 import { BagEntryEditorOverlay, type BagEntryEditorAndDeletionKeys, type BagEntryFrom } from './editors/BagEntryEditorOverlay';
 import { useDialogsRef } from '@hooks/useDialogsRef';
 
 type BagEntryListProps = {
   title: string;
-  bagEntries: StudioTrainerBagEntry[];
+  trainer: StudioTrainer;
   disabledImport: boolean;
   from: BagEntryFrom;
 };
@@ -19,10 +19,11 @@ const BagEntryListComponent = styled(PokemonBattlerListComponent)``;
 const BagEntryListHeader = styled(PokemonBattlerListHeader)``;
 const BagEntryListGrid = styled(PokemonBattlerListGrid)``;
 
-export const BagEntryList = ({ title, bagEntries, disabledImport, from }: BagEntryListProps) => {
+export const BagEntryList = ({ title, trainer, disabledImport, from }: BagEntryListProps) => {
   const dialogsRef = useDialogsRef<BagEntryEditorAndDeletionKeys>();
   const { t } = useTranslation();
   const [index, setIndex] = useState<number>(0);
+  const bagEntries = trainer.bagEntries;
 
   return (
     <BagEntryListComponent size="full" data-noactive>
@@ -46,7 +47,15 @@ export const BagEntryList = ({ title, bagEntries, disabledImport, from }: BagEnt
       ) : (
         <BagEntryListGrid>
           {bagEntries.map((bagEntry, index) => (
-            <ItemBagEntry key={`item-bag-entry-${index}`} dialogsRef={dialogsRef} bagEntry={bagEntry} from={from} index={index} setIndex={setIndex} />
+            <ItemBagEntry
+              key={`item-bag-entry-${index}`}
+              dialogsRef={dialogsRef}
+              bagEntry={bagEntry}
+              from={from}
+              index={index}
+              trainer={trainer}
+              setIndex={setIndex}
+            />
           ))}
         </BagEntryListGrid>
       )}

--- a/src/views/components/bagEntry/ItemBagEntry.tsx
+++ b/src/views/components/bagEntry/ItemBagEntry.tsx
@@ -7,13 +7,12 @@ import { ClearButtonOnlyIcon } from '@components/buttons';
 import { useTranslation } from 'react-i18next';
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
 import { itemIconPath } from '@utils/path';
-import { StudioTrainerBagEntry } from '@modelEntities/trainer';
+import { StudioTrainer, StudioTrainerBagEntry } from '@modelEntities/trainer';
 import { ResourceImage } from '@components/ResourceImage';
 import { useShortcutNavigation } from '@hooks/useShortcutNavigation';
 import { CONTROL, useKeyPress } from '@hooks/useKeyPress';
 import type { BagEntryDialogsRef, BagEntryFrom } from './editors/BagEntryEditorOverlay';
 import { assertUnreachable } from '@utils/assertUnreachable';
-import { useTrainerPage } from '@hooks/usePage';
 import { useUpdateTrainer } from '@components/database/trainer/editors/useUpdateTrainer';
 import { cloneEntity } from '@utils/cloneEntity';
 
@@ -22,6 +21,7 @@ type ItemBagEntryProps = {
   bagEntry: StudioTrainerBagEntry;
   from: BagEntryFrom;
   index: number;
+  trainer: StudioTrainer;
   setIndex: Dispatch<React.SetStateAction<number>>;
 };
 
@@ -79,11 +79,10 @@ const ItemBagEntryHeader = styled.div`
   }
 `;
 
-export const ItemBagEntry = ({ dialogsRef, bagEntry, from, index, setIndex }: ItemBagEntryProps) => {
+export const ItemBagEntry = ({ dialogsRef, bagEntry, from, index, trainer, setIndex }: ItemBagEntryProps) => {
   const { projectDataValues: items } = useProjectItems();
   const getItemName = useGetEntityNameText();
   const item = items[bagEntry.dbSymbol];
-  const { trainer } = useTrainerPage();
   const updateTrainer = useUpdateTrainer(trainer);
   const { t } = useTranslation();
   const isClickable: boolean = useKeyPress(CONTROL);

--- a/src/views/pages/database/Trainer.page.tsx
+++ b/src/views/pages/database/Trainer.page.tsx
@@ -43,12 +43,7 @@ export const TrainerPage = () => {
               disabledImport={false}
               from="trainer"
             />
-            <BagEntryList
-              title={t('trainer_bag', { name: trainerName })}
-              bagEntries={trainer.bagEntries}
-              disabledImport={cannotDelete}
-              from="trainer"
-            />
+            <BagEntryList title={t('trainer_bag', { name: trainerName })} trainer={trainer} disabledImport={cannotDelete} from="trainer" />
           </DataBlockWrapper>
           <DataBlockWrapper>
             <DataBlockWithAction size="full" title={t('deletion')}>


### PR DESCRIPTION
## Description

This PR fixes a rollback in the trainer page between the bag items and the creatures of the trainer.

Bug report here: https://discord.com/channels/143824995867557888/1381988271718010920

## How reproduce

1. Add an item
2. Add a creature
3. Remove the item

The creature is deleted too.

## Tests to perform

- [x] The user can add an item, add a creature and remove the item without deleting the creature
- [x] The user can import items, add a creature and remove an item without deleting the creature
