### PR TITLE
Fix showndown format import

### DIFF
--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -77,7 +77,7 @@ const buildExpandPokemonSetup = (set: PokemonSet, from: string) => {
 };
 
 const extractBaseName = (name: string): string => {
-  const exceptions = ['Ho-Oh', 'Porygon-Z'];
+  const exceptions = ['Ho-Oh', 'Porygon-Z', 'Jangmo-o', 'Hakamo-o', 'Kommo-o', 'Chi-Yu', 'Ting-Lu', 'Wo-Chien', 'Chien-Pao'];
   if (exceptions.includes(name)) return name;
 
   const index = name.indexOf('-');
@@ -86,7 +86,12 @@ const extractBaseName = (name: string): string => {
   return name.substring(0, index);
 };
 
-const convertToDbSymbol = (str: string | undefined): DbSymbol => str?.toLowerCase().replace(/[\s-]+/g, '_') as DbSymbol;
+const convertToDbSymbol = (str: string | undefined): DbSymbol =>
+  str
+    ?.toLowerCase()
+    .normalize('NFD') //Remove accents
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\s-’'\\.:]+/g, '_') as DbSymbol;
 
 const convertGender = (gender: string): 0 | 1 | 2 | -1 => {
   switch (gender) {

--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -89,7 +89,7 @@ const extractBaseName = (name: string): string => {
 const convertToDbSymbol = (str: string | undefined): DbSymbol =>
   str
     ?.toLowerCase()
-    .normalize('NFD') //Remove accents
+    .normalize('NFD') // Remove accents
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[\s-’'\\.:]+/g, '_') as DbSymbol;
 


### PR DESCRIPTION
## Description

This MR fixes the showndown import process not working in some specific cases.

The array containing Pokémon that have an hyphen '-' in their name has been completed to avoid false positives on alternative forms.

The conversion to DbSymbol from a string has been completed to include usual special characters like ', : or .
The conversion also includes a normalization to remove accents from letters.

## Note before testing

Here's a template to test different cases on:

```
POKEMON_NAME
Ability: Overgrow
- King's Shield
- Land's Wrath
```

## Tests to perform

- [x] Test the import process with Pokémon without special characters in their name, the importation still works correctly
- [x] Test the import process with Pokémon with special characters in their name, the importation works correctly (examples: Jangmo-o, Ho-oh, Type: Null, Farfetch'd, Mr. Mime)
- [x] Test the import process with moves with special characters in their name, the importation works correctly (examples are included in the template above)
