### PR TITLE
Users are now able to launch PSDK games from Studio even if there is some special characters in the path

### DIFF
--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -9,14 +9,16 @@ export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, s
   if (process.platform === 'win32') {
     return ['cmd.exe', ['/c', 'psdk.bat', ...args]];
   } else if (process.platform === 'linux') {
-    const linuxArgs = ['-e', `./game-linux.sh ${args.join(' ')}`];
     if (existsSync('/usr/bin/gnome-terminal')) {
-      return ['gnome-terminal', linuxArgs];
+      return ['gnome-terminal', ['--', './game-linux.sh', ...args]];
     }
     if (existsSync('/usr/bin/konsole')) {
-      return ['konsole', linuxArgs];
+      return ['konsole', ['-e', './game-linux.sh', ...args]];
     }
-    log.info('No terminal found. The PSDK console will not be displayed.');
+    if (existsSync('/usr/bin/xterm')) {
+      return ['xterm', ['-e', `bash -c "./game-linux.sh ${args.join(' ')}; exec bash"`]];
+    }
+    log.warn('No terminal found. The PSDK console will not be displayed.');
     return ['./game-linux.sh', args];
   } else if (process.platform === 'darwin') {
     return ['./game-mac.sh', args];

--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -1,28 +1,46 @@
 import { spawn } from 'child_process';
 import path from 'path';
 import { generateGameLinuxFileContent, generateGameMacFileContent, generatePSDKBatFileContent } from '@services/generatePSDKBatFileContent';
-import { writeFileSync, existsSync, readFileSync, chmodSync } from 'fs';
+import { writeFileSync, existsSync, readFileSync, chmodSync, unlinkSync } from 'fs';
 import { getPSDKBinariesPath } from '@services/getPSDKVersion';
+import { tmpdir } from 'os';
 import log from 'electron-log';
 
-export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, string[]] => {
+const hasSpecialChars = (str: string) => /[&^%]/.test(str);
+
+export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, string[], string | null] => {
   if (process.platform === 'win32') {
-    return ['cmd.exe', ['/c', `"${projectPath}/psdk.bat" ${args.join(' ')}`]];
+    const batPath = path.join(projectPath, 'psdk.bat');
+    const argsStr = args.join(' ');
+
+    // If special characters are detected, use temporary file approach
+    if (hasSpecialChars(batPath)) {
+      const tempBatPath = path.join(tmpdir(), `psdk_launcher_${Date.now()}.bat`);
+
+      const tempBatContent = `@echo off
+cd /d "${projectPath}"
+call "${batPath}" ${argsStr}`;
+
+      writeFileSync(tempBatPath, tempBatContent);
+      return ['cmd.exe', ['/c', `"${tempBatPath}"`], tempBatPath];
+    } else {
+      // Normal path without special characters
+      return ['cmd.exe', ['/c', `"${batPath}" ${argsStr}`], null];
+    }
   } else if (process.platform === 'linux') {
     const linuxArgs = ['-e', `"${projectPath.replaceAll(' ', '\\ ')}/game-linux.sh ${args.join(' ')}"`];
     if (existsSync('/usr/bin/gnome-terminal')) {
-      return ['gnome-terminal', linuxArgs];
+      return ['gnome-terminal', linuxArgs, null];
     }
     if (existsSync('/usr/bin/konsole')) {
-      return ['konsole', linuxArgs];
+      return ['konsole', linuxArgs, null];
     }
     log.info('No terminal found. The PSDK console will not be displayed.');
-    return ['./game-linux.sh', args];
+    return ['./game-linux.sh', args, null];
   } else if (process.platform === 'darwin') {
-    // TODO: figure out how to display the console :v
-    return ['./game-mac.sh', args];
+    return ['./game-mac.sh', args, null];
   } else {
-    return ['./game.rb', args];
+    return ['./game.rb', args, null];
   }
 };
 
@@ -31,6 +49,7 @@ const bootLoadFilename = () => {
   if (process.platform === 'linux') return 'game-linux.sh';
   return 'psdk.bat';
 };
+
 const generateBootLoadContent = (projectPath: string) => {
   if (process.platform === 'darwin') return generateGameMacFileContent(projectPath);
   if (process.platform === 'linux') return generateGameLinuxFileContent(projectPath);
@@ -62,11 +81,37 @@ const canLaunchPSDK = () => {
   return false;
 };
 
+const cleanUpTempFile = (tempFile: string) => {
+  try {
+    if (existsSync(tempFile)) {
+      unlinkSync(tempFile);
+      log.info('Cleaned up temp launcher:', tempFile);
+    }
+  } catch (err) {
+    log.error('Failed to delete temp launcher:', err);
+  }
+};
+
 export const startPSDK = (projectPath: string) => {
   if (!canLaunchPSDK()) return;
 
   RMXP2StudioSafetyNet(projectPath);
-  const childProcess = spawn(...getSpawnArgs(projectPath), { cwd: projectPath, shell: true, detached: true, stdio: 'ignore' });
+  const [command, spawnArgs, tempFile] = getSpawnArgs(projectPath);
+
+  const childProcess = spawn(command, spawnArgs, {
+    cwd: projectPath,
+    shell: true,
+    detached: true,
+    stdio: 'ignore',
+  });
+
+  // Clean up temp file after process starts (if one was created)
+  if (tempFile) {
+    childProcess.on('spawn', () => {
+      setTimeout(() => cleanUpTempFile(tempFile), 1000);
+    });
+  }
+
   childProcess.unref();
 };
 
@@ -74,7 +119,20 @@ const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
   if (!canLaunchPSDK()) return;
 
   RMXP2StudioSafetyNet(projectPath);
-  const childProcess = spawn(...getSpawnArgs(projectPath, ...args), { cwd: projectPath, shell: true, detached: true, stdio: 'ignore' });
+  const [command, spawnArgs, tempFile] = getSpawnArgs(projectPath, ...args);
+
+  const childProcess = spawn(command, spawnArgs, {
+    cwd: projectPath,
+    shell: true,
+    detached: true,
+    stdio: 'ignore',
+  });
+  // Clean up temp file after process starts (if one was created)
+  if (tempFile) {
+    childProcess.on('spawn', () => {
+      setTimeout(() => cleanUpTempFile(tempFile), 1000);
+    });
+  }
   childProcess.unref();
 };
 

--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -1,46 +1,27 @@
 import { spawn } from 'child_process';
 import path from 'path';
 import { generateGameLinuxFileContent, generateGameMacFileContent, generatePSDKBatFileContent } from '@services/generatePSDKBatFileContent';
-import { writeFileSync, existsSync, readFileSync, chmodSync, unlinkSync } from 'fs';
+import { writeFileSync, existsSync, readFileSync, chmodSync } from 'fs';
 import { getPSDKBinariesPath } from '@services/getPSDKVersion';
-import { tmpdir } from 'os';
 import log from 'electron-log';
 
-const hasSpecialChars = (str: string) => /[&^%]/.test(str);
-
-export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, string[], string | null] => {
+export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, string[]] => {
   if (process.platform === 'win32') {
-    const batPath = path.join(projectPath, 'psdk.bat');
-    const argsStr = args.join(' ');
-
-    // If special characters are detected, use temporary file approach
-    if (hasSpecialChars(batPath)) {
-      const tempBatPath = path.join(tmpdir(), `psdk_launcher_${Date.now()}.bat`);
-
-      const tempBatContent = `@echo off
-cd /d "${projectPath}"
-call "${batPath}" ${argsStr}`;
-
-      writeFileSync(tempBatPath, tempBatContent);
-      return ['cmd.exe', ['/c', `"${tempBatPath}"`], tempBatPath];
-    } else {
-      // Normal path without special characters
-      return ['cmd.exe', ['/c', `"${batPath}" ${argsStr}`], null];
-    }
+    return ['cmd.exe', ['/c', 'psdk.bat', ...args]];
   } else if (process.platform === 'linux') {
-    const linuxArgs = ['-e', `"${projectPath.replaceAll(' ', '\\ ')}/game-linux.sh ${args.join(' ')}"`];
+    const linuxArgs = ['-e', `./game-linux.sh ${args.join(' ')}`];
     if (existsSync('/usr/bin/gnome-terminal')) {
-      return ['gnome-terminal', linuxArgs, null];
+      return ['gnome-terminal', linuxArgs];
     }
     if (existsSync('/usr/bin/konsole')) {
-      return ['konsole', linuxArgs, null];
+      return ['konsole', linuxArgs];
     }
     log.info('No terminal found. The PSDK console will not be displayed.');
-    return ['./game-linux.sh', args, null];
+    return ['./game-linux.sh', args];
   } else if (process.platform === 'darwin') {
-    return ['./game-mac.sh', args, null];
+    return ['./game-mac.sh', args];
   } else {
-    return ['./game.rb', args, null];
+    return ['./game.rb', args];
   }
 };
 
@@ -81,59 +62,52 @@ const canLaunchPSDK = () => {
   return false;
 };
 
-const cleanUpTempFile = (tempFile: string) => {
-  try {
-    if (existsSync(tempFile)) {
-      unlinkSync(tempFile);
-      log.info('Cleaned up temp launcher:', tempFile);
-    }
-  } catch (err) {
-    log.error('Failed to delete temp launcher:', err);
-  }
-};
-
 export const startPSDK = (projectPath: string) => {
   if (!canLaunchPSDK()) return;
 
   RMXP2StudioSafetyNet(projectPath);
-  const [command, spawnArgs, tempFile] = getSpawnArgs(projectPath);
 
-  const childProcess = spawn(command, spawnArgs, {
-    cwd: projectPath,
-    shell: true,
-    detached: true,
-    stdio: 'ignore',
-  });
+  const studioPath = process.cwd();
+  try {
+    process.chdir(projectPath);
 
-  // Clean up temp file after process starts (if one was created)
-  if (tempFile) {
-    childProcess.on('spawn', () => {
-      setTimeout(() => cleanUpTempFile(tempFile), 1000);
+    const [command, spawnArgs] = getSpawnArgs(projectPath);
+
+    const childProcess = spawn(command, spawnArgs, {
+      cwd: projectPath,
+      shell: true,
+      detached: true,
+      stdio: 'ignore',
     });
-  }
 
-  childProcess.unref();
+    childProcess.unref();
+  } finally {
+    process.chdir(studioPath);
+  }
 };
 
 const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
   if (!canLaunchPSDK()) return;
 
   RMXP2StudioSafetyNet(projectPath);
-  const [command, spawnArgs, tempFile] = getSpawnArgs(projectPath, ...args);
 
-  const childProcess = spawn(command, spawnArgs, {
-    cwd: projectPath,
-    shell: true,
-    detached: true,
-    stdio: 'ignore',
-  });
-  // Clean up temp file after process starts (if one was created)
-  if (tempFile) {
-    childProcess.on('spawn', () => {
-      setTimeout(() => cleanUpTempFile(tempFile), 1000);
+  const studioPath = process.cwd();
+  try {
+    process.chdir(projectPath);
+
+    const [command, spawnArgs] = getSpawnArgs(projectPath, ...args);
+
+    const childProcess = spawn(command, spawnArgs, {
+      cwd: projectPath,
+      shell: true,
+      detached: true,
+      stdio: 'ignore',
     });
+
+    childProcess.unref();
+  } finally {
+    process.chdir(studioPath);
   }
-  childProcess.unref();
 };
 
 export const startPSDKDebug = (projectPath: string) => startPSDKWithArgs(projectPath, 'debug');


### PR DESCRIPTION
## Description

Check if the project has a special characters and create a temporary file who lauch PSDK, thats the only one solutions who works for me after testing a lot with others command with the shell.

## Steps to reproduce the behavior:

Create a project with the character & in the name or in the path
Try to launcher PSDK with Studio
PSDK does not launch

[<!-- Explain all the scenario the tester has to test. -->](https://github.com/PokemonWorkshop/PokemonStudio/issues/649)
