### PR TITLE
Fix audio files being copied to the project's root on the Music Design dashboard

### DIFF
--- a/src/views/components/dashboard/music/DashboardMusicDesign.tsx
+++ b/src/views/components/dashboard/music/DashboardMusicDesign.tsx
@@ -3,18 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { PageEditor } from '@components/pages';
 import { useConfigSoundDesign } from '@src/hooks/useProjectConfig';
 import { AUDIO_EXT } from '@components/inputs/AudioInput';
-import type { SoundEffectsKeys, SoundLocated } from '@modelEntities/config';
 import { EditorsContainer } from './music.style';
 import { AudioFile } from '@modelEntities/common';
 import { OtherResource } from '@components/resources';
-import { SoundEditorKeys, SoundEditorOverlay } from './editors/SoundEditorOverlay';
+import { SoundEditorKeys, SoundEditorOverlay, type SoundEffect } from './editors/SoundEditorOverlay';
 import { useDialogsRef } from '@src/hooks/useDialogsRef';
-import { useUpdateConfigMusic } from './ressoures/useUpdateConfigSound';
+import { getAudioName, useUpdateConfigMusic } from './ressoures/useUpdateConfigSound';
 import { TuneButtonOnlyIcon } from '@components/buttons/TuneButtonOnlyIcon';
 
 interface SoundMapping {
   title: string;
-  soundEffects: { key: SoundEffectsKeys; located: SoundLocated }[];
+  soundEffects: SoundEffect[];
 }
 
 const MusicState: SoundMapping[] = [
@@ -52,25 +51,28 @@ const MusicState: SoundMapping[] = [
 
 export const DashboardMusicDesign = () => {
   const { t } = useTranslation();
-  const { projectConfigValues: musicDesign } = useConfigSoundDesign();
   const dialogsRef = useDialogsRef<SoundEditorKeys>();
-  const [audioFile, setAudioFile] = useState<(AudioFile & { key: SoundEffectsKeys; located: SoundLocated }) | null>(null);
+  const [audioFile, setAudioFile] = useState<(AudioFile & SoundEffect) | null>(null);
+
+  const { projectConfigValues: musicDesign } = useConfigSoundDesign();
   const { onResourceMusicsChoosen, onResourceMusicsClean } = useUpdateConfigMusic(musicDesign);
 
   const musicState = useMemo(() => {
     return MusicState.map((state) => {
       return {
         ...state,
-        soundEffects: state.soundEffects.map((soundEffect) => {
+        soundEffects: state.soundEffects.reduce<(SoundEffect & AudioFile)[]>((prev, soundEffect) => {
           const located = musicDesign?.[soundEffect.located];
           const audio = located?.[soundEffect.key as keyof typeof located] as AudioFile | undefined;
-          return audio ? { ...soundEffect, ...audio } : null;
-        }),
+          if (!audio) return prev;
+
+          return [...prev, { ...soundEffect, ...audio }];
+        }, []),
       };
     });
   }, [musicDesign]);
 
-  const handleOpenEditor = (soundEffect: AudioFile & { key: SoundEffectsKeys; located: SoundLocated }) => {
+  const handleOpenEditor = (soundEffect: AudioFile & SoundEffect) => {
     setAudioFile(soundEffect);
     dialogsRef.current?.openDialog('music', false);
   };
@@ -79,27 +81,25 @@ export const DashboardMusicDesign = () => {
     <EditorsContainer>
       {musicState.map((state) => (
         <PageEditor key={state.title} editorTitle={t('music_default')} title={t(state.title)} canCollapse>
-          {state.soundEffects.map((soundEffect, index) => (
+          {state.soundEffects.map((soundEffect) => (
             <OtherResource
               type="music"
-              title={t(`${soundEffect?.key}`)}
-              resourcePath={soundEffect?.name ?? ''}
+              title={t(`${soundEffect.translateKey ?? soundEffect.key}`)}
+              resourcePath={getAudioName(soundEffect.located, soundEffect.name)}
               extensions={AUDIO_EXT}
               onResourceChoosen={(resourcePath: string) => {
-                onResourceMusicsChoosen(resourcePath, soundEffect?.key as SoundEffectsKeys, soundEffect?.located as SoundLocated);
+                onResourceMusicsChoosen(resourcePath, soundEffect.key, soundEffect.located);
               }}
               onResourceClean={() => {
-                if (soundEffect?.key) onResourceMusicsClean(soundEffect?.key as SoundEffectsKeys, soundEffect?.located as SoundLocated);
+                onResourceMusicsClean(soundEffect.key, soundEffect.located);
               }}
-              key={soundEffect?.key ?? index}
+              key={soundEffect.key}
               beforeButtons={
                 <button>
                   <TuneButtonOnlyIcon
                     onClick={(e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
                       e.stopPropagation();
-                      if (soundEffect) {
-                        handleOpenEditor(soundEffect as AudioFile & { key: SoundEffectsKeys; located: SoundLocated });
-                      }
+                      handleOpenEditor(soundEffect);
                     }}
                   />
                 </button>


### PR DESCRIPTION
## Description

This PR fixes an issue where audio files that were modifed through the Music Design dashboard page were copied to the project's root instead of the correct `bgm` or `me` folder.

## Tests to perform

- [x] Go to the Music Design dashboard page, adding or changing any audio files here correctly works and the chosen file is copied to the correct folder (`Game Over` and `Creature caught` go in audio/me, other go in audio/bgm)
- [x] Other functionnalities of the page still work without regression (open folder, editor, remove etc...)
