### PR TITLE
Fix quests custom goals text being set to the same ID when created by importing existing data

### DIFF
--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -5,9 +5,8 @@ import { cloneEntity } from './cloneEntity';
 import { findFirstAvailableFormTextId, findFirstAvailableCustomObjectiveTextId } from './ModelUtils';
 import { ProjectData } from '@src/GlobalStateProvider';
 import { StudioItem } from '@modelEntities/item';
-import { StudioQuest } from '@modelEntities/quest';
+import { StudioQuest, StudioQuestObjective } from '@modelEntities/quest';
 import { StudioGroup } from '@modelEntities/group';
-import { object } from 'zod/dist/types';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -49,9 +48,9 @@ export const importCreatureData = (creature: StudioCreature, dataToImport: Studi
   const newAllPokemon = {
     ...allPokemon,
     [newCreature.dbSymbol]: newCreature,
-  }; //To avoid getting same text IDs for other forms
+  }; // To avoid getting same text IDs for other forms
 
-  //Update form text IDs
+  // Update form text IDs
   newCreature.forms.slice(1).forEach((form) => {
     const formTextIdName = findFirstAvailableFormTextId(newAllPokemon, 0, 'name');
     const formTextIdDescription = findFirstAvailableFormTextId(newAllPokemon, 0, 'description');
@@ -85,7 +84,34 @@ export const importQuestData = (quest: StudioQuest, dataToImport: StudioQuest, a
   const newAllQuests = {
     ...allQuests,
     [newQuest.dbSymbol]: newQuest,
-  }; //To avoid getting same text IDs for custom objectives
+  }; // To avoid getting same text IDs for custom objectives
+
+  newQuest.objectives.forEach((objective) => {
+    if (objective.objectiveMethodName === 'objective_custom') {
+      const customTextId = findFirstAvailableCustomObjectiveTextId(newAllQuests, 0);
+      objective.objectiveMethodArgs[1] = customTextId;
+    }
+  });
+
+  return newQuest;
+};
+
+export const importQuestObjectivesData = (
+  quest: StudioQuest,
+  dataToImport: StudioQuestObjective[],
+  allQuests: ProjectData['quests']
+): StudioQuest => {
+  const cloneData = cloneEntity(dataToImport);
+
+  const newQuest = {
+    ...quest,
+    objectives: cloneData,
+  };
+
+  const newAllQuests = {
+    ...allQuests,
+    [newQuest.dbSymbol]: newQuest,
+  }; // To avoid getting same text IDs for custom objectives
 
   newQuest.objectives.forEach((objective) => {
     if (objective.objectiveMethodName === 'objective_custom') {

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -81,17 +81,7 @@ export const importQuestData = (quest: StudioQuest, dataToImport: StudioQuest, a
     earnings: cloneData.earnings,
   };
 
-  const newAllQuests = {
-    ...allQuests,
-    [newQuest.dbSymbol]: newQuest,
-  }; // To avoid getting same text IDs for custom objectives
-
-  newQuest.objectives.forEach((objective) => {
-    if (objective.objectiveMethodName === 'objective_custom') {
-      const customTextId = findFirstAvailableCustomObjectiveTextId(newAllQuests, 0);
-      objective.objectiveMethodArgs[1] = customTextId;
-    }
-  });
+  redetermineCustomGoalsId(newQuest, allQuests);
 
   return newQuest;
 };
@@ -108,19 +98,23 @@ export const importQuestObjectivesData = (
     objectives: cloneData,
   };
 
+  redetermineCustomGoalsId(newQuest, allQuests);
+
+  return newQuest;
+};
+
+const redetermineCustomGoalsId = (quest: StudioQuest, allQuests: ProjectData['quests']) => {
   const newAllQuests = {
     ...allQuests,
-    [newQuest.dbSymbol]: newQuest,
+    [quest.dbSymbol]: quest,
   }; // To avoid getting same text IDs for custom objectives
 
-  newQuest.objectives.forEach((objective) => {
+  quest.objectives.forEach((objective) => {
     if (objective.objectiveMethodName === 'objective_custom') {
       const customTextId = findFirstAvailableCustomObjectiveTextId(newAllQuests, 0);
       objective.objectiveMethodArgs[1] = customTextId;
     }
   });
-
-  return newQuest;
 };
 
 export const importGroupData = (group: StudioGroup, dataToImport: StudioGroup): StudioGroup => {

--- a/src/utils/importEntityDataUtils.ts
+++ b/src/utils/importEntityDataUtils.ts
@@ -2,11 +2,12 @@ import { StudioTrainer } from '@modelEntities/trainer';
 import { StudioMove } from '@modelEntities/move';
 import { StudioCreature } from '@modelEntities/creature';
 import { cloneEntity } from './cloneEntity';
-import { findFirstAvailableFormTextId } from './ModelUtils';
+import { findFirstAvailableFormTextId, findFirstAvailableCustomObjectiveTextId } from './ModelUtils';
 import { ProjectData } from '@src/GlobalStateProvider';
 import { StudioItem } from '@modelEntities/item';
 import { StudioQuest } from '@modelEntities/quest';
 import { StudioGroup } from '@modelEntities/group';
+import { object } from 'zod/dist/types';
 
 export const importTrainerData = (trainer: StudioTrainer, dataToImport: StudioTrainer): StudioTrainer => {
   const cloneData = cloneEntity(dataToImport);
@@ -71,15 +72,29 @@ export const importItemData = (item: StudioItem, dataToImport: StudioItem): Stud
   };
 };
 
-export const importQuestData = (quest: StudioQuest, dataToImport: StudioQuest): StudioQuest => {
+export const importQuestData = (quest: StudioQuest, dataToImport: StudioQuest, allQuests: ProjectData['quests']): StudioQuest => {
   const cloneData = cloneEntity(dataToImport);
 
-  return {
-    ...cloneData,
-    id: quest.id,
-    dbSymbol: quest.dbSymbol,
-    isPrimary: quest.isPrimary,
+  const newQuest = {
+    ...quest,
+    resolution: cloneData.resolution,
+    objectives: cloneData.objectives,
+    earnings: cloneData.earnings,
   };
+
+  const newAllQuests = {
+    ...allQuests,
+    [newQuest.dbSymbol]: newQuest,
+  }; //To avoid getting same text IDs for custom objectives
+
+  newQuest.objectives.forEach((objective) => {
+    if (objective.objectiveMethodName === 'objective_custom') {
+      const customTextId = findFirstAvailableCustomObjectiveTextId(newAllQuests, 0);
+      objective.objectiveMethodArgs[1] = customTextId;
+    }
+  });
+
+  return newQuest;
 };
 
 export const importGroupData = (group: StudioGroup, dataToImport: StudioGroup): StudioGroup => {

--- a/src/views/components/database/quest/editors/QuestGoalImportEditor.tsx
+++ b/src/views/components/database/quest/editors/QuestGoalImportEditor.tsx
@@ -9,6 +9,9 @@ import { useQuestPage } from '@src/hooks/usePage';
 import { useUpdateQuest } from './useUpdateQuest';
 import styled from 'styled-components';
 import React, { forwardRef, useMemo, useRef, useState } from 'react';
+import { QUEST_CUSTOM_OBJECTIVE_TEXT_ID, updateIndexSpeakToBeatNpc } from '@root/src/models/entities/quest';
+import { importQuestObjectivesData } from '@root/src/utils/importEntityDataUtils';
+import { useSetProjectText, useGetProjectText } from '@root/src/utils/ReadingProjectText';
 
 const GoalImportInfo = styled.div`
   ${({ theme }) => theme.fonts.normalRegular};
@@ -30,6 +33,8 @@ type QuestGoalImportEditorProps = {
 export const QuestGoalImportEditor = forwardRef<EditorHandlingClose, QuestGoalImportEditorProps>(({ closeDialog }, ref) => {
   const { t } = useTranslation();
   const { quests, quest } = useQuestPage();
+  const setText = useSetProjectText();
+  const getText = useGetProjectText();
   const updateQuest = useUpdateQuest(quest);
   const firstDbSymbol = useMemo(
     () =>
@@ -47,8 +52,27 @@ export const QuestGoalImportEditor = forwardRef<EditorHandlingClose, QuestGoalIm
   const onClickImport = () => {
     if (!overrideRef.current) return;
 
-    if (overrideRef.current.checked) updateQuest({ objectives: cloneEntity(quests[selectedQuest].objectives) });
-    else updateQuest({ objectives: [...quest.objectives, ...cloneEntity(quests[selectedQuest].objectives)] });
+    const objectives = overrideRef.current.checked
+      ? cloneEntity(quests[selectedQuest].objectives)
+      : [...quest.objectives, ...cloneEntity(quests[selectedQuest].objectives)];
+
+    const updatedQuest = importQuestObjectivesData(quest, objectives, quests);
+
+    // Copy custom objectives texts
+    let objectiveCpt = 0;
+    updatedQuest.objectives.forEach((objective) => {
+      if (objective.objectiveMethodName === 'objective_custom') {
+        setText(
+          QUEST_CUSTOM_OBJECTIVE_TEXT_ID,
+          objective.objectiveMethodArgs[1] as number,
+          getText(QUEST_CUSTOM_OBJECTIVE_TEXT_ID, objectives[objectiveCpt].objectiveMethodArgs[1] as number)
+        );
+      }
+      objectiveCpt++;
+    });
+
+    updateIndexSpeakToBeatNpc(updatedQuest.objectives);
+    updateQuest(updatedQuest);
     closeDialog();
   };
 

--- a/src/views/components/database/quest/editors/QuestNewEditor.tsx
+++ b/src/views/components/database/quest/editors/QuestNewEditor.tsx
@@ -4,8 +4,14 @@ import { TFunction } from 'i18next';
 import { Input, InputContainer, InputWithTopLabelContainer, Label, MultiLineInput } from '@components/inputs';
 import { useProjectQuests } from '@hooks/useProjectData';
 import { DarkButton, PrimaryButton } from '@components/buttons';
-import { QUEST_CATEGORIES, QUEST_DESCRIPTION_TEXT_ID, QUEST_NAME_TEXT_ID, QUEST_RESOLUTIONS } from '@modelEntities/quest';
-import { useSetProjectText } from '@utils/ReadingProjectText';
+import {
+  QUEST_CATEGORIES,
+  QUEST_CUSTOM_OBJECTIVE_TEXT_ID,
+  QUEST_DESCRIPTION_TEXT_ID,
+  QUEST_NAME_TEXT_ID,
+  QUEST_RESOLUTIONS,
+} from '@modelEntities/quest';
+import { useGetProjectText, useSetProjectText } from '@utils/ReadingProjectText';
 import { createQuest } from '@utils/entityCreation';
 import { TooltipWrapper } from '@ds/Tooltip';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
@@ -47,6 +53,7 @@ export const QuestNewEditor = forwardRef<EditorHandlingClose, QuestNewEditorProp
   const { projectDataValues: quests, setProjectDataValues: setQuest } = useProjectQuests();
   const { t } = useTranslation();
   const setText = useSetProjectText();
+  const getText = useGetProjectText();
   const categoryOptions = useMemo(() => questCategoryEntries(t), [t]);
   const resolutionOptions = useMemo(() => questResolutionEntries(t), [t]);
   const [name, setName] = useState(''); // We can't use a ref because of the button behavior
@@ -64,7 +71,20 @@ export const QuestNewEditor = forwardRef<EditorHandlingClose, QuestNewEditorProp
     let newQuest = createQuest(quests, categoryRef.current === 'primary', 'default');
 
     if (importing && selectedQuest !== '__undef__') {
-      newQuest = importQuestData(newQuest, quests[selectedQuest]);
+      newQuest = importQuestData(newQuest, quests[selectedQuest], quests);
+
+      //Copy custom objectives texts
+      let objectiveCpt = 0;
+      newQuest.objectives.forEach((objective) => {
+        if (objective.objectiveMethodName === 'objective_custom') {
+          setText(
+            QUEST_CUSTOM_OBJECTIVE_TEXT_ID,
+            objective.objectiveMethodArgs[1] as number,
+            getText(QUEST_CUSTOM_OBJECTIVE_TEXT_ID, quests[selectedQuest].objectives[objectiveCpt].objectiveMethodArgs[1] as number)
+          );
+        }
+        objectiveCpt++;
+      });
     }
 
     setText(QUEST_NAME_TEXT_ID, newQuest.id, name);

--- a/src/views/components/database/quest/editors/QuestNewEditor.tsx
+++ b/src/views/components/database/quest/editors/QuestNewEditor.tsx
@@ -73,7 +73,7 @@ export const QuestNewEditor = forwardRef<EditorHandlingClose, QuestNewEditorProp
     if (importing && selectedQuest !== '__undef__') {
       newQuest = importQuestData(newQuest, quests[selectedQuest], quests);
 
-      //Copy custom objectives texts
+      // Copy custom objectives texts
       let objectiveCpt = 0;
       newQuest.objectives.forEach((objective) => {
         if (objective.objectiveMethodName === 'objective_custom') {


### PR DESCRIPTION
## Description

This PR fixes two issues that are closely related. When custom goals are created via an importation method (whether by creating an entire quest with existing data, or only importing another quest's goals) the text IDs used by these goals were the same as the imported ones, creating conflicts.

closes #680 

## Note before testing

- [x] Have an existing quest in your database with one or more custom goals set.

## Tests to perform

- [x] Create a new quest using the "Other data" method, the copied custom goals have newly assigned IDs and the texts have been copied
- [x] In an existing quest, import goals from another quest, the copied custom goals have newly assigned IDs and the texts have been copied
