### PR TITLE
Fix the InputContainerCollapse with the zod forms

### DIFF
--- a/src/views/components/inputs/InputContainerCollapse.tsx
+++ b/src/views/components/inputs/InputContainerCollapse.tsx
@@ -92,7 +92,7 @@ type CollapseGroupChildrenProps = {
 };
 
 const CollapseGroupChildren = styled.div<CollapseGroupChildrenProps>`
-  display: flex;
+  display: ${({ collapse }) => (collapse ? 'flex' : 'none')};
   flex-direction: column;
   gap: ${({ gap }) => gap || '12px'};
   margin-bottom: ${({ collapse, noMargin }) => (collapse && !noMargin ? '16px' : '0')};
@@ -125,11 +125,9 @@ export const InputGroupCollapse: FunctionComponent<InputGroupCollapseProps> = ({
   return (
     <InputGroupCollapseContainer>
       <CollapseGroupTitle title={title} collapse={collapse} onClick={onClickedCollapse} onDelete={onDelete} />
-      {collapse && (
-        <CollapseGroupChildren gap={gap} noMargin={noMargin || false} collapse={collapse}>
-          {children}
-        </CollapseGroupChildren>
-      )}
+      <CollapseGroupChildren gap={gap} noMargin={noMargin || false} collapse={collapse}>
+        {children}
+      </CollapseGroupChildren>
     </InputGroupCollapseContainer>
   );
 };


### PR DESCRIPTION
## Description

The issue has been reported here: https://github.com/PokemonWorkshop/PokemonStudio/issues/550

The InputContainerCollapse was not implemented correctly to work with zod forms, because you simply need to hide the information (with css rules), not ‘delete’ it. The validator does not allow an editor to be closed if mandatory elements are missing.

The fix simply consisted of hiding the elements.

The fix has no impact if zod form is not used.

Closes #550

## Tests to perform

- [x] Navigate to the Database section.
- [x] Open the Stats panel.
- [x] Toggle one of the dropdowns inside the aside.
- [x] Attempt to click outside the aside to close it, the editor should be closed