### PR TITLE
Fix dialog overlay softlock with multiple clicks

### DIFF
--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -112,7 +112,7 @@ const closeDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEl
   animation.onfinish = () => {
     dialog.classList.remove('open');
     backdrop.classList.remove('open');
-    dialog.close();
+    if (dialog.open) dialog.close();
     onFinish();
     dialog.removeEventListener('cancel', onDialogCancel);
 
@@ -185,11 +185,31 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     const [currentDialog, setCurrentDialog] = useState<Keys | undefined>(undefined);
     const [isCenter, setIsCenter] = useState(false);
     const backdropRef = useRef<HTMLDivElement>(null);
+    const dialogActionRef = useRef<number>(0);
+    const openDialogTimeoutRef = useRef<number | null>(null);
+
+    // Invalidate previous open/close actions and cancel any pending delayed open
+    const prepareDialogAction = () => {
+      if (openDialogTimeoutRef.current !== null) {
+        window.clearTimeout(openDialogTimeoutRef.current);
+        openDialogTimeoutRef.current = null;
+      }
+      return ++dialogActionRef.current;
+    };
 
     const closeDialog = () => {
+      const currentAction = prepareDialogAction();
       handleCloseRef.current?.onClose();
-      if (dialogRef.current && backdropRef.current)
-        closeDialogWithAnimation(dialogRef.current, backdropRef.current, isCenter, () => setCurrentDialog(undefined));
+      if (dialogRef.current && backdropRef.current) {
+        closeDialogWithAnimation(dialogRef.current, backdropRef.current, isCenter, () => {
+          if (currentAction !== dialogActionRef.current) return;
+          setCurrentDialog(undefined);
+        });
+      } else {
+        if (currentAction === dialogActionRef.current) {
+          setCurrentDialog(undefined);
+        }
+      }
     };
 
     const currentlyRenderedDialog = useMemo(() => {
@@ -207,16 +227,28 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     };
 
     const openDialog = (name: Keys, isCenterDialog?: boolean) => {
+      const currentAction = prepareDialogAction();
       setIsCenter(isCenterDialog || false);
       setCurrentDialog(name);
-      // Without tick, if the dialog change between center and right, the dialog is not displayed correctly
-      setTimeout(() => {
+      openDialogTimeoutRef.current = window.setTimeout(() => {
+        openDialogTimeoutRef.current = null;
+        if (currentAction !== dialogActionRef.current) return;
         if (dialogRef.current && backdropRef.current) openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog || false);
       }, 0);
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useImperativeHandle(ref, () => ({ closeDialog, openDialog: openDialog, currentDialog }), [currentDialog]);
+
+    // Cleanup any pending delayed open when the component unmounts
+    useEffect(() => {
+      return () => {
+        if (openDialogTimeoutRef.current !== null) {
+          window.clearTimeout(openDialogTimeoutRef.current);
+          openDialogTimeoutRef.current = null;
+        }
+      };
+    }, []);
 
     // Handle user pressing the escape key
     useEffect(() => {

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -205,10 +205,8 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
           if (currentAction !== dialogActionRef.current) return;
           setCurrentDialog(undefined);
         });
-      } else {
-        if (currentAction === dialogActionRef.current) {
-          setCurrentDialog(undefined);
-        }
+      } else if (currentAction === dialogActionRef.current) {
+        setCurrentDialog(undefined);
       }
     };
 


### PR DESCRIPTION
Fix a race condition in EditorOverlayV2 where multiple rapid clicks could leave the overlay visible after the dialog was already closed.

The change makes sure older delayed open actions do not run after a newer open or close action.

## Template ##

Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

When you're opening and closing the editor of a data block, Studio can be soft locked and still displaying the editor overlay even if the editor is closed. This should not happen.

This change invalidates previous dialog actions, cancels pending delayed opens, and only applies close cleanup if it still belongs to the latest action.

## Note before testing

I also checked the other database editor pages and could not reproduce the issue there.

## Tests to perform

From original issue:
Steps to reproduce the behavior:
1. Go to the Items page
2. Click on the first data block multiple times to open and close it successively
3. See the soft lock (Verify that the softlock no longer happens)

Closes https://github.com/PokemonWorkshop/PokemonStudio/issues/724