### PR TITLE
Refactor move battle stage modifier editor

### DIFF
--- a/src/views/components/database/move/editors/MoveStatisticsEditor.tsx
+++ b/src/views/components/database/move/editors/MoveStatisticsEditor.tsx
@@ -1,39 +1,41 @@
-import React, { forwardRef, useMemo } from 'react';
 import { Editor } from '@components/editor';
-import { useTranslation } from 'react-i18next';
-import { MOVE_BATTLE_STAGE_MOD_LIST, StudioBattleStageMod, StudioMove } from '@modelEntities/move';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
-import { useMovePage } from '@hooks/usePage';
-import { useUpdateMove } from './useUpdateMove';
-import { useZodForm } from '@hooks/useZodForm';
-import { cloneEntity } from '@utils/cloneEntity';
-import { STATISTIC_EDITOR_SCHEMA } from './MoveStatisticsEditor/StatisticEditorSchema';
-import { BattleStageModEditor } from './MoveStatisticsEditor/BattleStageModEditor';
 import { InputFormContainer } from '@components/inputs/InputContainer';
+import { useMovePage } from '@hooks/usePage';
+import { useZodForm } from '@hooks/useZodForm';
+import { MOVE_BATTLE_STAGE_MOD_LIST, StudioBattleStageMod, StudioMove } from '@modelEntities/move';
+import React, { forwardRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BattleStageModEditor } from './MoveStatisticsEditor/BattleStageModEditor';
+import { MoveStatisticsFormData, STATISTIC_EDITOR_SCHEMA } from './MoveStatisticsEditor/StatisticEditorSchema';
+import { useUpdateMove } from './useUpdateMove';
 
-const initBattleStageMods = (move: StudioMove): StudioMove => {
-  const battleStagsMods = MOVE_BATTLE_STAGE_MOD_LIST.reduce<StudioBattleStageMod[]>((prev, stageMod) => {
-    const modificator = move.battleStageMod.find(({ battleStage }) => battleStage === stageMod)?.modificator;
-    prev.push({ battleStage: stageMod, modificator: modificator ?? 0 });
-    return prev;
-  }, []);
-  const moveWithBattleStageMods = cloneEntity(move);
-  moveWithBattleStageMods.battleStageMod = battleStagsMods;
-  return moveWithBattleStageMods;
-};
+const moveBattleStageToUI = (move: StudioMove): MoveStatisticsFormData => ({
+  battleStages: MOVE_BATTLE_STAGE_MOD_LIST.map((stage) => ({
+    type: stage,
+    value: move.battleStageMod.find(({ battleStage }) => battleStage === stage)?.modificator ?? 0,
+  })),
+});
+
+const uiToMoveBattleStage = ({ battleStages }: MoveStatisticsFormData): StudioBattleStageMod[] =>
+  battleStages
+    .filter(({ value }) => value !== 0)
+    .map(({ type: stage, value: modificator }) => ({
+      battleStage: stage,
+      modificator: modificator,
+    }));
 
 export const MoveStatisticsEditor = forwardRef<EditorHandlingClose>((_, ref) => {
   const { t } = useTranslation();
   const { move } = useMovePage();
   const updateMove = useUpdateMove(move);
-  const moveWithBattleStageMods = useMemo(() => initBattleStageMods(move), [move]);
-  const { canClose, getFormData, onInputTouched, defaults, formRef } = useZodForm(STATISTIC_EDITOR_SCHEMA, moveWithBattleStageMods);
+  const formData = useMemo(() => moveBattleStageToUI(move), [move]);
+  const { canClose, getFormData, onInputTouched, defaults, formRef } = useZodForm(STATISTIC_EDITOR_SCHEMA, formData);
 
   const onClose = () => {
     const result = canClose() && getFormData();
     if (result && result.success) {
-      const battleStageMods = result.data.battleStageMod.filter(({ modificator }) => modificator !== 0);
-      updateMove({ battleStageMod: battleStageMods });
+      updateMove({ battleStageMod: uiToMoveBattleStage(result.data) });
     }
   };
 

--- a/src/views/components/database/move/editors/MoveStatisticsEditor/BattleStageModEditor.tsx
+++ b/src/views/components/database/move/editors/MoveStatisticsEditor/BattleStageModEditor.tsx
@@ -14,8 +14,8 @@ export const BattleStageModEditor = ({ index, label, onTouched, defaults }: Batt
 
   return (
     <>
-      <Input name={`battleStageMod.${index}.battleStage`} style={{ display: 'none' }} />
-      <Input name={`battleStageMod.${index}.modificator`} label={label} labelLeft onInput={onTouched} />
+      <Input name={`battleStages.${index}.type`} style={{ display: 'none' }} />
+      <Input name={`battleStages.${index}.value`} label={label} labelLeft onInput={onTouched} />
     </>
   );
 };

--- a/src/views/components/database/move/editors/MoveStatisticsEditor/StatisticEditorSchema.ts
+++ b/src/views/components/database/move/editors/MoveStatisticsEditor/StatisticEditorSchema.ts
@@ -1,3 +1,15 @@
-import { MOVE_VALIDATOR } from '@modelEntities/move';
+import { MOVE_BATTLE_STAGE_MOD_LIST, MOVE_BATTLE_STAGE_VALIDATOR } from '@modelEntities/move';
+import { z } from 'zod';
 
-export const STATISTIC_EDITOR_SCHEMA = MOVE_VALIDATOR.pick({ battleStageMod: true });
+export const STATISTIC_EDITOR_SCHEMA = z.object({
+  battleStages: z
+    .array(
+      z.object({
+        type: MOVE_BATTLE_STAGE_VALIDATOR,
+        value: z.number().min(-99).max(99),
+      }),
+    )
+    .length(MOVE_BATTLE_STAGE_MOD_LIST.length),
+});
+
+export type MoveStatisticsFormData = z.infer<typeof STATISTIC_EDITOR_SCHEMA>;


### PR DESCRIPTION
## Description

Closes #53

This PR decouples the move statistics editor form data from the persisted `battleStageMod` structure.

It adds a new `{ type, value }` structure for the UI and converts data between it and `{ battleStage, modificator }` when loading and saving the form.

## Tests to perform

Since this doesn't add any new functionality, everything in the editor should work as usual.

- The editor should save both positive and negative values.
- The editor should reject values greater than `99` or less than `-99`.

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Refactor Move Battle Stage modifier editor
<!-- changelog:end -->