### PR TITLE
Add a Fast Debug Mode launch action and shortcut

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1322,6 +1322,7 @@
   "test": "Das Projekt testen",
   "play_release_mode": "Das Spiel spielen",
   "play_debug_mode": "Debug-Modus",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "Systemmarkierungen-Editor",
   "play_worldmap_mode": "Weltkarten-Editor",
   "not_available_yet": "Verfügbar in einer zukünftigen Version",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1322,6 +1322,7 @@
   "test": "Test the project",
   "play_release_mode": "Play the game",
   "play_debug_mode": "Debug mode",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "System Tags Editor",
   "play_worldmap_mode": "World Maps Editor",
   "not_available_yet": "Available in a future release",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1322,6 +1322,7 @@
   "test": "Probar el proyecto",
   "play_release_mode": "Jugar al juego",
   "play_debug_mode": "Modo Debug",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "Editor de System Tags",
   "play_worldmap_mode": "Editor de World Maps",
   "not_available_yet": "Disponible en una versión futura",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1322,6 +1322,7 @@
   "test": "Tester le projet",
   "play_release_mode": "Lancer le jeu",
   "play_debug_mode": "Mode Debug",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "Éditeur de System Tags",
   "play_worldmap_mode": "Éditeur de World Maps",
   "not_available_yet": "Disponible dans une prochaine version",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1322,7 +1322,7 @@
   "test": "Tester le projet",
   "play_release_mode": "Lancer le jeu",
   "play_debug_mode": "Mode Debug",
-  "play_fast_debug_mode": "Fast Debug Mode",
+  "play_fast_debug_mode": "Mode Debug rapide",
   "play_tags_mode": "Éditeur de System Tags",
   "play_worldmap_mode": "Éditeur de World Maps",
   "not_available_yet": "Disponible dans une prochaine version",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1322,6 +1322,7 @@
   "test": "Testare il progetto",
   "play_release_mode": "Avviare il gioco",
   "play_debug_mode": "Modalità Debug",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "Editor di System Tags",
   "play_worldmap_mode": "Editor di World Maps",
   "not_available_yet": "Disponibile in versioni future",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -1322,6 +1322,7 @@
   "test": "Test the project",
   "play_release_mode": "Play the game",
   "play_debug_mode": "Debug mode",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "System Tags Editor",
   "play_worldmap_mode": "World Maps Editor",
   "not_available_yet": "Available in a future release",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -1322,6 +1322,7 @@
   "test": "Test the project",
   "play_release_mode": "Play the game",
   "play_debug_mode": "Debug mode",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "System Tags Editor",
   "play_worldmap_mode": "World Maps Editor",
   "not_available_yet": "Available in a future release",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1322,6 +1322,7 @@
   "test": "Testar o projeto",
   "play_release_mode": "Iniciar o jogo",
   "play_debug_mode": "Mode Debug",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "Editor de System Tag",
   "play_worldmap_mode": "Editor de World Maps",
   "not_available_yet": "Disponível numa proxima versão",

--- a/assets/i18n/zh_Hans.json
+++ b/assets/i18n/zh_Hans.json
@@ -1322,6 +1322,7 @@
   "test": "Test the project",
   "play_release_mode": "Play the game",
   "play_debug_mode": "Debug mode",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "System Tags Editor",
   "play_worldmap_mode": "World Maps Editor",
   "not_available_yet": "Available in a future release",

--- a/assets/i18n/zh_Hant.json
+++ b/assets/i18n/zh_Hant.json
@@ -1322,6 +1322,7 @@
   "test": "Test the project",
   "play_release_mode": "Play the game",
   "play_debug_mode": "Debug mode",
+  "play_fast_debug_mode": "Fast Debug Mode",
   "play_tags_mode": "System Tags Editor",
   "play_worldmap_mode": "World Maps Editor",
   "not_available_yet": "Available in a future release",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,7 +54,7 @@ import { registerShowItemInFolder } from '../backendTasks/showFileInFolder';
 import { registerWriteProjectMetadata } from '../backendTasks/writeProjectMetadata';
 import { getLastPSDKVersion } from '../services/getLastPSDKVersion';
 import { getPSDKBinariesPath, getPSDKVersion } from '../services/getPSDKVersion';
-import { startPSDK, startPSDKDebug, startPSDKWorldmap } from '../services/startPSDK';
+import { startPSDK, startPSDKDebug, startPSDKFastDebug, startPSDKWorldmap } from '../services/startPSDK';
 import { updatePSDK } from '../services/updatePSDK';
 import MenuBuilder from './menu';
 
@@ -156,6 +156,7 @@ ipcMain.on('get-last-psdk-version', getLastPSDKVersion);
 ipcMain.on('update-psdk', updatePSDK);
 ipcMain.on('start-psdk', (_, projectPath: string) => startPSDK(projectPath));
 ipcMain.on('start-psdk-debug', (_, projectPath: string) => startPSDKDebug(projectPath));
+ipcMain.on('start-psdk-fast-debug', (_, projectPath: string) => startPSDKFastDebug(projectPath));
 ipcMain.on('start-psdk-worldmap', (_, projectPath: string) => startPSDKWorldmap(projectPath));
 ipcMain.on('external-window', (_, arg) => shell.openExternal(arg));
 registerGetStudioVersion(ipcMain);

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -85,6 +85,13 @@ export default class MenuBuilder {
               this.mainWindow.webContents.send('request-shortcut', 'play');
             },
           },
+          {
+            label: 'Fast Debug Mode',
+            accelerator: 'CmdOrCtrl+Shift+D',
+            click: () => {
+              this.mainWindow.webContents.send('request-shortcut', 'fast_debug');
+            },
+          },
           { type: 'separator' },
           {
             label: 'Quit',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -87,7 +87,7 @@ export default class MenuBuilder {
           },
           {
             label: 'Fast Debug Mode',
-            accelerator: 'CmdOrCtrl+Shift+D',
+            accelerator: 'CmdOrCtrl+Shift+P',
             click: () => {
               this.mainWindow.webContents.send('request-shortcut', 'fast_debug');
             },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -205,6 +205,7 @@ declare global {
       unregisterPSDKUpdateEvents: () => void;
       startPSDK: (projectPath: string) => void;
       startPSDKDebug: (projectPath: string) => void;
+      startPSDKFastDebug: (projectPath: string) => void;
       startPSDKWorldmap: (projectPath: string) => void;
       platform: string;
       externalWindow: (link: string) => void;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -106,6 +106,9 @@ contextBridge.exposeInMainWorld('api', {
   startPSDKDebug: (projectPath: string) => {
     ipcRenderer.send('start-psdk-debug', projectPath);
   },
+  startPSDKFastDebug: (projectPath: string) => {
+    ipcRenderer.send('start-psdk-fast-debug', projectPath);
+  },
   startPSDKWorldmap: (projectPath: string) => {
     ipcRenderer.send('start-psdk-worldmap', projectPath);
   },

--- a/src/services/startPSDK.ts
+++ b/src/services/startPSDK.ts
@@ -119,4 +119,5 @@ const startPSDKWithArgs = (projectPath: string, ...args: string[]) => {
 };
 
 export const startPSDKDebug = (projectPath: string) => startPSDKWithArgs(projectPath, 'debug');
+export const startPSDKFastDebug = (projectPath: string) => startPSDKWithArgs(projectPath, 'debug', 'skip_title');
 export const startPSDKWorldmap = (projectPath: string) => startPSDKWithArgs(projectPath, '--worldmap');

--- a/src/views/components/buttons/PlayButton.tsx
+++ b/src/views/components/buttons/PlayButton.tsx
@@ -101,6 +101,7 @@ export const PlayButton = () => {
     const isShortcutEnabled = () => !document.querySelector('#dialogs')?.textContent;
     return {
       play: () => isShortcutEnabled() && startPSDKAndCloseMenu(window.api.startPSDKDebug),
+      fast_debug: () => isShortcutEnabled() && startPSDKAndCloseMenu(window.api.startPSDKFastDebug),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.projectPath]);
@@ -118,6 +119,7 @@ export const PlayButton = () => {
         <div className="play-menu">
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDK)}>{t('play_release_mode')}</span>
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKDebug)}>{t('play_debug_mode')}</span>
+          <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKFastDebug)}>{t('play_fast_debug_mode')}</span>
           <span onClick={() => startPSDKAndCloseMenu(window.api.startPSDKWorldmap)}>{t('play_worldmap_mode')}</span>
         </div>
       </PlayMenuButtonContainer>


### PR DESCRIPTION
## Summary
This PR adds a new **Fast Debug Mode** launch action that skips the title screen and introduction, providing the fastest possible path into gameplay for developers who need to iterate quickly.

## Root cause
The existing launch options (Play, Debug Mode, World Maps Editor) do not provide a way to skip the title screen. Users who test frequently must replay the introduction each time they launch the game.

## Changes
- Add  in  that passes  arguments to PSDK
- Expose  through the preload API and main IPC bridge
- Add **Fast Debug Mode** to the Play button dropdown menu alongside existing launch options
- Add a menu bar shortcut () and keyboard shortcut handler for Fast Debug Mode
- Add  translation key to all supported locales

## Testing
- 
/home/c436zhan/oss-work/PokemonWorkshop__PokemonStudio__issue-778/src/preload.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/ban-ts-comment')

✖ 1 problem (0 errors, 1 warning)
  0 errors and 1 warning potentially fixable with the `--fix` option. — 0 errors, 1 pre-existing warning
-  — clean
- Changes follow existing launch-mode architecture patterns exactly

Fixes #778

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Add a Fast Debug Mode launch action and shortcut using CTRL + Shift + P
<!-- changelog:end -->