### PR TITLE
Use Enter key on the nature's name editor redirects to the homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-studio",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-studio",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@electron-forge/publisher-github": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pokemon-studio",
   "productName": "Pokémon Studio",
   "description": "Pokémon Studio is a monster taming game editor which helps you to bring your ideas to life, in just a few clicks.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "main": "./.vite/build/index.js",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": {

--- a/src/views/components/database/nature/editors/NatureFrameEditor.tsx
+++ b/src/views/components/database/nature/editors/NatureFrameEditor.tsx
@@ -38,7 +38,7 @@ export const NatureFrameEditor = forwardRef<EditorHandlingClose>((_, ref) => {
 
   return (
     <Editor type="edit" title={t('information')}>
-      <InputFormContainer ref={formRef}>
+      <InputFormContainer ref={formRef} onSubmit={(e) => e.preventDefault()}>
         <TranslatableTextFields ref={tTFR} handleTranslateClick={handleTranslateClick} nature={nature} natureName={natureName} />
       </InputFormContainer>
       <NatureTranslationOverlay nature={nature} onClose={onTranslationOverlayClose} ref={dialogsRef} />


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

User should not be redirect after an edit with the keyboard on the nature page editor.

## Note before testing

I've tested all the app, and did'nt find any other bug like that.

## Tests to perform

Steps to reproduce the behavior:

1. Go to Nature Page
2. Click on first block data editor
3. Edit the nature name
4. Tap enter after that
5. Redirect to the homepage.

Closes #720 