### PR TITLE
Fix a Tech Items table page crash when a deleted move was linked to a Tech Item

### DIFF
--- a/src/views/components/database/item/TechItemsTable.tsx
+++ b/src/views/components/database/item/TechItemsTable.tsx
@@ -68,7 +68,7 @@ const RenderTechItem = ({ item, state }: RenderTechItemProps) => {
         />
       </span>
       <span></span>
-      {techItemMove !== '__undef__' ? (
+      {techItemMove !== '__undef__' && move.type ? (
         <>
           <TypeCategory type={move.type}>{getTypeName(state.projectData.types[move.type])}</TypeCategory>
           <MoveCategory category={move.category}>{t(move.category)}</MoveCategory>


### PR DESCRIPTION
## Description

This PR fixes a crash happening when a deleted move was still linked to a Tech Item.
It was happening because of a failed fetch of a text (the move's type).

closes #673

## Note before testing

Delete a move that is linked to a Tech Item from your database.

## Tests to perform

- [x] Open the Tech Items table page and scroll to see the item linked to the move you deleted, the app does not crash
