### PR TITLE
Fix a crash when you quickly navigate to a type page using CTRL + Left clic

### DIFF
--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -1,28 +1,28 @@
-import type { StudioMove } from '@modelEntities/move';
-import {
-  getEntityNameTextUsingTextId,
-  getEntityNameText,
-  useGetEntityNameTextUsingTextId,
-  useGetEntityNameText,
-  useGetCreatureFormNameText,
-} from '@utils/ReadingProjectText';
-import { useProjectDataReadonly } from './useProjectData';
-import { useTextInfosReadonly } from './useTextInfos';
 import type { StudioDex } from '@modelEntities/dex';
-import type { StudioType } from '@modelEntities/type';
 import type { StudioItem } from '@modelEntities/item';
-import type { StudioNature } from '@modelEntities/nature';
 import type { StudioMap } from '@modelEntities/map';
+import type { StudioMove } from '@modelEntities/move';
+import type { StudioNature } from '@modelEntities/nature';
+import type { StudioType } from '@modelEntities/type';
 import { Language } from '@pages/texts/Translation.page';
 import { useGlobalState } from '@src/GlobalStateProvider';
+import { useLoaderRef } from '@utils/loaderContext';
+import { checkValidMaplink } from '@utils/MapLinkUtils';
+import { getMapOverviewPath, join } from '@utils/path';
+import {
+  getEntityNameText,
+  getEntityNameTextUsingTextId,
+  useGetCreatureFormNameText,
+  useGetEntityNameText,
+  useGetEntityNameTextUsingTextId,
+} from '@utils/ReadingProjectText';
+import { getSetting } from '@utils/settings';
+import { showNotification } from '@utils/showNotification';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { join, getMapOverviewPath } from '@utils/path';
-import { showNotification } from '@utils/showNotification';
 import { useGeneratingMapOverview } from './useGeneratingMapOverview';
-import { useLoaderRef } from '@utils/loaderContext';
-import { getSetting } from '@utils/settings';
-import { checkValidMaplink } from '@utils/MapLinkUtils';
+import { useProjectDataReadonly } from './useProjectData';
+import { useTextInfosReadonly } from './useTextInfos';
 
 export const useAbilityPage = () => {
   const { projectDataValues: abilities, selectedDataIdentifier: dbSymbol, state } = useProjectDataReadonly('abilities', 'ability');
@@ -136,13 +136,14 @@ export const useDexPage = () => {
 export const useTypePage = () => {
   const { projectDataValues: types, selectedDataIdentifier: typeSelected } = useProjectDataReadonly('types', 'type');
   const getTypeName = useGetEntityNameTextUsingTextId();
-  const currentType: StudioType = types[typeSelected] || types[typeSelected];
+  const currentType: StudioType = types[typeSelected];
 
   return {
     types,
     typeDbSymbol: typeSelected,
     currentTypeName: getTypeName(currentType),
     currentType,
+    canBeDeleted: currentType.id <= 18,
   };
 };
 

--- a/src/views/pages/database/Type.page.tsx
+++ b/src/views/pages/database/Type.page.tsx
@@ -1,33 +1,25 @@
-import React, { useEffect } from 'react';
-import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
-import { TypeControlBar } from '@components/database/type/TypeControlBar';
-import { TypeFrame } from '@components/database/type/TypeFrame';
-import { useNavigate } from 'react-router-dom';
-import { DatabasePageStyle } from '@components/database/DatabasePageStyle';
-import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerStyle';
-import { TypeEfficiencyData } from '@components/database/type/TypeEfficiencyData';
-import { TypeResistanceData } from '@components/database/type/TypeResistanceData';
 import { DarkButton, DeleteButtonWithIcon } from '@components/buttons';
-import { useTranslation } from 'react-i18next';
+import { DatabasePageStyle } from '@components/database/DatabasePageStyle';
+import { DataBlockWithAction, DataBlockWrapper } from '@components/database/dataBlocks';
 import { DataBlockWithTitleNoActive } from '@components/database/dataBlocks/DataBlockWithTitle';
+import { TypeEditorAndDeletionKeys, TypeEditorOverlay } from '@components/database/type/editors/TypeEditorOverlay';
+import { TypeControlBar } from '@components/database/type/TypeControlBar';
+import { TypeEfficiencyData } from '@components/database/type/TypeEfficiencyData';
+import { TypeFrame } from '@components/database/type/TypeFrame';
+import { TypeResistanceData } from '@components/database/type/TypeResistanceData';
+import { TooltipWrapper } from '@ds/Tooltip';
 import { useDialogsRef } from '@hooks/useDialogsRef';
 import { useTypePage } from '@hooks/usePage';
-import { TypeEditorAndDeletionKeys, TypeEditorOverlay } from '@components/database/type/editors/TypeEditorOverlay';
-import { useProjectTypes } from '@hooks/useProjectData';
-import { TooltipWrapper } from '@ds/Tooltip';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { PageContainerStyle, PageDataConstrainerStyle } from './PageContainerStyle';
 
 export const TypePage = () => {
   const dialogsRef = useDialogsRef<TypeEditorAndDeletionKeys>();
-  const { setProjectDataValues: setType } = useProjectTypes();
-  const { currentTypeName, currentType } = useTypePage();
+  const { currentTypeName, currentType, canBeDeleted } = useTypePage();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const canBeDeleted: boolean = currentType.id <= 18;
-
-  useEffect(() => {
-    if (!currentType) return;
-    setType({ [currentType.dbSymbol]: currentType }, { type: currentType.dbSymbol });
-  }, [currentType]);
 
   return (
     <DatabasePageStyle>


### PR DESCRIPTION
## Description

Fix PR fixes a crash when an user quickly navigate to a type page using CTRL + Left clic

Closes #774 

## Tests to perform

- [x] The user can quickly navigate to a type page using CTRL + Left clic
- [x] The type page works correctly

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Fix a crash when you quickly navigate to a type page using CTRL + Left clic
<!-- changelog:end -->