### PR TITLE
Fix an issue where users could assign a map to multiple zones

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1143,7 +1143,7 @@
   "maps_list": "List of maps",
   "displayed_panel": "Displayed panel",
   "forced_weather": "Forced weather",
-  "map_already_exists": "Map #{{mapId}} is already in the list or assigned an other zone.",
+  "map_already_exists": "Map #{{mapId}} is already in the list or assigned to another zone.",
   "panel_number": "Panel number",
   "weather-1": "By default",
   "weather0": "None",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1143,7 +1143,7 @@
   "maps_list": "List of maps",
   "displayed_panel": "Displayed panel",
   "forced_weather": "Forced weather",
-  "map_already_exists": "Map #{{mapId}} is already in the list.",
+  "map_already_exists": "Map #{{mapId}} is already in the list or assigned an other zone.",
   "panel_number": "Panel number",
   "weather-1": "By default",
   "weather0": "None",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1143,7 +1143,7 @@
   "maps_list": "Liste des cartes",
   "displayed_panel": "Panneau affiché",
   "forced_weather": "Météo forcée",
-  "map_already_exists": "La carte #{{mapId}} est déjà dans la liste.",
+  "map_already_exists": "La carte #{{mapId}} est déjà dans la liste ou assignée à une autre zone.",
   "panel_number": "Numéro du panneau",
   "weather-1": "Par défaut",
   "weather0": "Aucune",

--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -267,5 +267,6 @@ export const useZonePage = () => {
     zoneName,
     groups,
     cannotDelete: Object.keys(zones).length <= 1,
+    state,
   };
 };

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -1,19 +1,48 @@
 import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
+import styled from 'styled-components';
 import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { TextInputError } from '@components/inputs/Input';
+import { TagWithDeletion, TagWithDeletionContainer } from '@components/Tag';
 import { Select } from '@ds/Select';
 import { useZonePage } from '@src/hooks/usePage';
 import { useUpdateZone } from './useUpdateZone';
 import type { StudioZone, StudioZoneForcedWeather } from '@modelEntities/zone';
 import { padStr } from '@utils/PadStr';
-import { MultiSelect } from '@ds/MultiSelect';
-import { useSelectOptions } from '@src/hooks/useSelectOptions';
+import { cloneEntity } from '@utils/cloneEntity';
 import { ProjectData } from '@src/GlobalStateProvider';
-import type { DbSymbol } from '@modelEntities/dbSymbol';
-import { SelectOption } from '@ds/Select/types';
+
+const InputMapsListContainer = styled(InputWithTopLabelContainer)`
+  gap: 16px;
+`;
+
+const InputMapWithErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  ${Input} {
+    text-align: left;
+  }
+`;
+
+const MapsListContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 4px;
+
+  ${TagWithDeletionContainer} {
+    gap: 4px;
+
+    span.map-id {
+      height: 18px;
+    }
+  }
+`;
 
 // -1 = By default, 0 = None, 1 = Rain, 2 = Sun/Zenith, 3 = Sandstorm, 4 = Hail, 5 = Foggy
 const WeatherCategories = [-1, 0, 1, 2, 3, 4, 5] as const;
@@ -21,10 +50,7 @@ const WeatherCategories = [-1, 0, 1, 2, 3, 4, 5] as const;
 const weatherCategoryEntries = (t: TFunction) =>
   WeatherCategories.map((category) => ({ value: category.toString(), label: t(`weather${category}`) }));
 
-const mapDbSymbolsFromMapIds = (mapIds: number[]) => mapIds.map((mapId) => `map${padStr(mapId, 3)}` as DbSymbol);
-const mapIdsFromMapDbSymbols = (mapDbSymbols: DbSymbol[], maps: ProjectData['maps']) => mapDbSymbols.map((dbSymbol) => maps[dbSymbol].id);
-
-const filterMapsAlreadyAssignedInZones = (mapOptions: SelectOption<DbSymbol>[], zonesData: ProjectData['zones'], currentZone: StudioZone) => {
+const mapsAlreadyAssignedInZones = (zonesData: ProjectData['zones'], currentZone: StudioZone) => {
   const zones = Object.values(zonesData);
   const maps = new Set(
     zones.reduce<number[]>((maps, zone) => {
@@ -34,14 +60,7 @@ const filterMapsAlreadyAssignedInZones = (mapOptions: SelectOption<DbSymbol>[], 
       return maps;
     }, [])
   );
-  const mapDbSymbolsAssigned = mapDbSymbolsFromMapIds(Array.from(maps.values()));
-  const mapDbSymbolsCurrentZone = mapDbSymbolsFromMapIds(currentZone.maps);
-  return mapOptions.reduce((options, option) => {
-    const index = mapDbSymbolsAssigned.findIndex((mapDbSymbol) => mapDbSymbol === option.value);
-    if (index === -1 || mapDbSymbolsCurrentZone.includes(option.value)) return [...options, option];
-
-    return options;
-  }, [] as SelectOption<DbSymbol>[]);
+  return Array.from(maps.values());
 };
 
 export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
@@ -51,9 +70,37 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const forcedWeatherRef = useRef<string | undefined>();
   const panelIdRef = useRef<HTMLInputElement>(null);
   const weatherOptions = useMemo(() => weatherCategoryEntries(t), [t]);
-  const [maps, setMaps] = useState<DbSymbol[]>(mapDbSymbolsFromMapIds(zone.maps));
-  const defaultMapOptions = useSelectOptions('maps') as SelectOption<DbSymbol>[];
-  const mapOptions = useMemo(() => filterMapsAlreadyAssignedInZones(defaultMapOptions, state.projectData.zones, zone), []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const mapsAlreadyAssigned = useMemo(() => mapsAlreadyAssignedInZones(state.projectData.zones, zone), []);
+  const [maps, setMaps] = useState<number[]>(cloneEntity(zone.maps));
+  const [errorNewMap, setErrorNewMap] = useState<number | false>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (inputRef.current && inputRef.current.validity.valid && event.key === 'Enter') {
+      const target = event.target as HTMLInputElement;
+      const mapIds = target.value
+        .split(',')
+        .filter((v) => v.trim().length !== 0)
+        .map((v) => Number(v))
+        .filter((v, i, a) => i === a.indexOf(v));
+      const errorMapId = mapIds.find((mapId) => maps.includes(mapId) || mapsAlreadyAssigned.includes(mapId));
+      if (errorMapId !== undefined) {
+        setErrorNewMap(errorMapId);
+        return;
+      }
+
+      inputRef.current.value = '';
+      if (errorNewMap !== false) setErrorNewMap(false);
+      setMaps(maps.concat(mapIds));
+    }
+  };
+
+  const onDeleteMap = (index: number) => {
+    const mapsEdited = cloneEntity(maps);
+    mapsEdited.splice(index, 1);
+    setMaps(mapsEdited);
+  };
 
   const canClose = () => {
     const result = !!panelIdRef?.current?.validity.valid;
@@ -69,7 +116,7 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     updateZone({
       forcedWeather,
       panelId: panelIdRef.current.valueAsNumber,
-      maps: mapIdsFromMapDbSymbols(maps, state.projectData.maps),
+      maps,
     });
   };
 
@@ -78,10 +125,22 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   return (
     <Editor type="edit" title={t('settings')}>
       <InputContainer>
-        <InputWithTopLabelContainer>
+        <InputMapsListContainer>
           <Label htmlFor="map">{t('maps_list')}</Label>
-          <MultiSelect defaultValue={maps} onChange={setMaps} options={mapOptions} />
-        </InputWithTopLabelContainer>
+          <InputMapWithErrorContainer>
+            <Input type="text" name="map" pattern="[0-9]{1,5} *(?:, *[0-9]{0,5} *)*" ref={inputRef} onKeyDown={handleKeyDown} />
+            {errorNewMap !== false && <TextInputError>{t('map_already_exists', { mapId: padStr(errorNewMap, 2) })}</TextInputError>}
+          </InputMapWithErrorContainer>
+          <MapsListContainer>
+            {maps
+              .sort((a, b) => a - b)
+              .map((id, index) => (
+                <TagWithDeletion key={index} index={index} onClickDelete={onDeleteMap}>
+                  <span className="map-id">{padStr(id, 2)}</span>
+                </TagWithDeletion>
+              ))}
+          </MapsListContainer>
+        </InputMapsListContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="panel-number">{t('panel_number')}</Label>
           <Input type="number" name="panel-number" min="0" max="99999" defaultValue={zone.panelId} ref={panelIdRef} />

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -35,10 +35,10 @@ const filterMapsAlreadyAssignedInZones = (mapOptions: SelectOption<DbSymbol>[], 
     }, [])
   );
   const mapDbSymbolsAssigned = mapDbSymbolsFromMapIds(Array.from(maps.values()));
-  const mapDbSymbolCurrentZone = mapDbSymbolsFromMapIds(currentZone.maps);
-  return mapOptions.reduce((options, currentOption) => {
-    const index = mapDbSymbolsAssigned.findIndex((mapDbSymbol) => mapDbSymbol === currentOption.value);
-    if (index === -1 || mapDbSymbolCurrentZone.includes(currentOption.value)) return [...options, currentOption];
+  const mapDbSymbolsCurrentZone = mapDbSymbolsFromMapIds(currentZone.maps);
+  return mapOptions.reduce((options, option) => {
+    const index = mapDbSymbolsAssigned.findIndex((mapDbSymbol) => mapDbSymbol === option.value);
+    if (index === -1 || mapDbSymbolsCurrentZone.includes(option.value)) return [...options, option];
 
     return options;
   }, [] as SelectOption<DbSymbol>[]);

--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -1,51 +1,19 @@
 import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import styled from 'styled-components';
-
 import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
-import { TextInputError } from '@components/inputs/Input';
-import { TagWithDeletion, TagWithDeletionContainer } from '@components/Tag';
 import { Select } from '@ds/Select';
-
 import { useZonePage } from '@src/hooks/usePage';
 import { useUpdateZone } from './useUpdateZone';
-
-import { StudioZoneForcedWeather } from '@modelEntities/zone';
-
+import type { StudioZone, StudioZoneForcedWeather } from '@modelEntities/zone';
 import { padStr } from '@utils/PadStr';
-import { cloneEntity } from '@utils/cloneEntity';
-
-const InputMapsListContainer = styled(InputWithTopLabelContainer)`
-  gap: 16px;
-`;
-
-const InputMapWithErrorContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-
-  ${Input} {
-    text-align: left;
-  }
-`;
-
-const MapsListContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  gap: 4px;
-
-  ${TagWithDeletionContainer} {
-    gap: 4px;
-
-    span.map-id {
-      height: 18px;
-    }
-  }
-`;
+import { MultiSelect } from '@ds/MultiSelect';
+import { useSelectOptions } from '@src/hooks/useSelectOptions';
+import { ProjectData } from '@src/GlobalStateProvider';
+import type { DbSymbol } from '@modelEntities/dbSymbol';
+import { SelectOption } from '@ds/Select/types';
 
 // -1 = By default, 0 = None, 1 = Rain, 2 = Sun/Zenith, 3 = Sandstorm, 4 = Hail, 5 = Foggy
 const WeatherCategories = [-1, 0, 1, 2, 3, 4, 5] as const;
@@ -53,42 +21,39 @@ const WeatherCategories = [-1, 0, 1, 2, 3, 4, 5] as const;
 const weatherCategoryEntries = (t: TFunction) =>
   WeatherCategories.map((category) => ({ value: category.toString(), label: t(`weather${category}`) }));
 
+const mapDbSymbolsFromMapIds = (mapIds: number[]) => mapIds.map((mapId) => `map${padStr(mapId, 3)}` as DbSymbol);
+const mapIdsFromMapDbSymbols = (mapDbSymbols: DbSymbol[], maps: ProjectData['maps']) => mapDbSymbols.map((dbSymbol) => maps[dbSymbol].id);
+
+const filterMapsAlreadyAssignedInZones = (mapOptions: SelectOption<DbSymbol>[], zonesData: ProjectData['zones'], currentZone: StudioZone) => {
+  const zones = Object.values(zonesData);
+  const maps = new Set(
+    zones.reduce<number[]>((maps, zone) => {
+      if (zone.dbSymbol === currentZone.dbSymbol) return maps;
+
+      maps.push(...zone.maps);
+      return maps;
+    }, [])
+  );
+  const mapDbSymbolsAssigned = mapDbSymbolsFromMapIds(Array.from(maps.values()));
+  const mapDbSymbolCurrentZone = mapDbSymbolsFromMapIds(currentZone.maps);
+  return mapOptions.reduce((options, currentOption) => {
+    const index = mapDbSymbolsAssigned.findIndex((mapDbSymbol) => mapDbSymbol === currentOption.value);
+    if (index === -1 || mapDbSymbolCurrentZone.includes(currentOption.value)) return [...options, currentOption];
+
+    return options;
+  }, [] as SelectOption<DbSymbol>[]);
+};
+
 export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation();
-  const { zone } = useZonePage();
+  const { zone, state } = useZonePage();
   const updateZone = useUpdateZone(zone);
   const forcedWeatherRef = useRef<string | undefined>();
   const panelIdRef = useRef<HTMLInputElement>(null);
   const weatherOptions = useMemo(() => weatherCategoryEntries(t), [t]);
-  const [maps, setMaps] = useState<number[]>(cloneEntity(zone.maps));
-  const [errorNewMap, setErrorNewMap] = useState<number | false>(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
-    if (inputRef.current && inputRef.current.validity.valid && event.key === 'Enter') {
-      const target = event.target as HTMLInputElement;
-      const mapIds = target.value
-        .split(',')
-        .filter((v) => v.trim().length !== 0)
-        .map((v) => Number(v))
-        .filter((v, i, a) => i === a.indexOf(v));
-      const errorMapId = mapIds.find((mapId) => maps.includes(mapId));
-      if (errorMapId !== undefined) {
-        setErrorNewMap(errorMapId);
-        return;
-      }
-
-      inputRef.current.value = '';
-      if (errorNewMap !== false) setErrorNewMap(false);
-      setMaps(maps.concat(mapIds));
-    }
-  };
-
-  const onDeleteMap = (index: number) => {
-    const mapsEdited = cloneEntity(maps);
-    mapsEdited.splice(index, 1);
-    setMaps(mapsEdited);
-  };
+  const [maps, setMaps] = useState<DbSymbol[]>(mapDbSymbolsFromMapIds(zone.maps));
+  const defaultMapOptions = useSelectOptions('maps') as SelectOption<DbSymbol>[];
+  const mapOptions = useMemo(() => filterMapsAlreadyAssignedInZones(defaultMapOptions, state.projectData.zones, zone), []);
 
   const canClose = () => {
     const result = !!panelIdRef?.current?.validity.valid;
@@ -104,7 +69,7 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
     updateZone({
       forcedWeather,
       panelId: panelIdRef.current.valueAsNumber,
-      maps,
+      maps: mapIdsFromMapDbSymbols(maps, state.projectData.maps),
     });
   };
 
@@ -113,22 +78,10 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   return (
     <Editor type="edit" title={t('settings')}>
       <InputContainer>
-        <InputMapsListContainer>
+        <InputWithTopLabelContainer>
           <Label htmlFor="map">{t('maps_list')}</Label>
-          <InputMapWithErrorContainer>
-            <Input type="text" name="map" pattern="[0-9]{1,5} *(?:, *[0-9]{0,5} *)*" ref={inputRef} onKeyDown={handleKeyDown} />
-            {errorNewMap !== false && <TextInputError>{t('map_already_exists', { mapId: padStr(errorNewMap, 2) })}</TextInputError>}
-          </InputMapWithErrorContainer>
-          <MapsListContainer>
-            {maps
-              .sort((a, b) => a - b)
-              .map((id, index) => (
-                <TagWithDeletion key={index} index={index} onClickDelete={onDeleteMap}>
-                  <span className="map-id">{padStr(id, 2)}</span>
-                </TagWithDeletion>
-              ))}
-          </MapsListContainer>
-        </InputMapsListContainer>
+          <MultiSelect defaultValue={maps} onChange={setMaps} options={mapOptions} />
+        </InputWithTopLabelContainer>
         <InputWithLeftLabelContainer>
           <Label htmlFor="panel-number">{t('panel_number')}</Label>
           <Input type="number" name="panel-number" min="0" max="99999" defaultValue={zone.panelId} ref={panelIdRef} />


### PR DESCRIPTION
## Description

This PR prevents that the user to add a map in the current zone if the map is already assigned to another zone.
If the user assigned a map to several zones in the past, it is the user's responsibility to fix those zones.

> [!NOTE]
> For the translation, "map_already_exists" key text needs an update for de, es, it and pt.

Closes #532 

## Tests to perform

- [x] The user can assign a map to a zone
- [x] The user can not assign a map to a zone if the map already exists in this zone
- [x] The user can not assign a map to a zone if the map already exists in those zones
