### PR TITLE
Fix the migration adding the contest data to moves by removing a wrongly named file

### DIFF
--- a/src/migrations/addMoveContestData.ts
+++ b/src/migrations/addMoveContestData.ts
@@ -754,7 +754,7 @@ export const addMoveContestData = async (_: IpcMainEvent, projectPath: string) =
     return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/moves', `${newMove.dbSymbol}.json`), JSON.stringify(newMove, null, 2));
   }, Promise.resolve());
 
-  fsPromise.rm(path.join(projectPath, 'Data/Studio/moves/kotow_cleave.json')); // Remove wrongly named file coming from Gen 9 datapack
+  await fsPromise.rm(path.join(projectPath, 'Data/Studio/moves/kotow_cleave.json')); // Remove wrongly named file coming from Gen 9 datapack
 
   saveCSV(path.join(csvPath, `${MOVE_CONTEST_DESCRIPTION_TEXT_ID}.csv`), descriptionTexts);
 };

--- a/src/migrations/addMoveContestData.ts
+++ b/src/migrations/addMoveContestData.ts
@@ -754,7 +754,7 @@ export const addMoveContestData = async (_: IpcMainEvent, projectPath: string) =
     return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/moves', `${newMove.dbSymbol}.json`), JSON.stringify(newMove, null, 2));
   }, Promise.resolve());
 
-  fsPromise.rm(path.join(projectPath, 'Data/Studio/moves/kotow_cleave.json')); //Remove wrongly named file coming from Gen 9 datapack
+  fsPromise.rm(path.join(projectPath, 'Data/Studio/moves/kotow_cleave.json')); // Remove wrongly named file coming from Gen 9 datapack
 
   saveCSV(path.join(csvPath, `${MOVE_CONTEST_DESCRIPTION_TEXT_ID}.csv`), descriptionTexts);
 };

--- a/src/migrations/addMoveContestData.ts
+++ b/src/migrations/addMoveContestData.ts
@@ -754,5 +754,7 @@ export const addMoveContestData = async (_: IpcMainEvent, projectPath: string) =
     return fsPromise.writeFile(path.join(projectPath, 'Data/Studio/moves', `${newMove.dbSymbol}.json`), JSON.stringify(newMove, null, 2));
   }, Promise.resolve());
 
+  fsPromise.rm(path.join(projectPath, 'Data/Studio/moves/kotow_cleave.json')); //Remove wrongly named file coming from Gen 9 datapack
+
   saveCSV(path.join(csvPath, `${MOVE_CONTEST_DESCRIPTION_TEXT_ID}.csv`), descriptionTexts);
 };


### PR DESCRIPTION
## Description

This PR adds a line to the migration that adds the contest data to moves.
This was done to prevent a known issue with the Gen 9 datapack that contains a file named differently from the db_symbol it contains, effectively duplicating it during the migration and causing the project to not be able to load due to the old file not being compliant with the Zod format. 

Closes #650

## Note before testing

In a pre-2.7.0 project, create a file named `kotow_cleave` in your moves folder. Paste this content inside:
```json
{
  "klass": "Move",
  "id": 902,
  "dbSymbol": "kowtow_cleave",
  "mapUse": 0,
  "battleEngineMethod": "s_basic",
  "type": "dark",
  "power": 85,
  "accuracy": 0,
  "pp": 10,
  "category": "physical",
  "movecriticalRate": 1,
  "priority": 0,
  "isAuthentic": false,
  "isBallistics": false,
  "isBite": false,
  "isBlocable": true,
  "isCharge": false,
  "isDance": false,
  "isDirect": true,
  "isEffectChance": false,
  "isGravity": false,
  "isHeal": false,
  "isKingRockUtility": true,
  "isMagicCoatAffected": false,
  "isMental": false,
  "isMirrorMove": true,
  "isNonSkyBattle": false,
  "isPowder": false,
  "isPulse": false,
  "isPunch": false,
  "isRecharge": false,
  "isSnatchable": false,
  "isSoundAttack": false,
  "isSlicingAttack": true,
  "isUnfreeze": false,
  "isWind": false,
  "battleEngineAimedTarget": "adjacent_pokemon",
  "battleStageMod": [],
  "moveStatus": [],
  "effectChance": 0,
}
```

- Note the difference between the db_symbol and the file name (kotow/kowtow)

## Tests to perform

- [x] Try loading the project, the migration should work and the project should load
- [x] The old file named `kotow_cleave.json` has been removed
- [x] The new file named `kowtow_cleave.json` has been correctly created
- [x] Launching the migration on a project that does not contain this file works correctly
