### PR TITLE
Fix some i18n keys that were not displayed correctly

### DIFF
--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -71,7 +71,7 @@
   "statistics": "Statistiques",
   "form": "Forme",
   "movepool": "Movepool",
-  "undefined": "Non défini",
+  "undefined": "Non définie",
   "character": "Characters",
   "characters": "Characters",
   "condition": "Condition :",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,7 +21,7 @@ const activeLanguages = Object.entries(languages)
   .filter(([_, isActive]) => isActive)
   .map(([lang]) => lang);
 
-const context = import.meta.glob('../assets/i18n/*.json', { eager: true });
+const context = import.meta.glob<{ default: TranslationSchema }>('../assets/i18n/*.json', { eager: true });
 
 const resources: Record<string, { translation: Record<string, string> }> = {};
 
@@ -33,7 +33,7 @@ Object.keys(context).forEach((key) => {
 
   if (!activeLanguages.includes(lang)) return;
 
-  const translation = context[key];
+  const translation = context[key].default;
   resources[lang] = { translation: translation as TranslationSchema };
 });
 


### PR DESCRIPTION
## Description

This PR fixes an issue with some i18n keys (`undefined`, `weather-1`, `gender-1`)

Closes #552

## Tests to perform

- [x] The translations show correctly

# Screenshots (before fix)

<img width="278" height="223" alt="Image" src="https://github.com/user-attachments/assets/1757d96f-8d07-4cbe-b146-68e2a4e31193" />

<img width="1391" height="467" alt="Image" src="https://github.com/user-attachments/assets/52cd9838-ad12-441e-9ad3-c3ec58d0ae38" />

