### PR TITLE
Fix the editor overlay position on Linux and MacOS

### DIFF
--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -99,7 +99,7 @@ const animationOption = {
   easing: 'ease-in',
 } as const;
 
-const DIALOG_TOP_OFFSET = '26px';
+const DIALOG_TOP_OFFSET = window.api.platform === 'win32' ? '26px' : '0px';
 const DIALOG_TRANSFORM_RIGHT = 'translateX(-100%)';
 const DIALOG_TRANSFORM_CENTER = 'translate(0%, -50%)';
 const DIALOG_TOP_PERCENTAGE = '10%';


### PR DESCRIPTION
## Description

This PR fixes the editor overlay position on Linux and MacOS.

## Tests to perform

- [x] The editor overlay position is correct

## Screenshot

![image](https://github.com/user-attachments/assets/352ed4c8-545f-4dab-ae6a-365657afda96)
