### PR TITLE
Enable the terminal to pop on MacOS when clicking the Play button

### DIFF
--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -21,7 +21,16 @@ export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, s
     log.warn('No terminal found. The PSDK console will not be displayed.');
     return ['./game-linux.sh', args];
   } else if (process.platform === 'darwin') {
-    return ['./game-mac.sh', args];
+    return [
+      'osascript',
+      [
+        '-e',
+        `tell application "Terminal"
+          do script "cd '${projectPath}' && ./game-mac.sh ${args.join(' ')}"
+          activate
+        end tell`
+      ]
+    ];
   } else {
     return ['./game.rb', args];
   }
@@ -75,14 +84,16 @@ export const startPSDK = (projectPath: string) => {
 
     const [command, spawnArgs] = getSpawnArgs(projectPath);
 
+    const isMac = process.platform === 'darwin';
+
     const childProcess = spawn(command, spawnArgs, {
       cwd: projectPath,
-      shell: true,
-      detached: true,
-      stdio: 'ignore',
+      shell: !isMac,
+      detached: !isMac,
+      stdio: isMac ? 'inherit' : 'ignore',
     });
 
-    childProcess.unref();
+    if (!isMac) childProcess.unref();
   } finally {
     process.chdir(studioPath);
   }
@@ -99,14 +110,16 @@ const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
 
     const [command, spawnArgs] = getSpawnArgs(projectPath, ...args);
 
+    const isMac = process.platform === 'darwin';
+
     const childProcess = spawn(command, spawnArgs, {
       cwd: projectPath,
-      shell: true,
-      detached: true,
-      stdio: 'ignore',
+      shell: !isMac,
+      detached: !isMac,
+      stdio: isMac ? 'inherit' : 'ignore',
     });
 
-    childProcess.unref();
+    if (!isMac) childProcess.unref();
   } finally {
     process.chdir(studioPath);
   }

--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -28,8 +28,8 @@ export const getSpawnArgs = (projectPath: string, ...args: string[]): [string, s
         `tell application "Terminal"
           do script "cd '${projectPath}' && ./game-mac.sh ${args.join(' ')}"
           activate
-        end tell`
-      ]
+        end tell`,
+      ],
     ];
   } else {
     return ['./game.rb', args];
@@ -73,6 +73,17 @@ const canLaunchPSDK = () => {
   return false;
 };
 
+const childProcessFn = (projectPath: string, command: string, spawnArgs: string[]) => {
+  const isMac = process.platform === 'darwin';
+  const childProcess = spawn(command, spawnArgs, {
+    cwd: projectPath,
+    shell: !isMac,
+    detached: !isMac,
+    stdio: isMac ? 'inherit' : 'ignore',
+  });
+  if (!isMac) childProcess.unref();
+};
+
 export const startPSDK = (projectPath: string) => {
   if (!canLaunchPSDK()) return;
 
@@ -84,16 +95,7 @@ export const startPSDK = (projectPath: string) => {
 
     const [command, spawnArgs] = getSpawnArgs(projectPath);
 
-    const isMac = process.platform === 'darwin';
-
-    const childProcess = spawn(command, spawnArgs, {
-      cwd: projectPath,
-      shell: !isMac,
-      detached: !isMac,
-      stdio: isMac ? 'inherit' : 'ignore',
-    });
-
-    if (!isMac) childProcess.unref();
+    childProcessFn(projectPath, command, spawnArgs);
   } finally {
     process.chdir(studioPath);
   }
@@ -110,16 +112,7 @@ const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
 
     const [command, spawnArgs] = getSpawnArgs(projectPath, ...args);
 
-    const isMac = process.platform === 'darwin';
-
-    const childProcess = spawn(command, spawnArgs, {
-      cwd: projectPath,
-      shell: !isMac,
-      detached: !isMac,
-      stdio: isMac ? 'inherit' : 'ignore',
-    });
-
-    if (!isMac) childProcess.unref();
+    childProcessFn(projectPath, command, spawnArgs);
   } finally {
     process.chdir(studioPath);
   }


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

Currently, MacOS users cannot access the terminal when playtesting from Studio. This PR changes this behavior to ensure MacOS users have a terminal.

## Note before testing

Due to how it is done (using osascript to pass a series of instructions to MacOS), the terminal stays after the game is closed unlike Windows and Linux on which it closes itself at the end of the process. I personally think the tradeoff is acceptable (having a terminal that does not close >>> having no terminal at all).

## Tests to perform

- [x] Try to playtest a project on Windows: the original behavior should still be there and a console should appear then close when the game is closed.
- [x] Try to playtest a project on Ubuntu (or any Linux distribution we support): the original behavior should still be there and a console should appear then close when the game is closed.
- [x] Try to playtest a project on MacOS: a terminal should appear and the game should launch properly. The terminal stays after the game is closed.