### PR TITLE
Add new parameter to items to allow the use of Mega Evolution

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
   "dashboard_save": "Speichern",
-  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode",
+  "add_mega_evolution_parameter_to_items": "Adding Mega Evolution parameter to items",
+  "allow_mega": "Mega Evolution",
+  "allow_mega_evolution": "Allow Mega Evolution"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
   "dashboard_save": "Save",
-  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode",
+  "add_mega_evolution_parameter_to_items": "Adding Mega Evolution parameter to items",
+  "allow_mega": "Mega Evolution",
+  "allow_mega_evolution": "Allow Mega Evolution"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
   "dashboard_save": "Guardar",
-  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode",
+  "add_mega_evolution_parameter_to_items": "Adding Mega Evolution parameter to items",
+  "allow_mega": "Mega Evolution",
+  "allow_mega_evolution": "Allow Mega Evolution"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Gérer la liste des techniques",
   "tech_list": "Liste des techniques",
   "dashboard_save": "Sauvegarde",
-  "migrate_groups_for_3v3_battle_mode": "Migration des groupes pour le support du mode de combat 3v3"
+  "migrate_groups_for_3v3_battle_mode": "Migration des groupes pour le support du mode de combat 3v3",
+  "add_mega_evolution_parameter_to_items": "Ajout du paramètre de Méga-Évolution aux objets",
+  "allow_mega": "Méga-Évolution",
+  "allow_mega_evolution": "Permet la Méga-Évolution"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
   "dashboard_save": "Salvataggio",
-  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode",
+  "add_mega_evolution_parameter_to_items": "Adding Mega Evolution parameter to items",
+  "allow_mega": "Mega Evolution",
+  "allow_mega_evolution": "Allow Mega Evolution"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1530,5 +1530,8 @@
   "handle_tech_list": "Manage technique items",
   "tech_list": "List of technique items",
   "dashboard_save": "Save",
-  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode"
+  "migrate_groups_for_3v3_battle_mode": "Migrate groups to support 3v3 combat mode",
+  "add_mega_evolution_parameter_to_items": "Adding Mega Evolution parameter to items",
+  "allow_mega": "Mega Evolution",
+  "allow_mega_evolution": "Allow Mega Evolution"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "./.webpack/main",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/migrations/addMegaEvolutionParameterToItems.ts
+++ b/src/migrations/addMegaEvolutionParameterToItems.ts
@@ -1,0 +1,90 @@
+import { IpcMainEvent } from 'electron';
+import path from 'path';
+import { readProjectFolder } from '@src/backendTasks/readProjectData';
+import fsPromise from 'fs/promises';
+import { z } from 'zod';
+import { deletePSDKDatFile } from './migrateUtils';
+import {
+  ALL_PP_HEALING_ITEM_VALIDATOR,
+  BALL_ITEM_VALIDATOR,
+  CONSTANT_HEALING_ITEM_VALIDATOR,
+  EV_BOOST_ITEM_VALIDATOR,
+  EVENT_ITEM_VALIDATOR,
+  EXP_INCREASE_ITEM_VALIDATOR,
+  FLEEING_ITEM_VALIDATOR,
+  HEALING_ITEM_VALIDATOR,
+  LEVEL_INCREASE_ITEM_VALIDATOR,
+  PP_HEALING_ITEM_VALIDATOR,
+  PP_INCREASE_ITEM_VALIDATOR,
+  RATE_HEALING_ITEM_VALIDATOR,
+  REPEL_ITEM_VALIDATOR,
+  STAT_BOOST_ITEM_VALIDATOR,
+  STATUS_CONSTANT_HEALING_ITEM_VALIDATOR,
+  STATUS_HEALING_ITEM_VALIDATOR,
+  STATUS_RATE_HEALING_ITEM_VALIDATOR,
+  STONE_ITEM_VALIDATOR,
+  StudioItem,
+  TECH_ITEM_VALIDATOR,
+  UNKNOWN_ITEM_VALIDATOR,
+} from '@modelEntities/item';
+import { parseJSON } from '@utils/json/parse';
+
+// C'est moche, mais d'après ce ticket y a pas moyen de faire autrement https://github.com/colinhacks/zod/discussions/1434
+const PRE_MIGRATION_ITEM_VALIDATOR = z.discriminatedUnion('klass', [
+  UNKNOWN_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  PP_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  ALL_PP_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  BALL_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  CONSTANT_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  STAT_BOOST_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  EV_BOOST_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  EVENT_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  FLEEING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  LEVEL_INCREASE_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  EXP_INCREASE_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  PP_INCREASE_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  RATE_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  REPEL_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  STATUS_CONSTANT_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  STATUS_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  STATUS_RATE_HEALING_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  STONE_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+  TECH_ITEM_VALIDATOR.omit({ isAllowingMega: true }),
+]);
+type StudioItemDataBeforeMigration = z.infer<typeof PRE_MIGRATION_ITEM_VALIDATOR>;
+
+const MEGA_TOOLS = [
+  'mega_ring',
+  'mega_bracelet',
+  'mega_pendant',
+  'mega_glasses',
+  'mega_anchor',
+  'mega_stickpin',
+  'mega_tiara',
+  'mega_anklet',
+  'mega_cuff',
+  'mega_charm',
+  'mega_glove',
+];
+
+const addParameter = (item: StudioItemDataBeforeMigration): StudioItem => {
+  return {
+    ...item,
+    isAllowingMega: MEGA_TOOLS.includes(item.dbSymbol),
+  };
+};
+
+export const addMegaEvolutionParameterToItems = async (_: IpcMainEvent, projectPath: string) => {
+  deletePSDKDatFile(projectPath);
+
+  const items = await readProjectFolder(projectPath, 'items');
+  await items.reduce(async (lastPromise, item) => {
+    await lastPromise;
+    const itemParsed = PRE_MIGRATION_ITEM_VALIDATOR.safeParse(parseJSON<StudioItem>(item.data, item.filename));
+    if (itemParsed.success) {
+      const newItem = addParameter(itemParsed.data);
+      return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/items', `${newItem.dbSymbol}.json`), JSON.stringify(newItem, null, 2));
+    }
+  }, Promise.resolve());
+};

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -18,6 +18,7 @@ import { addCsvForQuestsCustomObjectives } from './addCsvForQuestsCustomObjectiv
 import { addEggInCreatureResources } from './addEggInCreatureResources';
 import { addBattleCamera3dToSettings } from './addBattleCamera3dToSettings';
 import { migrateGroupsFor3v3BattleMode } from './migrateGroupsFor3v3BattleMode';
+import { addMegaEvolutionParameterToItems } from './addMegaEvolutionParameterToItems';
 
 type MigrateConfigType = {
   migration: MigrationTask;
@@ -136,5 +137,10 @@ export const MIGRATION_CONFIG: MigrateConfigType[] = [
     migration: migrateGroupsFor3v3BattleMode,
     version: '2.5.0',
     message: 'migrate_groups_for_3v3_battle_mode',
+  },
+  {
+    migration: addMegaEvolutionParameterToItems,
+    version: '2.5.0',
+    message: 'add_mega_evolution_parameter_to_items',
   },
 ];

--- a/src/migrations/migrationConfig.ts
+++ b/src/migrations/migrationConfig.ts
@@ -140,7 +140,7 @@ export const MIGRATION_CONFIG: MigrateConfigType[] = [
   },
   {
     migration: addMegaEvolutionParameterToItems,
-    version: '2.5.0',
+    version: '2.5.1',
     message: 'add_mega_evolution_parameter_to_items',
   },
 ];

--- a/src/models/entities/item.ts
+++ b/src/models/entities/item.ts
@@ -13,6 +13,7 @@ const ITEM_BASE_VALIDATOR = z.object({
   isMapUsable: z.boolean(),
   isLimited: z.boolean(),
   isHoldable: z.boolean(),
+  isAllowingMega: z.boolean(),
   flingPower: POSITIVE_OR_ZERO_INT,
 });
 
@@ -254,8 +255,22 @@ export const mutateItemInto = <K extends StudioItem['klass']>(
   originItem: StudioItem,
   targetItem: Extract<StudioItem, { klass: K }>
 ): typeof targetItem => {
-  const { id, dbSymbol, icon, price, socket, position, isBattleUsable, isMapUsable, isLimited, isHoldable, flingPower } = originItem;
-  const newItem = { ...targetItem, id, dbSymbol, icon, price, socket, position, isBattleUsable, isMapUsable, isLimited, isHoldable, flingPower };
+  const { id, dbSymbol, icon, price, socket, position, isBattleUsable, isMapUsable, isLimited, isHoldable, isAllowingMega, flingPower } = originItem;
+  const newItem = {
+    ...targetItem,
+    id,
+    dbSymbol,
+    icon,
+    price,
+    socket,
+    position,
+    isBattleUsable,
+    isMapUsable,
+    isLimited,
+    isHoldable,
+    isAllowingMega,
+    flingPower,
+  };
 
   if ('loyaltyMalus' in originItem && 'loyaltyMalus' in newItem) newItem.loyaltyMalus = originItem.loyaltyMalus;
   if ('ppCount' in originItem && 'ppCount' in newItem) newItem.ppCount = originItem.ppCount;

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -184,6 +184,7 @@ export const createItem = <K extends StudioItem['klass']>(klass: K, dbSymbol: Db
     isMapUsable: false,
     isLimited: false,
     isHoldable: false,
+    isAllowingMega: false,
     flingPower: 30,
   };
   type Output = Extract<StudioItem, { klass: K }>;

--- a/src/views/components/database/item/ItemParametersData.tsx
+++ b/src/views/components/database/item/ItemParametersData.tsx
@@ -18,7 +18,7 @@ const NoParameterContainer = styled.div`
   color: ${({ theme }) => theme.colors.text500};
 `;
 
-const atLeastOneParameter = (item: StudioItem) => item.isBattleUsable || item.isMapUsable || item.isLimited || item.isHoldable;
+const atLeastOneParameter = (item: StudioItem) => item.isBattleUsable || item.isMapUsable || item.isLimited || item.isHoldable || item.isAllowingMega;
 
 type ItemParemetersDataProps = {
   dialogsRef: ItemDialogsRef;
@@ -43,6 +43,7 @@ export const ItemParametersData = ({ dialogsRef }: ItemParemetersDataProps) => {
             {item.isMapUsable && <Tag>{t('map')}</Tag>}
             {item.isLimited && <Tag>{t('limited')}</Tag>}
             {item.isHoldable && <Tag>{t('holdable')}</Tag>}
+            {item.isAllowingMega && <Tag>{t('allow_mega')}</Tag>}
           </ParameterContainer>
         ) : (
           <NoParameterContainer>{t('no_parameter')}</NoParameterContainer>

--- a/src/views/components/database/item/editors/ItemParametersDataEditor.tsx
+++ b/src/views/components/database/item/editors/ItemParametersDataEditor.tsx
@@ -18,6 +18,7 @@ export const ItemParametersDataEditor = forwardRef<EditorHandlingClose>((_, ref)
     isMapUsable: item.isMapUsable,
     isLimited: item.isLimited,
     isHoldable: item.isHoldable,
+    isAllowingMega: item.isAllowingMega,
   });
 
   const handleClose = () => {
@@ -61,6 +62,14 @@ export const ItemParametersDataEditor = forwardRef<EditorHandlingClose>((_, ref)
             name="can_be_held"
             checked={params.isHoldable}
             onChange={(event) => setParams((prevFormData) => ({ ...prevFormData, isHoldable: event.target.checked }))}
+          />
+        </InputWithLeftLabelContainer>
+        <InputWithLeftLabelContainer>
+          <Label htmlFor="allow_mega_evolution">{t('allow_mega_evolution')}</Label>
+          <Toggle
+            name="allow_mega_evolution"
+            checked={params.isAllowingMega}
+            onChange={(event) => setParams((prevFormData) => ({ ...prevFormData, isAllowingMega: event.target.checked }))}
           />
         </InputWithLeftLabelContainer>
       </InputContainer>


### PR DESCRIPTION
## Description

This PR add a new parameter to items that allow to know if possessing this item in the bag allows the player to Mega Evolve its Pokémon

closes #416

## Tests to perform

- [x] Opening a project correctly launches the migration
- [x] After the migration, pre-existing mega tools all have the `isAllowingMega` parameter set to true in their JSON file (Mega Ring, Mega Bracelet, Mega Anchor are example of mega tools)
- [x] The badge `Mega Evolution` appears in the 'parameters' block of these items in the Database
- [x] Opening the parameters editor correctly shows a new Toggle option to define if the item allows the use of Mega Evolution
- [x] Modifying the toggle value correctly changes the JSON value `isAllowingMega`
