### PR TITLE
Fix EditorOverlay regression due to React 19

### DIFF
--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -176,8 +176,8 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     dialogToShow: Keys,
     handleCloseRef: ReturnType<typeof useEditorHandlingCloseRef>,
     closeDialog: () => void,
-    props: PropsWithoutRef<Props>
-  ) => ReactNode
+    props: PropsWithoutRef<Props>,
+  ) => ReactNode,
 ) => {
   const reactComponent = forwardRef<DialogRefData<Keys>, Props>((props, ref) => {
     const dialogRef = useRef<HTMLDialogElement>(null);
@@ -186,14 +186,10 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     const [isCenter, setIsCenter] = useState(false);
     const backdropRef = useRef<HTMLDivElement>(null);
     const dialogActionRef = useRef<number>(0);
-    const openDialogTimeoutRef = useRef<number | null>(null);
+    const pendingOpenRef = useRef<{ isCenterDialog: boolean } | null>(null);
 
     // Invalidate previous open/close actions and cancel any pending delayed open
     const prepareDialogAction = () => {
-      if (openDialogTimeoutRef.current !== null) {
-        window.clearTimeout(openDialogTimeoutRef.current);
-        openDialogTimeoutRef.current = null;
-      }
       return ++dialogActionRef.current;
     };
 
@@ -225,28 +221,24 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     };
 
     const openDialog = (name: Keys, isCenterDialog?: boolean) => {
-      const currentAction = prepareDialogAction();
+      prepareDialogAction();
       setIsCenter(isCenterDialog || false);
       setCurrentDialog(name);
-      openDialogTimeoutRef.current = window.setTimeout(() => {
-        openDialogTimeoutRef.current = null;
-        if (currentAction !== dialogActionRef.current) return;
-        if (dialogRef.current && backdropRef.current) openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog || false);
-      }, 0);
+      pendingOpenRef.current = { isCenterDialog: isCenterDialog || false };
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useImperativeHandle(ref, () => ({ closeDialog, openDialog: openDialog, currentDialog }), [currentDialog]);
 
-    // Cleanup any pending delayed open when the component unmounts
     useEffect(() => {
-      return () => {
-        if (openDialogTimeoutRef.current !== null) {
-          window.clearTimeout(openDialogTimeoutRef.current);
-          openDialogTimeoutRef.current = null;
-        }
-      };
-    }, []);
+      if (!currentDialog || !pendingOpenRef.current) return;
+      const { isCenterDialog } = pendingOpenRef.current;
+      pendingOpenRef.current = null;
+
+      if (dialogRef.current && backdropRef.current) {
+        openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog);
+      }
+    }, [currentDialog]);
 
     // Handle user pressing the escape key
     useEffect(() => {
@@ -384,7 +376,7 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
           ></div>
         </DialogContainer>
       </>,
-      document.querySelector('#dialogs') || document.createElement('div')
+      document.querySelector('#dialogs') || document.createElement('div'),
     );
   });
   reactComponent.displayName = displayName;

--- a/src/views/components/editor/EditorOverlayV2.tsx
+++ b/src/views/components/editor/EditorOverlayV2.tsx
@@ -127,18 +127,21 @@ const closeDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivEl
   };
 };
 
-const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivElement, isCenter: boolean) => {
+const openDialogWithAnimation = (dialog: HTMLDialogElement, backdrop: HTMLDivElement, isCenter: boolean, onFinish: () => void) => {
   dialog.addEventListener('cancel', onDialogCancel);
   dialog.classList.add('open');
   backdrop.classList.add('open');
-  dialog.animate(isCenter ? animationKeys.center.open : animationKeys.right.open, animationOption);
+  const animation = dialog.animate(isCenter ? animationKeys.center.open : animationKeys.right.open, animationOption);
 
-  setTimeout(() => {
-    const focusableElements = dialog.querySelectorAll(focusableHtmlElements);
-    if (focusableElements?.length) {
-      (focusableElements[0] as HTMLElement).focus();
-    }
-  }, animationOption.duration);
+  animation.onfinish = () => {
+    onFinish();
+    setTimeout(() => {
+      const focusableElements = dialog.querySelectorAll(focusableHtmlElements);
+      if (focusableElements?.length) {
+        (focusableElements[0] as HTMLElement).focus();
+      }
+    }, animationOption.duration);
+  };
 };
 
 /**
@@ -187,6 +190,7 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     const backdropRef = useRef<HTMLDivElement>(null);
     const dialogActionRef = useRef<number>(0);
     const pendingOpenRef = useRef<{ isCenterDialog: boolean } | null>(null);
+    const isAnimatingRef = useRef(false);
 
     // Invalidate previous open/close actions and cancel any pending delayed open
     const prepareDialogAction = () => {
@@ -197,8 +201,10 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       const currentAction = prepareDialogAction();
       handleCloseRef.current?.onClose();
       if (dialogRef.current && backdropRef.current) {
+        isAnimatingRef.current = true;
         closeDialogWithAnimation(dialogRef.current, backdropRef.current, isCenter, () => {
           if (currentAction !== dialogActionRef.current) return;
+          isAnimatingRef.current = false;
           setCurrentDialog(undefined);
         });
       } else if (currentAction === dialogActionRef.current) {
@@ -221,6 +227,8 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
     };
 
     const openDialog = (name: Keys, isCenterDialog?: boolean) => {
+      if (isAnimatingRef.current) return;
+
       prepareDialogAction();
       setIsCenter(isCenterDialog || false);
       setCurrentDialog(name);
@@ -236,7 +244,8 @@ export const defineEditorOverlay = <Keys extends string, Props extends Record<st
       pendingOpenRef.current = null;
 
       if (dialogRef.current && backdropRef.current) {
-        openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog);
+        isAnimatingRef.current = true;
+        openDialogWithAnimation(dialogRef.current, backdropRef.current, isCenterDialog, () => (isAnimatingRef.current = false));
       }
     }, [currentDialog]);
 


### PR DESCRIPTION
## Description

This PR fixes a regression introduced by the update to React 19.

Changes to the rendering process in React 19 caused `setTimeout` to become ineffective in the implementation of the dialog opening, which could prevent the dialog from opening correctly in certain circumstances.

The fix replaced `setTimeout` with a `useEffect` to better align with the rendering process.

## Before test

Check that `neverRemindMeMapModification` is set to false (or does not exist) in the cache.
If it is set to true, change the value to false.

<img width="944" height="346" alt="image" src="https://github.com/user-attachments/assets/18391a35-ef07-49ed-84e1-6fe220b7399c" />

## Tests to perform

- [x] Edit a map and use the shortchut CTRL + S ; the dialog `MapModificationWarningDialog` should be show correctly. 
