### PR TITLE
Event commands should have the same color than their categories in the list

### DIFF
--- a/src/views/components/event/EventCommand.tsx
+++ b/src/views/components/event/EventCommand.tsx
@@ -6,6 +6,22 @@ import HelperIcon from '@assets/icons/global/error2.svg';
 import type { StudioEventCommand } from '@modelEntities/event/command';
 import { IconsFromCommand } from './EventCommandIcon';
 
+const CommandIconContainer = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  width: 24px;
+
+  &[data-color='violet'] {
+    color: rgb(149, 89, 208);
+  }
+
+  &[data-color='blue'] {
+    color: rgb(37, 113, 201);
+  }
+`;
+
 const EventCommandContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -26,15 +42,6 @@ const EventCommandContainer = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-
-    .command-icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 24px;
-      width: 24px;
-      color: rgb(149, 89, 208);
-    }
 
     .helper-icon {
       display: flex;
@@ -62,9 +69,10 @@ const EventCommandContainer = styled.div`
 type EventCommandProps = {
   command: StudioEventCommand;
   hasHelper?: boolean;
+  color: string;
 };
 
-export const EventCommand = ({ command, hasHelper }: EventCommandProps) => {
+export const EventCommand = ({ command, hasHelper, color }: EventCommandProps) => {
   const { setType } = useEventContext();
   const { t } = useTranslation();
 
@@ -76,7 +84,7 @@ export const EventCommand = ({ command, hasHelper }: EventCommandProps) => {
   return (
     <EventCommandContainer draggable onDragStart={(event) => onDragStart(event, command)}>
       <div className="header">
-        <span className="command-icon">{IconsFromCommand[command]}</span>
+        <CommandIconContainer data-color={color}>{IconsFromCommand[command]}</CommandIconContainer>
         {hasHelper && (
           <span className="helper-icon" data-tooltip={t(`event_command_${command}_helper`)}>
             <HelperIcon />

--- a/src/views/components/event/EventCommands.tsx
+++ b/src/views/components/event/EventCommands.tsx
@@ -109,7 +109,7 @@ export const EventCommands = ({ category, setSelectedCommandCategory, research }
       </div>
       <div className="commands">
         {commands.map(({ commandType, helper }) => (
-          <EventCommand key={commandType} command={commandType} hasHelper={helper} />
+          <EventCommand key={commandType} command={commandType} hasHelper={helper} color={IconsFromCategory[category].color} />
         ))}
       </div>
     </EventCommandsContainer>


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Adapt event commands color based on their categories by passing the data-color prop

## Tests to perform

Check that every event commands got the same color as their event category
