### PR TITLE
Users can now set negative values to a battle stage modifier of an Item

### DIFF
--- a/src/views/components/database/item/editors/ItemBattleDataEditor.tsx
+++ b/src/views/components/database/item/editors/ItemBattleDataEditor.tsx
@@ -52,7 +52,7 @@ export const ItemBattleDataEditor = forwardRef<EditorHandlingClose>((_, ref) => 
           </InputWithTopLabelContainer>
           <InputWithLeftLabelContainer>
             <Label htmlFor="value">{t('value')}</Label>
-            <Input type="number" defaultValue={item.count} ref={countRef} min="0" max="99" />
+            <Input type="number" defaultValue={item.count} ref={countRef} min="-99" max="99" />
           </InputWithLeftLabelContainer>
         </InputContainer>
       )}


### PR DESCRIPTION
## Description

This PR allows users to set a negative value to the battle stage modifier of an item, making it decrease a Creature's stat when used in battle.

closes #669 

## Tests to perform

- [x] Try to set a negative value to a battle stage modifier of an Item, the text field accepts it, the editor can be closed and the json is correctly updated after saving.
