### PR TITLE
Fix EV and IV values for Special Defense and Speed being inverted during showdown format import

### DIFF
--- a/src/utils/showdownUtils.tsx
+++ b/src/utils/showdownUtils.tsx
@@ -109,9 +109,9 @@ const formatStats = (stats: StatsTable, defaultValue: number): StudioIvEv => {
     hp: stats?.hp ?? defaultValue,
     atk: stats?.atk ?? defaultValue,
     dfe: stats?.def ?? defaultValue,
-    spd: stats?.spd ?? defaultValue,
+    spd: stats?.spe ?? defaultValue,
     ats: stats?.spa ?? defaultValue,
-    dfs: stats?.spe ?? defaultValue,
+    dfs: stats?.spd ?? defaultValue,
   };
 };
 


### PR DESCRIPTION
## Description

This MR fixes an issue where values set for Special Defense and Speed in a showdown format were being inverted when imported in Studio.

Link to the topic highlighting the problem: https://discord.com/channels/143824995867557888/1486769037965922314

## Note before testing

Here's a example of showdown format that triggers the issue:
```txt
Alakazam @ Alakazite
Ability: Magic Guard
EVs: 252 SpA / 4 SpD / 252 Spe
```

In the current prod version, the resulting Alakazam will have 4 EVs in Speed and 252 in Special Defense.

## Tests to perform

- [x] EV values are now correctly imported
