### PR TITLE
Adding display of the save warning in case of modifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import './i18n';
 import DesignSystemRouterComponent from '@ds/DesignSystem.router';
 import PocRouterComponent from '@poc/Poc.router';
 import { TooltipContext } from '@ds/Tooltip/TooltipContext';
+import { CloseListener } from '@components/modals/CloseListener';
+import { UnsavedWarningProvider } from '@components/modals/unsavedWarningContext';
 
 const App = () => {
   return (
@@ -32,26 +34,29 @@ const App = () => {
         <LoaderContextProvider>
           <ThemeProvider theme={theme}>
             <GlobalStyle />
-            <UnsavedWarningModal />
-            <MemoryRouter>
-              <NavigationBarComponent />
-              <Routes>
-                <Route path="/home" element={<HomePage />} />
-                <Route path="/dashboard/*" element={<DashboardRouter />} />
-                <Route path="/psdkupdate" element={<PSDKUpdatePage />} />
-                <Route path="/database/*" element={<DatabasePage />} />
-                <Route path="/world/*" element={<WorldRouter />} />
-                <Route path="/texts/*" element={<TextsRouter />} />
-                <Route path="/code" />
-                <Route path="/help" />
-                <Route path="/settings/*" element={<SettingsRouter />} />
-                <Route path="/account" />
-                <Route path="/designSystem/*" element={<DesignSystemRouterComponent />} />
-                <Route path="/compilation" element={<CompilationPage />} />
-                <Route path="/poc/*" element={<PocRouterComponent />} />
-                <Route path="/" element={<Navigate to="/home" />} />
-              </Routes>
-            </MemoryRouter>
+            <UnsavedWarningProvider>
+              <CloseListener />
+              <UnsavedWarningModal />
+              <MemoryRouter>
+                <NavigationBarComponent />
+                <Routes>
+                  <Route path="/home" element={<HomePage />} />
+                  <Route path="/dashboard/*" element={<DashboardRouter />} />
+                  <Route path="/psdkupdate" element={<PSDKUpdatePage />} />
+                  <Route path="/database/*" element={<DatabasePage />} />
+                  <Route path="/world/*" element={<WorldRouter />} />
+                  <Route path="/texts/*" element={<TextsRouter />} />
+                  <Route path="/code" />
+                  <Route path="/help" />
+                  <Route path="/settings/*" element={<SettingsRouter />} />
+                  <Route path="/account" />
+                  <Route path="/designSystem/*" element={<DesignSystemRouterComponent />} />
+                  <Route path="/compilation" element={<CompilationPage />} />
+                  <Route path="/poc/*" element={<PocRouterComponent />} />
+                  <Route path="/" element={<Navigate to="/home" />} />
+                </Routes>
+              </MemoryRouter>
+            </UnsavedWarningProvider>
             <Loader />
             <ReactNotifications />
           </ThemeProvider>

--- a/src/hooks/useProjectSave/useSaveProjectAction.tsx
+++ b/src/hooks/useProjectSave/useSaveProjectAction.tsx
@@ -1,0 +1,32 @@
+// @hooks/useSaveProjectAction.ts
+import { useProjectSave } from '@hooks/useProjectSave';
+import { useLoaderRef } from '@utils/loaderContext';
+import { useDialogsRef } from '@hooks/useDialogsRef';
+import { SaveEditorAndDeletionKeys } from '@components/save/SaveEditorOverlay';
+
+export const useSaveProjectAction = () => {
+  const { isDataToSave, isMapsToSave, save } = useProjectSave();
+  const loaderRef = useLoaderRef();
+  const dialogsRef = useDialogsRef<SaveEditorAndDeletionKeys>();
+
+  const handleSave = async () => {
+    const skipMapWarning = localStorage.getItem('neverRemindMeMapModification') === 'true';
+
+    if (skipMapWarning || !isMapsToSave) {
+      save(
+        () => loaderRef.current.close(),
+        ({ errorMessage }) => loaderRef.current.setError('saving_project_error', errorMessage)
+      );
+      return;
+    }
+
+    dialogsRef.current?.openDialog('map_warning', true);
+  };
+
+  return {
+    handleSave,
+    isDataToSave,
+    isMapsToSave,
+    dialogsRef,
+  };
+};

--- a/src/views/components/buttons/LoadProjectButton/LoadProjectButton.tsx
+++ b/src/views/components/buttons/LoadProjectButton/LoadProjectButton.tsx
@@ -5,9 +5,12 @@ import { useLoaderRef } from '@utils/loaderContext';
 import { useProjectLoad } from '@hooks/useProjectLoad';
 import { useTranslation } from 'react-i18next';
 
-type LoadProjectButtonProps = { children: ReactNode };
+type LoadProjectButtonProps = {
+  children: ReactNode;
+  onClick?: () => void;
+};
 
-export const LoadProjectButton = ({ children }: LoadProjectButtonProps) => {
+export const LoadProjectButton = ({ children, onClick }: LoadProjectButtonProps) => {
   const navigate = useNavigate();
   const loaderRef = useLoaderRef();
   const projectLoad = useProjectLoad();
@@ -37,5 +40,5 @@ export const LoadProjectButton = ({ children }: LoadProjectButtonProps) => {
     []
   );
 
-  return <SecondaryButton onClick={() => handleClick()}>{children}</SecondaryButton>;
+  return <SecondaryButton onClick={onClick}>{children}</SecondaryButton>;
 };

--- a/src/views/components/buttons/SaveProjectButton.tsx
+++ b/src/views/components/buttons/SaveProjectButton.tsx
@@ -5,11 +5,9 @@ import { BaseIcon } from '@components/icons/BaseIcon';
 import SvgContainer from '@components/icons/BaseIcon/SvgContainer';
 
 import { BaseButtonStyle } from './GenericButtons';
-import { useProjectSave } from '@hooks/useProjectSave';
-import { useLoaderRef } from '@utils/loaderContext';
-import { StudioShortcutActions, useShortcut } from '@hooks/useShortcuts';
-import { useDialogsRef } from '@hooks/useDialogsRef';
-import { SaveEditorAndDeletionKeys, SaveEditorOverlay } from '@components/save/SaveEditorOverlay';
+import { useShortcut, StudioShortcutActions } from '@hooks/useShortcuts';
+import { SaveEditorOverlay } from '@components/save/SaveEditorOverlay';
+import { useSaveProjectAction } from '@src/hooks/useProjectSave/useSaveProjectAction';
 
 const SaveProjectButtonContainer = styled(BaseButtonStyle)`
   display: inline-block;
@@ -28,7 +26,6 @@ const SaveProjectButtonContainer = styled(BaseButtonStyle)`
 
   &:active > ${SvgContainer} {
     background-color: ${theme.colors.primarySoft};
-
     svg {
       color: ${theme.colors.primaryBase};
     }
@@ -41,11 +38,7 @@ const BadgeContainer = styled.div`
   align-items: flex-end;
 `;
 
-type BadgeProps = {
-  visible: boolean;
-};
-
-const Badge = styled.div<BadgeProps>`
+const Badge = styled.div<{ visible: boolean }>`
   ${({ visible }) => !visible && 'display: none;'}
   border-radius: 100%;
   background-color: ${theme.colors.dangerBase};
@@ -54,30 +47,15 @@ const Badge = styled.div<BadgeProps>`
 `;
 
 export const SaveProjectButton = () => {
-  const { isDataToSave, isMapsToSave, save } = useProjectSave();
-  const loaderRef = useLoaderRef();
-  const dialogsRef = useDialogsRef<SaveEditorAndDeletionKeys>();
-
-  const handleSave = async () => {
-    const skipMapWarning = localStorage.getItem('neverRemindMeMapModification') === 'true';
-    if (skipMapWarning || !isMapsToSave) {
-      save(
-        () => loaderRef.current.close(),
-        ({ errorMessage }) => loaderRef.current.setError('saving_project_error', errorMessage)
-      );
-      return;
-    }
-    dialogsRef.current?.openDialog('map_warning', true);
-  };
+  const { handleSave, isDataToSave, dialogsRef } = useSaveProjectAction();
 
   const shortcutMap = useMemo<StudioShortcutActions>(() => {
-    // No shortcut if an editor is opened and no data to save
     const isShortcutEnabled = () => !document.querySelector('#dialogs')?.textContent && isDataToSave;
     return {
       save: () => isShortcutEnabled() && handleSave(),
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [save, isDataToSave]);
+  }, [handleSave, isDataToSave]);
+
   useShortcut(shortcutMap);
 
   return (

--- a/src/views/components/home/ProjectCard.tsx
+++ b/src/views/components/home/ProjectCard.tsx
@@ -12,6 +12,9 @@ import { Project } from '@utils/projectList';
 import { ResourceImage } from '@components/ResourceImage';
 import { useShowItemInFolder } from '@hooks/useShowItemInFolder';
 import { join } from '@utils/path';
+import { useUnsavedWarning } from '@components/modals/unsavedWarningContext';
+import { useSaveProjectAction } from '@src/hooks/useProjectSave/useSaveProjectAction';
+import { useGlobalState } from '@src/GlobalStateProvider';
 
 const ProjectCardContainer = styled(ActiveContainer)`
   position: relative;
@@ -103,6 +106,9 @@ export const ProjectCard = ({ project, onDeleteProjectToList, onUpdateProjectLis
   const projectLoad = useProjectLoad();
   const navigate = useNavigate();
   const showItemInFolder = useShowItemInFolder();
+  const { handleSave, isDataToSave } = useSaveProjectAction();
+  const { openModal, setOnConfirmQuit } = useUnsavedWarning();
+  const [state] = useGlobalState();
 
   const handleChangeFileClick = () => {
     return window.api.chooseProjectFileToOpen(
@@ -118,23 +124,34 @@ export const ProjectCard = ({ project, onDeleteProjectToList, onUpdateProjectLis
   const handleClick = async () => {
     if (!project) return;
 
-    projectLoad(
-      { projectDirName: project.projectPath },
-      () => {
-        loaderRef.current.close();
-        navigate('/dashboard');
-      },
-      ({ errorMessage }) => {
-        // TODO: Make an other way to find out if the project is not found
-        if (errorMessage.includes('no such file or directory')) {
-          const errorNode = <SecondaryButton onClick={handleChangeFileClick}>{t('browse_my_files')}</SecondaryButton>;
-          loaderRef.current.setError('loading_project_error', t('project_studio_not_found'), false, errorNode);
-        } else {
-          loaderRef.current.setError('loading_project_error', errorMessage);
-        }
-      },
-      (count) => loaderRef.current.setError('loading_project_error', t('integrity_message', { count }), true)
-    );
+    const loadProject = () => {
+      projectLoad(
+        { projectDirName: project.projectPath },
+        () => {
+          loaderRef.current.close();
+          navigate('/dashboard');
+        },
+        ({ errorMessage }) => {
+          if (errorMessage.includes('no such file or directory')) {
+            const errorNode = <SecondaryButton onClick={handleChangeFileClick}>{t('browse_my_files')}</SecondaryButton>;
+            loaderRef.current.setError('loading_project_error', t('project_studio_not_found'), false, errorNode);
+          } else {
+            loaderRef.current.setError('loading_project_error', errorMessage);
+          }
+        },
+        (count) => loaderRef.current.setError('loading_project_error', t('integrity_message', { count }), true)
+      );
+    };
+
+    if (isDataToSave && state.projectData) {
+      setOnConfirmQuit(async () => {
+        await handleSave();
+        loadProject();
+      });
+      openModal();
+    } else {
+      loadProject();
+    }
   };
 
   const onClickFolder = async (path: string, event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {

--- a/src/views/components/modals/CloseListener.tsx
+++ b/src/views/components/modals/CloseListener.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { useSaveProjectAction } from '@src/hooks/useProjectSave/useSaveProjectAction';
+import { useUnsavedWarning } from '@components/modals/unsavedWarningContext';
+
+/**
+ * React component that listens for application close requests and handles unsaved data warnings.
+ *
+ * When a close request is received (via `window.api.requestClose`), this component checks if there is unsaved data.
+ * - If there is unsaved data, it opens a confirmation modal and, upon confirmation, saves the data before closing.
+ * - If there is no unsaved data, it proceeds to close the application immediately.
+ *
+ * This component does not render any UI and should be mounted at the root of the application.
+ *
+ * @returns null
+ */
+export const CloseListener = () => {
+  const { openModal, setOnConfirmQuit } = useUnsavedWarning();
+  const { isDataToSave, handleSave } = useSaveProjectAction();
+
+  const isDataToSaveRef = useRef(isDataToSave);
+  useEffect(() => {
+    isDataToSaveRef.current = isDataToSave;
+  }, [isDataToSave]);
+
+  useEffect(() => {
+    const listener = async (_event: unknown, forceQuit = false) => {
+      if (isDataToSaveRef.current) {
+        setOnConfirmQuit(async () => {
+          await handleSave();
+          await window.api.safeClose(forceQuit);
+        });
+        openModal();
+      } else {
+        await window.api.safeClose(forceQuit);
+      }
+    };
+
+    window.api.requestClose.on(listener);
+    return () => {
+      window.api.requestClose.removeListener(listener);
+    };
+  }, [openModal, setOnConfirmQuit, handleSave]);
+
+  return null;
+};

--- a/src/views/components/modals/UnsavedWarningModal.tsx
+++ b/src/views/components/modals/UnsavedWarningModal.tsx
@@ -1,13 +1,7 @@
-import React, { useMemo, useEffect, useState, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-
 import theme from '@src/AppTheme';
-import { EditorOverlayContainer } from '@components/editor';
-import { PrimaryButton } from '@components/buttons';
-import { BaseIcon } from '@components/icons/BaseIcon';
-import { useProjectSave } from '@hooks/useProjectSave';
-import { useLoaderRef } from '@utils/loaderContext';
 import {
   MessageBoxActionContainer,
   MessageBoxCancelLink,
@@ -16,6 +10,10 @@ import {
   MessageBoxTextContainer,
   MessageBoxTitleIconContainer,
 } from '@components/MessageBoxContainer';
+import { BaseIcon } from '@components/icons/BaseIcon';
+import { PrimaryButton } from '@components/buttons';
+import { EditorOverlayContainer } from '@components/editor';
+import { useUnsavedWarning } from './unsavedWarningContext';
 
 const OverlayContainer = styled(EditorOverlayContainer)`
   display: flex;
@@ -26,71 +24,11 @@ const OverlayContainer = styled(EditorOverlayContainer)`
 
 export const UnsavedWarningModal = () => {
   const { t } = useTranslation();
-  const { isDataToSave, save } = useProjectSave();
-  const loaderRef = useLoaderRef();
-  const [show, setShow] = useState<boolean>(false);
-  const shouldForceQuit = useRef<boolean>(false);
-  const isDataToSaveRef = useRef<boolean>(isDataToSave);
-  const [state, setState] = useState<'init' | 'update'>('init');
+  const { showModal, closeModal, onConfirmQuit } = useUnsavedWarning();
 
-  const onQuit = async () => {
-    await window.api.safeClose(shouldForceQuit.current);
-  };
+  if (!showModal) return null;
 
-  const onSave = useMemo(
-    () => async () => {
-      setShow(false);
-      save(
-        async () => {
-          loaderRef.current.close();
-          await onQuit();
-        },
-        ({ errorMessage }) => loaderRef.current.setError('saving_project_error', errorMessage)
-      );
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isDataToSave]
-  );
-
-  const listener: Parameters<typeof window.api.requestClose.on>[0] = async (_event, forceQuit = false) => {
-    shouldForceQuit.current = forceQuit;
-    if (isDataToSaveRef.current) {
-      setShow(true);
-    } else {
-      await onQuit();
-    }
-  };
-
-  useEffect(() => {
-    if (state === 'init') {
-      window.api.requestClose.on(listener);
-      setState('update');
-    } else if (state === 'update') isDataToSaveRef.current = isDataToSave;
-
-    return () => {
-      window.api.requestClose.removeListener(listener);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDataToSave, state]);
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Tab' || (event.shiftKey && event.key === 'Tab') || (event.ctrlKey && event.key === 'a')) {
-        event.preventDefault();
-      }
-    };
-
-    if (show) {
-      document.addEventListener('keydown', handleKeyDown);
-    } else {
-      document.removeEventListener('keydown', handleKeyDown);
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [show]);
-
-  return show ? (
+  return (
     <OverlayContainer className="active">
       <MessageBoxContainer>
         <MessageBoxTitleIconContainer>
@@ -103,11 +41,11 @@ export const UnsavedWarningModal = () => {
           <p>{t('unsaved_description_modal')}</p>
         </MessageBoxTextContainer>
         <MessageBoxActionContainer>
-          <MessageBoxCancelLink onClick={() => setShow(false)}>{t('cancel')}</MessageBoxCancelLink>
-          <MessageBoxCancelLink onClick={onQuit}>{t('quit')}</MessageBoxCancelLink>
-          <PrimaryButton onClick={onSave}>{t('save')}</PrimaryButton>
+          <MessageBoxCancelLink onClick={closeModal}>{t('cancel')}</MessageBoxCancelLink>
+          <MessageBoxCancelLink onClick={onConfirmQuit}>{t('quit')}</MessageBoxCancelLink>
+          <PrimaryButton onClick={onConfirmQuit}>{t('save')}</PrimaryButton>
         </MessageBoxActionContainer>
       </MessageBoxContainer>
     </OverlayContainer>
-  ) : null;
+  );
 };

--- a/src/views/components/modals/unsavedWarningContext.tsx
+++ b/src/views/components/modals/unsavedWarningContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState, useRef, ReactNode } from 'react';
+
+type UnsavedWarningContextType = {
+  showModal: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+  setOnConfirmQuit: (cb: () => Promise<void>) => void;
+  onConfirmQuit: () => Promise<void>;
+};
+
+const UnsavedWarningContext = createContext<UnsavedWarningContextType | undefined>(undefined);
+
+export const UnsavedWarningProvider = ({ children }: { children: ReactNode }) => {
+  const [showModal, setShowModal] = useState(false);
+  const onConfirmQuitRef = useRef<() => Promise<void>>(() => Promise.resolve());
+
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
+  const setOnConfirmQuit = (cb: () => Promise<void>) => {
+    onConfirmQuitRef.current = cb;
+  };
+
+  const onConfirmQuit = async () => {
+    closeModal();
+    await onConfirmQuitRef.current();
+  };
+
+  return (
+    <UnsavedWarningContext.Provider value={{ showModal, openModal, closeModal, setOnConfirmQuit, onConfirmQuit }}>
+      {children}
+    </UnsavedWarningContext.Provider>
+  );
+};
+
+export const useUnsavedWarning = () => {
+  const context = useContext(UnsavedWarningContext);
+  if (!context) {
+    throw new Error('useUnsavedWarning must be used within UnsavedWarningProvider');
+  }
+  return context;
+};

--- a/src/views/pages/Home.page.tsx
+++ b/src/views/pages/Home.page.tsx
@@ -19,12 +19,21 @@ import { deleteProjectToList, getProjectList, updateProjectPath } from '@utils/p
 import { useDialogsRef } from '@hooks/useDialogsRef';
 import { useNavigate } from 'react-router-dom';
 
+import { useUnsavedWarning } from '@components/modals/unsavedWarningContext';
+import { useSaveProjectAction } from '@src/hooks/useProjectSave/useSaveProjectAction';
+import { useGlobalState } from '../../GlobalStateProvider'; // adapte si besoin
+// eslint-disable-next-line react-hooks/rules-of-hooks
+
 const HomePageComponent = () => {
   const dialogsRef = useDialogsRef<HomeEditorAndDeletionKeys>();
   const [appVersion, setAppVersion] = useState('');
   const [projectList, setProjectList] = useState(getProjectList());
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+
+  const { openModal, setOnConfirmQuit } = useUnsavedWarning();
+  const { handleSave, isDataToSave } = useSaveProjectAction();
+  const [state] = useGlobalState();
 
   const onDeleteProjectToList = (event: React.MouseEvent<HTMLSpanElement>, projectPath: string) => {
     event.stopPropagation();
@@ -35,6 +44,38 @@ const HomePageComponent = () => {
   const onUpdateProjectList = (projectPath: string, index: number) => {
     updateProjectPath(projectPath, index);
     setProjectList(getProjectList());
+  };
+
+  const handleOpenNewProject = () => {
+    if (isDataToSave && state.projectData) {
+      setOnConfirmQuit(async () => {
+        await handleSave();
+        dialogsRef.current?.openDialog('new_project');
+      });
+      openModal();
+    } else {
+      dialogsRef.current?.openDialog('new_project');
+    }
+  };
+
+  const handleOpenProject = () => {
+    if (isDataToSave && state.projectData) {
+      setOnConfirmQuit(async () => {
+        await handleSave();
+        window.api.chooseProjectFileToOpen(
+          { fileType: 'studio' },
+          () => {},
+          () => {}
+        );
+      });
+      openModal();
+    } else {
+      window.api.chooseProjectFileToOpen(
+        { fileType: 'studio' },
+        () => {},
+        () => {}
+      );
+    }
   };
 
   useEffect(() => {
@@ -56,6 +97,18 @@ const HomePageComponent = () => {
     return () => {};
   }, []);
 
+  const handleOpenProjectWrapper = () => {
+    if (isDataToSave && state.projectData) {
+      setOnConfirmQuit(async () => {
+        await handleSave();
+        handleOpenProject();
+      });
+      openModal();
+    } else {
+      handleOpenProject();
+    }
+  };
+
   return (
     <HomePageContainer>
       <Header>
@@ -69,8 +122,8 @@ const HomePageComponent = () => {
             <StudioIcon />
             <BrandingTitle>Pokémon Studio</BrandingTitle>
           </BrandingTitleContainer>
-          <LoadProjectButton>{t('open_a_project')}</LoadProjectButton>
-          <PrimaryButton onClick={() => dialogsRef.current?.openDialog('new_project')}>{t('new_project')}</PrimaryButton>
+          <LoadProjectButton onClick={handleOpenProjectWrapper}>{t('open_a_project')}</LoadProjectButton>
+          <PrimaryButton onClick={handleOpenNewProject}>{t('new_project')}</PrimaryButton>
         </BrandingActionContainer>
         {projectList.length !== 0 && (
           <RecentProjectContainer>


### PR DESCRIPTION
# Description

This PR implements a warning dialog that appears when a user tries to open a new project while another project with unsaved changes is already open.

The goal is to prevent accidental loss of ongoing work.

## Main Features

- Added a generic hook that:
  - Checks for unsaved data.
  - Communicates with the backend if needed.
  - Displays a warning dialog before allowing the new project to be opened.

- Integrated into the project opening flow to intercept the action if data needs to be saved.
