### PR TITLE
Fix app crash when adding a group to zone while having only one group in the project

### DIFF
--- a/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
@@ -62,12 +62,22 @@ export const ZoneAddGroupEditor = forwardRef<EditorHandlingClose, ZoneAddGroupEd
   const { zone, groups } = useZonePage();
   const updateZone = useUpdateZone(zone);
 
-  const firstDbSymbol = Object.entries(groups)
-    .map(([value, groupData]) => ({ value, index: groupData.id }))
-    .filter((data) => !zone.wildGroups.includes(data.value as DbSymbol))
-    .sort((a, b) => a.index - b.index)[0].value;
+  const firstDbSymbol = () => {
+    const firstUnusedGroup = Object.entries(groups)
+      .map(([value, groupData]) => ({ value, index: groupData.id }))
+      .filter((data) => !zone.wildGroups.includes(data.value as DbSymbol))
+      .sort((a, b) => a.index - b.index)[0];
 
-  const [group, setGroup] = useState<StudioGroup>(setAllTagsMapsOnByDefault(cloneEntity(groups[firstDbSymbol]), zone));
+    if (firstUnusedGroup) {
+      return firstUnusedGroup.value;
+    } else {
+      return Object.entries(groups)
+        .map(([value, groupData]) => ({ value, index: groupData.id }))
+        .sort((a, b) => a.index - b.index)[0].value;
+    }
+  };
+
+  const [group, setGroup] = useState<StudioGroup>(setAllTagsMapsOnByDefault(cloneEntity(groups[firstDbSymbol()]), zone));
   const updateGroup = useUpdateGroup(group);
 
   const onChange = (dbSymbol: string) => {


### PR DESCRIPTION
## Description

This PR fixes an issue where the app would crash when you have only one Group in your project and you try to add it to a Zone.

## Note before testing

Create a new project and delete all groups except the last one. Open the Zones database page.

## Tests to perform

- [x] Try to add your only group to a Zone, the app should not crash.
- [x] After successfully adding the group, the "Add group" button should be disabled.
