### PR TITLE
Remove the default Given Name of a creature in PokemonBattler logic

### DIFF
--- a/src/utils/cleanNaNValue.ts
+++ b/src/utils/cleanNaNValue.ts
@@ -7,7 +7,6 @@ import { StudioTrainer } from '@modelEntities/trainer';
 import { StudioZone } from '@modelEntities/zone';
 import { StudioGroup } from '@modelEntities/group';
 import { ProjectData, State } from '@src/GlobalStateProvider';
-import { getEntityNameText } from './ReadingProjectText';
 import { PokemonBattlerFrom } from '@components/pokemonBattler/editors/PokemonBattlerEditorOverlay';
 import { assertUnreachable } from './assertUnreachable';
 
@@ -116,7 +115,7 @@ export const removeExpandPokemonSetup = (encounter: StudioGroupEncounter, type: 
 const removeExpandPokemonSetupWithCondition = (
   encounter: StudioGroupEncounter,
   type: StudioExpandPokemonSetup['type'],
-  condition: string | number
+  condition: string | number,
 ) => {
   const index = encounter.expandPokemonSetup.findIndex((eps) => eps.type === type && eps.value === condition);
   if (index !== -1) encounter.expandPokemonSetup.splice(index, 1);
@@ -158,7 +157,6 @@ export const cleanExpandPokemonSetup = (encounter: StudioGroupEncounter, species
   removeExpandPokemonSetupWithCondition(encounter, 'rareness', -1);
   const specie = species[encounter.specie];
   if (specie) {
-    removeExpandPokemonSetupWithCondition(encounter, 'givenName', getEntityNameText(specie, state));
     const form = specie.forms.find((f) => f.form === encounter.form);
     if (form) removeExpandPokemonSetupWithCondition(encounter, 'rareness', form.catchRate);
   }

--- a/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
+++ b/src/views/components/pokemonBattler/editors/usePokemonBattler.ts
@@ -1,17 +1,17 @@
+import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
+import { useUpdateTrainer } from '@components/database/trainer/editors/useUpdateTrainer';
 import { useGroupPage, useQuestPage, useTrainerPage } from '@hooks/usePage';
-import { CurrentBattlerType, PokemonBattlerFrom } from './PokemonBattlerEditorOverlay';
 import { useProjectPokemon } from '@hooks/useProjectData';
-import { useEffect, useMemo, useState } from 'react';
+import { DbSymbol } from '@modelEntities/dbSymbol';
 import { StudioExpandPokemonSetup, StudioGroupEncounter, StudioIvEv, createExpandPokemonSetup } from '@modelEntities/groupEncounter';
+import { ProjectData } from '@src/GlobalStateProvider';
+import { assertUnreachable } from '@utils/assertUnreachable';
+import { cleanExpandPokemonSetup } from '@utils/cleanNaNValue';
 import { cloneEntity } from '@utils/cloneEntity';
 import { createEncounter } from '@utils/entityCreation';
-import { assertUnreachable } from '@utils/assertUnreachable';
 import { useGetEntityNameText } from '@utils/ReadingProjectText';
-import { DbSymbol } from '@modelEntities/dbSymbol';
-import { cleanExpandPokemonSetup } from '@utils/cleanNaNValue';
-import { useUpdateTrainer } from '@components/database/trainer/editors/useUpdateTrainer';
-import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
-import { ProjectData } from '@src/GlobalStateProvider';
+import { useEffect, useMemo, useState } from 'react';
+import { CurrentBattlerType, PokemonBattlerFrom } from './PokemonBattlerEditorOverlay';
 
 type RecordExpandPokemonSetupValue = number | string | DbSymbol | DbSymbol[] | StudioIvEv;
 export type RecordExpandPokemonSetup = Record<StudioExpandPokemonSetup['type'], RecordExpandPokemonSetupValue>;
@@ -23,21 +23,17 @@ const createOptionalExpandPokemonSetup = (encounter: StudioGroupEncounter) => {
   );
 };
 
-const createRecordExpandPokemonSetup = (
-  encounter: StudioGroupEncounter,
-  creatures: ProjectData['pokemon'],
-  getEntityName: ReturnType<typeof useGetEntityNameText>,
-): RecordExpandPokemonSetup => {
+const createRecordExpandPokemonSetup = (encounter: StudioGroupEncounter, creatures: ProjectData['pokemon']): RecordExpandPokemonSetup => {
   createOptionalExpandPokemonSetup(encounter);
   const { expandPokemonSetup } = encounter;
   const record = expandPokemonSetup.reduce((acc, obj) => {
     acc[obj.type] = obj.value;
     return acc;
   }, {} as RecordExpandPokemonSetup);
-  // Update rareness and given name
+  // Update rareness
   const specie = creatures[encounter.specie];
   record.rareness = record.rareness === -1 ? specie?.forms.find((form) => form.form === encounter.form)?.catchRate || 0 : record.rareness;
-  record.givenName ||= specie ? getEntityName(specie) : '???';
+  record.givenName ||= '';
   return record;
 };
 
@@ -111,21 +107,21 @@ export const usePokemonBattler = ({ action, currentBattler, from }: Props) => {
     if (action === 'edit') {
       switch (from) {
         case 'group':
-          return createRecordExpandPokemonSetup(cloneEntity(group.encounters[currentBattler.index]), creatures, getEntityName);
+          return createRecordExpandPokemonSetup(cloneEntity(group.encounters[currentBattler.index]), creatures);
         case 'trainer':
-          return createRecordExpandPokemonSetup(cloneEntity(trainer.party[currentBattler.index]), creatures, getEntityName);
+          return createRecordExpandPokemonSetup(cloneEntity(trainer.party[currentBattler.index]), creatures);
         case 'quest_earning': {
           const isEarningPokemonOrEgg = ['earning_pokemon', 'earning_egg'].includes(quest.earnings[currentBattler.index].earningMethodName);
           if (!isEarningPokemonOrEgg) break;
 
           const encounter = quest.earnings[currentBattler.index].earningArgs[0] as StudioGroupEncounter;
-          return createRecordExpandPokemonSetup(cloneEntity(encounter), creatures, getEntityName);
+          return createRecordExpandPokemonSetup(cloneEntity(encounter), creatures);
         }
         default:
           assertUnreachable(from);
       }
     }
-    const record = createRecordExpandPokemonSetup(createEncounter(from === 'group'), creatures, getEntityName);
+    const record = createRecordExpandPokemonSetup(createEncounter(from === 'group'), creatures);
     if (from !== 'group') record.originalTrainerName = getEntityName(trainer);
     return record;
   };
@@ -157,9 +153,8 @@ export const usePokemonBattler = ({ action, currentBattler, from }: Props) => {
     };
     if (updatedEncounter.specie !== encounter.specie) {
       updatedEncounter.form = 0;
-      const updatedGivenName = creatures[updatedEncounter.specie] ? getEntityName(creatures[updatedEncounter.specie]) : '???';
       const updatedRareness = creatures[updatedEncounter.specie]?.forms.find((form) => form.form === updatedEncounter.form)?.catchRate || 0;
-      updateExpandPokemonSetup({ givenName: updatedGivenName, rareness: updatedRareness });
+      updateExpandPokemonSetup({ rareness: updatedRareness });
     }
     setEncounter(updatedEncounter);
   };


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Remove the default name given put it at all empty string by default if the input is empty.

## Note before testing

## Tests to perform

1. Create the trainer
2. Add a Pokémon to the trainer
3. Change the game’s default language in Studio options
4. Open and close the Pokémon editor to trigger the change
5. Save


Petite PR rapide ça faisait longtemps.
