### PR TITLE
Add optional movepool inheritance when creating creature form

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -941,6 +941,7 @@
   "new_form": "Neue Form",
   "create_form": "Hinzufügen der Form",
   "form_type": "Typ der Form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Klassisch",
   "mega-evolution": "Megaentwicklung",
   "error_classic_form": "Du kannst keine klassischen Forme mehr erstellen.",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -941,6 +941,7 @@
   "new_form": "New form",
   "create_form": "Add the form",
   "form_type": "Type of form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classic",
   "mega-evolution": "Mega Evolution",
   "error_classic_form": "You can no longer create a classic form.",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -941,6 +941,7 @@
   "new_form": "Nueva forma",
   "create_form": "Añadir la forma",
   "form_type": "Tipo de forma",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Clásica",
   "mega-evolution": "Megaevolución",
   "error_classic_form": "Ya no puedes crear una forma clásica",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -941,7 +941,7 @@
   "new_form": "Nouvelle forme",
   "create_form": "Ajouter la forme",
   "form_type": "Type de forme",
-  "inherit_movepool": "Inherit movepool",
+  "inherit_movepool": "Copier les capacités",
   "classic": "Classique",
   "mega-evolution": "Méga-Évolution",
   "error_classic_form": "Vous ne pouvez plus créer de forme classique.",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -941,6 +941,7 @@
   "new_form": "Nouvelle forme",
   "create_form": "Ajouter la forme",
   "form_type": "Type de forme",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classique",
   "mega-evolution": "Méga-Évolution",
   "error_classic_form": "Vous ne pouvez plus créer de forme classique.",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -941,6 +941,7 @@
   "new_form": "Nuova forma",
   "create_form": "Aggiungi forma",
   "form_type": "Tipo di forma",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classica",
   "mega-evolution": "Megaevoluzione",
   "error_classic_form": "Non puoi aggiungere altre forme classiche.",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -941,6 +941,7 @@
   "new_form": "New form",
   "create_form": "Add the form",
   "form_type": "Type of form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classic",
   "mega-evolution": "Mega Evolution",
   "error_classic_form": "You can no longer create a classic form.",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -941,6 +941,7 @@
   "new_form": "Nieuwe vorm",
   "create_form": "Add the form",
   "form_type": "Type of form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Klassiek",
   "mega-evolution": "Mega Evolution",
   "error_classic_form": "You can no longer create a classic form.",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -941,6 +941,7 @@
   "new_form": "Nova forma",
   "create_form": "Adicionar a forma",
   "form_type": "Tipo da Forma",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classica",
   "mega-evolution": "Mega Evolução",
   "error_classic_form": "Você já não pode criar formas classicas.",

--- a/assets/i18n/zh_Hans.json
+++ b/assets/i18n/zh_Hans.json
@@ -941,6 +941,7 @@
   "new_form": "New form",
   "create_form": "Add the form",
   "form_type": "Type of form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classic",
   "mega-evolution": "Mega Evolution",
   "error_classic_form": "You can no longer create a classic form.",

--- a/assets/i18n/zh_Hant.json
+++ b/assets/i18n/zh_Hant.json
@@ -941,6 +941,7 @@
   "new_form": "New form",
   "create_form": "Add the form",
   "form_type": "Type of form",
+  "inherit_movepool": "Inherit movepool",
   "classic": "Classic",
   "mega-evolution": "Mega Evolution",
   "error_classic_form": "You can no longer create a classic form.",

--- a/src/utils/entityCreation.ts
+++ b/src/utils/entityCreation.ts
@@ -170,10 +170,15 @@ export const createCreatureForm = (
   form: StudioCreatureForm,
   types: { type1: DbSymbol; type2: DbSymbol },
   newFormId: number,
+  inheritMoveSet = true,
 ) => {
   const formTextIdName = findFirstAvailableFormTextId(allPokemon, 0, 'name');
   const formTextIdDescription = findFirstAvailableFormTextId(allPokemon, 0, 'description');
-  return cloneEntity({ ...form, ...types, form: newFormId, formTextId: { name: formTextIdName, description: formTextIdDescription } });
+  const newForm = cloneEntity({ ...form, ...types, form: newFormId, formTextId: { name: formTextIdName, description: formTextIdDescription } });
+
+  if (!inheritMoveSet) newForm.moveSet = [];
+
+  return newForm;
 };
 
 /**

--- a/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
+++ b/src/views/components/database/pokemon/editors/PokemonFormNewEditor.tsx
@@ -1,22 +1,22 @@
+import { DarkButton, PrimaryButton } from '@components/buttons';
+import { Editor } from '@components/editor';
+import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
+import { InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
+import { Input, MultiLineInput, TextInputError } from '@components/inputs/Input';
+import { InputFormContainer } from '@components/inputs/InputContainer';
+import { Select } from '@ds/Select';
+import { useCreaturePage } from '@hooks/usePage';
+import { useProjectPokemon } from '@hooks/useProjectData';
+import { useZodForm } from '@hooks/useZodForm';
+import { CREATURE_FORM_DESCRIPTION_TEXT_ID, CREATURE_FORM_NAME_TEXT_ID, CREATURE_FORM_VALIDATOR, StudioCreature } from '@modelEntities/creature';
+import { useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
+import { cloneEntity } from '@utils/cloneEntity';
+import { createCreatureForm } from '@utils/entityCreation';
+import { TFunction } from 'i18next';
 import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TFunction } from 'i18next';
-import { Editor } from '@components/editor';
-import { InputWithTopLabelContainer, Label } from '@components/inputs';
 import styled from 'styled-components';
-import { DarkButton, PrimaryButton } from '@components/buttons';
-import { Input, MultiLineInput, TextInputError } from '@components/inputs/Input';
-import { useProjectPokemon } from '@hooks/useProjectData';
-import { cloneEntity } from '@utils/cloneEntity';
-import { CREATURE_FORM_DESCRIPTION_TEXT_ID, CREATURE_FORM_NAME_TEXT_ID, CREATURE_FORM_VALIDATOR, StudioCreature } from '@modelEntities/creature';
-import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
-import { useCreaturePage } from '@hooks/usePage';
-import { useZodForm } from '@hooks/useZodForm';
-import { InputFormContainer } from '@components/inputs/InputContainer';
 import { TypeFields } from './InformationEditor/TypeFields';
-import { Select } from '@ds/Select';
-import { useGetEntityDescriptionText, useSetProjectText } from '@utils/ReadingProjectText';
-import { createCreatureForm } from '@utils/entityCreation';
 
 export const FormCategories = ['classic', 'mega-evolution'] as const;
 export type FormCategory = (typeof FormCategories)[number];
@@ -57,6 +57,7 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const newFormId = findFirstFormNotUsed(creature, formCategory);
   const [formName, setFormName] = useState(creatureName);
+  const [inheritMoveSet, setInheritMoveSet] = useState(true);
 
   useEditorHandlingClose(ref);
 
@@ -64,7 +65,7 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
     const data = getFormData();
     if (data.success == false || !descriptionRef.current) return;
 
-    const newForm = createCreatureForm(creatures, form, data.data, newFormId);
+    const newForm = createCreatureForm(creatures, form, data.data, newFormId, inheritMoveSet);
     if (newFormId <= 29 && creatures[form.babyDbSymbol]?.forms.find((f) => f.form === newFormId)) newForm.babyForm = newFormId;
 
     const updatedCreature = cloneEntity(creature);
@@ -99,6 +100,10 @@ export const PokemonFormNewEditor = forwardRef<EditorHandlingClose, Props>(({ cl
             <TextInputError>{t(formCategory === 'classic' ? 'error_classic_form' : 'error_mega_evolution_form')}</TextInputError>
           ) : null}
         </InputWithTopLabelContainer>
+        <InputWithLeftLabelContainer>
+          <Label>{t('inherit_movepool')}</Label>
+          <Toggle checked={inheritMoveSet} onChange={(event) => setInheritMoveSet(event.currentTarget.checked)} />
+        </InputWithLeftLabelContainer>
         <TypeFields form={form} defaults={defaults} />
         <ButtonContainer>
           <PrimaryButton onClick={onClickNew} disabled={isDisabled}>


### PR DESCRIPTION
## Description

Adds `Inherit movepool` option when creating a new Pokémon form.
- This option is enabled by default.
- When disabled, the new form will have an empty moveSet.

**Missing French translation for `inherit_movepool`**

Fix #764 

## Tests to perform

<!-- Explain all the scenario the tester has to test. -->
- When `Inherit movepool` is enabled, the new form should inherit the current form's movepool.
- When `Inherit movepool` is disabled, the new form should have an empty movepool.
- Existing form creation behavior should continue to work normally.
