### PR TITLE
Fix a text field in the Zones page that was allowing null values

### DIFF
--- a/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneSettingsEditor.tsx
@@ -14,6 +14,7 @@ import type { StudioZone, StudioZoneForcedWeather } from '@modelEntities/zone';
 import { padStr } from '@utils/PadStr';
 import { cloneEntity } from '@utils/cloneEntity';
 import { ProjectData } from '@src/GlobalStateProvider';
+import { cleanNaNValue } from '@root/src/utils/cleanNaNValue';
 
 const InputMapsListContainer = styled(InputWithTopLabelContainer)`
   gap: 16px;
@@ -115,7 +116,7 @@ export const ZoneSettingsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
     updateZone({
       forcedWeather,
-      panelId: panelIdRef.current.valueAsNumber,
+      panelId: cleanNaNValue(panelIdRef.current.valueAsNumber, 0),
       maps,
     });
   };


### PR DESCRIPTION
## Description

This PR fixes the text field for choosing the PanelId of a Zone that was not preventing the editor from closing if it had no value, resulting in a null value in the JSON file and causing the project to fail loading.

[Link to the topix that highlighted this issue](https://discord.com/channels/143824995867557888/1429459009957793943)

## Tests to perform

- [x] Open a zone's page and open the Settings editor, remove the value in the `Panel number` field and close the editor, the value 0 is automatically set to avoid a null
