### PR TITLE
Copy default sprites to female sprites when setting a Creature to 100% female

### DIFF
--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -36,7 +36,23 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       const { isGenderLess, ...data } = result.data;
       const femaleRate = isGenderLess ? -1 : data.femaleRate;
       const hasFemale = femaleRate <= 0 || femaleRate === 100 ? femaleRate === 100 : form.resources.hasFemale;
-      updateForm({ ...data, femaleRate, resources: { ...form.resources, hasFemale } });
+      let res = { ...form.resources, hasFemale };
+
+      if (femaleRate === 100) {
+        res = {
+          ...res,
+          iconF: res.iconF === undefined || res.iconF === '' ? res.icon : res.iconF,
+          iconShinyF: res.iconShinyF === undefined || res.iconShinyF === '' ? res.iconShiny : res.iconShinyF,
+          frontF: res.frontF === undefined || res.frontF === '' ? res.front : res.frontF,
+          frontShinyF: res.frontShinyF === undefined || res.frontShinyF === '' ? res.frontShiny : res.frontShinyF,
+          backF: res.backF === undefined || res.backF === '' ? res.back : res.backF,
+          backShinyF: res.backShinyF === undefined || res.backShinyF === '' ? res.backShiny : res.backShinyF,
+          characterF: res.characterF === undefined || res.characterF === '' ? res.character : res.characterF,
+          characterShinyF: res.characterShinyF === undefined || res.characterShinyF === '' ? res.characterShiny : res.characterShinyF,
+        };
+      }
+
+      updateForm({ ...data, femaleRate, resources: res });
     }
   };
   useEditorHandlingClose(ref, onClose, canClose);

--- a/src/views/components/database/pokemon/editors/EncounterEditor.tsx
+++ b/src/views/components/database/pokemon/editors/EncounterEditor.tsx
@@ -41,14 +41,14 @@ export const EncounterEditor = forwardRef<EditorHandlingClose>((_, ref) => {
       if (femaleRate === 100) {
         res = {
           ...res,
-          iconF: res.iconF === undefined || res.iconF === '' ? res.icon : res.iconF,
-          iconShinyF: res.iconShinyF === undefined || res.iconShinyF === '' ? res.iconShiny : res.iconShinyF,
-          frontF: res.frontF === undefined || res.frontF === '' ? res.front : res.frontF,
-          frontShinyF: res.frontShinyF === undefined || res.frontShinyF === '' ? res.frontShiny : res.frontShinyF,
-          backF: res.backF === undefined || res.backF === '' ? res.back : res.backF,
-          backShinyF: res.backShinyF === undefined || res.backShinyF === '' ? res.backShiny : res.backShinyF,
-          characterF: res.characterF === undefined || res.characterF === '' ? res.character : res.characterF,
-          characterShinyF: res.characterShinyF === undefined || res.characterShinyF === '' ? res.characterShiny : res.characterShinyF,
+          iconF: res.icon || res.iconF,
+          iconShinyF: res.iconShiny || res.iconShinyF,
+          frontF: res.front || res.frontF,
+          frontShinyF: res.frontShiny || res.frontShinyF,
+          backF: res.back || res.backF,
+          backShinyF: res.backShiny || res.backShinyF,
+          characterF: res.character || res.characterF,
+          characterShinyF: res.characterShiny || res.characterShinyF,
         };
       }
 


### PR DESCRIPTION
## Description

This PR makes it that when setting a Creature to be 100% female, it's default sprite names are copied into it's female sprite names if they're not already set.
This is to avoid the situation where the user first sets the default sprites, then changes the creature to 100% female and has to re-set the sprites for the female version.

closes #707

## Tests to perform

- [x] Change the female rate of a Creature to another value below 100, no changes should happen in the resources
- [x] Change the female rate of a Creature to 100, the female-related resources that were previously absent from the JSON, or had an empty value should be replaced by the male sprite value.
