### PR TITLE
Preserve trailing newline when writing i18n JSON files

### DIFF
--- a/updater_i18n.js
+++ b/updater_i18n.js
@@ -70,7 +70,7 @@ try {
     }
 
     if (syncJson(baseJson, targetJson) || isNewFile) {
-      fs.writeFileSync(targetPath, JSON.stringify(targetJson, null, 2), 'utf-8');
+      fs.writeFileSync(targetPath, `${JSON.stringify(targetJson, null, 2)}\n`, 'utf-8');
       console.log(`✅ ${lang}.json ${isNewFile ? 'created' : 'updated'} (ACTIVE).`);
     } else {
       console.log(`✅ ${lang}.json is already up-to-date (ACTIVE).`);
@@ -89,7 +89,7 @@ try {
     }
 
     if (syncJson(baseJson, targetJson)) {
-      fs.writeFileSync(targetPath, JSON.stringify(targetJson, null, 2), 'utf-8');
+      fs.writeFileSync(targetPath, `${JSON.stringify(targetJson, null, 2)}\n`, 'utf-8');
       console.log(`📝 ${lang}.json updated (INACTIVE).`);
     }
   });

--- a/updater_i18n.js
+++ b/updater_i18n.js
@@ -50,7 +50,13 @@ const i18nDir = './assets/i18n';
 const languages = require('./package.json').languages || {};
 
 try {
-  const baseJson = JSON.parse(fs.readFileSync(basePath, 'utf-8'));
+  const baseContent = fs.readFileSync(basePath, 'utf-8');
+  const baseJson = JSON.parse(baseContent);
+
+  const normalizedBaseContent = `${JSON.stringify(baseJson, null, 2)}\n`;
+  if (baseContent !== normalizedBaseContent) {
+    fs.writeFileSync(basePath, normalizedBaseContent, 'utf-8');
+  }
 
   const allLangs = Object.keys(languages);
   const activeLangs = allLangs.filter((lang) => languages[lang]['active']);


### PR DESCRIPTION
## Description

Le script `updater_i18n.js` écrivait les fichiers de traduction (`assets/i18n/*.json`) avec `JSON.stringify()` sans saut de ligne final, ce qui supprimait le `\n` de fin de fichier à chaque synchronisation et générait des PR ne contenant que ce changement parasite. Les deux écritures (langues actives et inactives) ajoutent maintenant systématiquement un `\n` final.

## Note before testing

Aucune action particulière requise, le changement est purement interne au script de synchronisation i18n.

## Tests to perform

- Modifier temporairement une clé dans `assets/i18n/en.json` puis lancer `node updater_i18n.js` (ou `npm start`) et vérifier que les fichiers `assets/i18n/*.json` réécrits se terminent bien par un saut de ligne.
- Relancer `node updater_i18n.js` sans modification et vérifier qu'aucun fichier n'est marqué comme modifié (`git status` propre).

## Changelog entry

<!-- changelog:start -->
Preserve trailing newline when writing i18n JSON files
<!-- changelog:end -->
