### PR TITLE
Add a new shortcut to Copy Identifier

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -294,7 +294,7 @@
   "save_logs_success": "Die Protokolldatei wurde im Ordner logs in Ihrem Projektverzeichnis gespeichert.",
   "save_logs_title_failure": "Speichern von Protokollen fehlgeschlagen",
   "save_logs_failure": "Beim Speichern der Protokolldatei ist ein Fehler aufgetreten.",
-  "identifier_message": "Kennung kopieren",
+  "identifier_message": "Kennung kopieren ({{shortcut}})",
   "copied": "Kopiert! ✅",
   "failed_to_copy": "Kopieren fehlgeschlagen ❌",
   "copy_code": "Kopieren des Codes",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -294,7 +294,7 @@
   "save_logs_success": "The log file has been saved in the logs folder in your project directory.",
   "save_logs_title_failure": "Failed to save logs",
   "save_logs_failure": "An error has occurred while saving the log file.",
-  "identifier_message": "Copy the identifier",
+  "identifier_message": "Copy the identifier ({{shortcut}})",
   "copied": "Copied! ✅",
   "failed_to_copy": "Failed to copy ❌",
   "copy_code": "Copy the code",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -294,7 +294,7 @@
   "save_logs_success": "El archivo de registro se ha guardado en la carpeta de registros en el directorio del proyecto.",
   "save_logs_title_failure": "No se pudieron guardar los registros",
   "save_logs_failure": "Un error ha ocurrido durante el guardado de registros.",
-  "identifier_message": "Copiar el identificador",
+  "identifier_message": "Copiar el identificador ({{shortcut}})",
   "copied": "¡Copiado! ✅",
   "failed_to_copy": "No se pudo copiar ❌",
   "copy_code": "Copiar el código",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -294,7 +294,7 @@
   "save_logs_success": "Le fichier de logs a été sauvegardé dans le dossier logs du répertoire de votre projet.",
   "save_logs_title_failure": "Échec lors de l'enregistrement des logs",
   "save_logs_failure": "Une erreur est survenue pendant la sauvegarde du fichier de logs.",
-  "identifier_message": "Copier l'identifiant",
+  "identifier_message": "Copier l'identifiant ({{shortcut}})",
   "copied": "Copié ! ✅",
   "failed_to_copy": "Échec de la copie ❌",
   "copy_code": "Copier le code",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -294,7 +294,7 @@
   "save_logs_success": "The log file has been saved in the logs folder in your project directory.",
   "save_logs_title_failure": "Failed to save logs",
   "save_logs_failure": "An error has occurred while saving the log file.",
-  "identifier_message": "Copia identificatore",
+  "identifier_message": "Copia identificatore ({{shortcut}})",
   "copied": "Copiato! ✅",
   "failed_to_copy": "Failed to copy ❌",
   "copy_code": "Copy the code",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -294,7 +294,7 @@
   "save_logs_success": "The log file has been saved in the logs folder in your project directory.",
   "save_logs_title_failure": "Failed to save logs",
   "save_logs_failure": "An error has occurred while saving the log file.",
-  "identifier_message": "Copy the identifier",
+  "identifier_message": "Copy the identifier ({{shortcut}})",
   "copied": "Copied! ✅",
   "failed_to_copy": "Failed to copy ❌",
   "copy_code": "Copy the code",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -294,7 +294,7 @@
   "save_logs_success": "Het logbestand is opgeslagen in de map logs in je projectmap.",
   "save_logs_title_failure": "Logs opslaan mislukt",
   "save_logs_failure": "Er is een fout opgetreden bij het opslaan van het logbestand.",
-  "identifier_message": "Kopieer de identificatie",
+  "identifier_message": "Kopieer de identificatie ({{shortcut}})",
   "copied": "Gekopieerd! ✅",
   "failed_to_copy": "Kopiëren mislukt ❌",
   "copy_code": "Kopieer de code",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -294,7 +294,7 @@
   "save_logs_success": "O arquivo de log foi salvo na pasta de logs no diretório do seu projeto.",
   "save_logs_title_failure": "Falha ao salvar os registros",
   "save_logs_failure": "Ocorreu um erro ao salvar o arquivo de log.",
-  "identifier_message": "Copiar o identificante",
+  "identifier_message": "Copiar o identificante ({{shortcut}})",
   "copied": "Copiado ! ✅",
   "failed_to_copy": "Falhou ao copiar ❌",
   "copy_code": "Copiar o código",

--- a/assets/i18n/zh_Hans.json
+++ b/assets/i18n/zh_Hans.json
@@ -294,7 +294,7 @@
   "save_logs_success": "日志已被存储于该项目的日志文件夹中。",
   "save_logs_title_failure": "保存日志失败",
   "save_logs_failure": "保存日志时出现错误。",
-  "identifier_message": "复制标识符",
+  "identifier_message": "复制标识符 ({{shortcut}})",
   "copied": "已复制！ ✅",
   "failed_to_copy": "复制失败 ❌",
   "copy_code": "复制代码",

--- a/assets/i18n/zh_Hant.json
+++ b/assets/i18n/zh_Hant.json
@@ -294,7 +294,7 @@
   "save_logs_success": "The log file has been saved in the logs folder in your project directory.",
   "save_logs_title_failure": "Failed to save logs",
   "save_logs_failure": "An error has occurred while saving the log file.",
-  "identifier_message": "Copy the identifier",
+  "identifier_message": "Copy the identifier ({{shortcut}})",
   "copied": "Copied! ✅",
   "failed_to_copy": "Failed to copy ❌",
   "copy_code": "Copy the code",

--- a/src/hooks/useShortcuts.tsx
+++ b/src/hooks/useShortcuts.tsx
@@ -11,17 +11,18 @@ const STUDIO_CTRL_SHORTCUTS = {
 const STUDIO_CTRL_SHIFT_SHORTCUTS = {
   db_previous_variant: ['ArrowLeft', 'Left'],
   db_next_variant: ['ArrowRight', 'Right'],
+  db_copy_identifier: ['KeyC'],
 } as const;
 
 export type StudioShortcut = keyof typeof STUDIO_CTRL_SHORTCUTS | keyof typeof STUDIO_CTRL_SHIFT_SHORTCUTS;
 export type StudioShortcutActions = Partial<Record<StudioShortcut, () => void>>;
 
 const KEY_TO_STUDIO_CTRL_SHORTCUT = Object.fromEntries(
-  Object.entries(STUDIO_CTRL_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut]))
+  Object.entries(STUDIO_CTRL_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut])),
 );
 
 const KEY_TO_STUDIO_CTRL_SHIFT_SHORTCUT = Object.fromEntries(
-  Object.entries(STUDIO_CTRL_SHIFT_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut]))
+  Object.entries(STUDIO_CTRL_SHIFT_SHORTCUTS).flatMap(([studioShortcut, keys]) => keys.map((key) => [key, studioShortcut as StudioShortcut])),
 );
 
 export const useShortcut = (shortcutActions: StudioShortcutActions) => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, shell, BrowserWindow, MenuItemConstructorOptions } from 'electron';
+import { BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
 
 export default class MenuBuilder {
   mainWindow: BrowserWindow;
@@ -103,6 +103,15 @@ export default class MenuBuilder {
             accelerator: 'CmdOrCtrl+N',
             click: () => {
               this.mainWindow.webContents.send('request-shortcut', 'db_new');
+            },
+          },
+          {
+            label: 'Copy identifier',
+            accelerator: this.isDarwin ? 'Alt+Shift+C' : 'Ctrl+Shift+C',
+            click: (_, __, e) => {
+              if (!e.triggeredByAccelerator) {
+                this.mainWindow.webContents.send('request-shortcut', 'db_copy_identifier');
+              }
             },
           },
           { type: 'separator' },

--- a/src/views/components/Copy.tsx
+++ b/src/views/components/Copy.tsx
@@ -1,7 +1,9 @@
-import React, { ReactNode } from 'react';
-import styled from 'styled-components';
-import { useTranslation } from 'react-i18next';
 import CopyIcon from '@assets/icons/global/copy.svg';
+import { StudioShortcutActions, useShortcut } from '@hooks/useShortcuts';
+import { showNotification } from '@utils/showNotification';
+import React, { ReactNode, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 import { DarkButton } from './buttons';
 
 export const CopyStyle = styled.button`
@@ -26,14 +28,20 @@ type CopyProps = {
   children?: ReactNode;
 };
 
+const copyData = async (dataToCopy: CopyProps['dataToCopy'], noColon?: true): Promise<string> => {
+  const text = await (typeof dataToCopy === 'string' ? dataToCopy : dataToCopy());
+  const copiedText = `${noColon ? '' : ':'}${text}`;
+  await navigator.clipboard.writeText(copiedText);
+  return copiedText;
+};
+
 const Copy = ({ dataToCopy, message, noColon, children }: CopyProps) => {
   const { t } = useTranslation();
 
   const onClickCopy: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement> = async (event) => {
     event.stopPropagation();
     try {
-      const text = await (typeof dataToCopy === 'string' ? dataToCopy : dataToCopy());
-      navigator.clipboard.writeText(`${noColon ? '' : ':'}${text}`);
+      await copyData(dataToCopy, noColon);
       window.dispatchEvent(new CustomEvent('tooltip:ChangeText', { detail: t('copied') }));
     } catch {
       window.dispatchEvent(new CustomEvent('tooltip:ChangeText', { detail: t('failed_to_copy') }));
@@ -58,7 +66,24 @@ type CopyIdentifierProps = Omit<CopyProps, 'message'>;
 
 export const CopyIdentifier = ({ dataToCopy, noColon }: CopyIdentifierProps) => {
   const { t } = useTranslation();
-  return <Copy dataToCopy={dataToCopy} message={t('identifier_message')} noColon={noColon} />;
+  const shortcut = window.api.platform === 'darwin' ? 'Option + Shift + C' : 'Ctrl + Shift + C';
+
+  const shortcutMap = useMemo<StudioShortcutActions>(
+    () => ({
+      db_copy_identifier: async () => {
+        try {
+          const copiedText = await copyData(dataToCopy, noColon);
+          showNotification('success', t('copied'), copiedText);
+        } catch {
+          showNotification('danger', t('failed_to_copy'), '');
+        }
+      },
+    }),
+    [dataToCopy, noColon, t],
+  );
+  useShortcut(shortcutMap);
+
+  return <Copy dataToCopy={dataToCopy} message={t('identifier_message', { shortcut })} noColon={noColon} />;
 };
 
 export const CopyButton = (props: Omit<CopyProps, 'noColon'>) => <Copy {...props} noColon />;


### PR DESCRIPTION
## Description

Adds a keyboard shortcut (`Ctrl + Shift + C`,  `Option + Shift + C` on macOS) to copy the current entity identifier. 

- The shortcut is registered inside the `CopyIdentifier` component, so all pages with a copy identifier button support it and the copied value is identical to the button's output.
- A notification is shown after copying; the shortcut is documented in the button tooltip. Mouse interactions are unchanged.
- Also added a "Copy identifier" entry in the Edit menu.

Closes #761

## Note before testing

macOS was not tested, because I don't have a Mac device.

## Tests to perform

1. On each database page with a copy identifier button (Pokémon, Moves, Items...), press `Ctrl + Shift + C`: a single success notification appears and the clipboard contains the identifier with the `:` prefix (e.g. `:bulbasaur`), identical to the copy button output.
2. On the Texts and Maps pages, the shortcut copies the id without the `:` prefix.
3. Hover the copy button: the tooltip shows the shortcut; clicking it still works as before.
4. Switch entity (`Ctrl + Left/Right`) then press the shortcut: the new entity's identifier is copied.
5. On pages without a copy identifier button, the shortcut does nothing.

These are the tests I performed. Please let me know if there are any additional cases I should check.