### PR TITLE
Add optional text preservation when creating a trainer from an existing one

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "Du kannst Items von einem anderen Trainer importieren.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "You can create this new item by importing data from another existing item.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "Puedes crear esta nueva misión importando datos de otra misión existente.",
   "item_import_info": "Puedes crear este nuevo objeto importando datos de otro objeto existente.",
   "trainer_import_info": "Puedes crear este nuevo entrenador importando datos de otro entrenador existente.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Oculto por defecto",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "Vous pouvez créer cette nouvelle quête en copiant les données d'une autre quête déjà existante.",
   "item_import_info": "Vous pouvez créer ce nouvel objet en copiant les données d'un autre objet déjà existant.",
   "trainer_import_info": "Vous pouvez créer ce nouveau dresseur en copiant les données d'un autre dresseur déjà existant.",
+  "preserve_text_data": "Copier les textes",
+  "preserve_text_data_info": "Copie également les textes et les traductions depuis l'entité de référence.",
   "hidden_default": "Masqué par défaut",
   "placeholder_select": "Sélectionner une option",
   "placeholder_select_all": "Tout sélectionner",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "Puoi creare questa nuova missione importando i dati di un'altra missione esistente.",
   "item_import_info": "Puoi creare questo nuovo strumento importando i dati di un altro strumento esistente.",
   "trainer_import_info": "Puoi creare questo nuovo allenatore importando i dati di un altro allenatore esistente.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "You can create this new item by importing data from another existing item.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "You can create this new item by importing data from another existing item.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "Você pode criar esta nova missão importando dados de outra missão existente.",
   "item_import_info": "Você pode criar este novo item importando dados de outro item existente.",
   "trainer_import_info": "Você pode criar este novo trainer importando dados de outro trainer existente.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Oculto por padrão",
   "placeholder_select": "Selecionar opção",
   "placeholder_select_all": "Selecionar tudo",

--- a/assets/i18n/zh_Hans.json
+++ b/assets/i18n/zh_Hans.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "You can create this new item by importing data from another existing item.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/assets/i18n/zh_Hant.json
+++ b/assets/i18n/zh_Hant.json
@@ -1541,6 +1541,8 @@
   "quest_import_info": "You can create this new quest by importing data from another existing quest.",
   "item_import_info": "You can create this new item by importing data from another existing item.",
   "trainer_import_info": "You can create this new trainer by importing data from another existing trainer.",
+  "preserve_text_data": "Copy texts",
+  "preserve_text_data_info": "Also copies the text and translations from the reference entity.",
   "hidden_default": "Hidden by default",
   "placeholder_select": "Select option",
   "placeholder_select_all": "Select all",

--- a/src/views/components/database/trainer/editors/TrainerNewEditor.tsx
+++ b/src/views/components/database/trainer/editors/TrainerNewEditor.tsx
@@ -3,7 +3,7 @@ import { Editor } from '@components/editor';
 
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
+import { Input, InputContainer, InputWithLeftLabelContainer, InputWithTopLabelContainer, Label, Toggle } from '@components/inputs';
 import { InputGroupCollapse } from '@components/inputs/InputContainerCollapse';
 import { SelectCustomSimple, SelectCustomWithInput } from '@components/SelectCustom';
 import { SelectTrainer } from '@components/selects';
@@ -21,7 +21,7 @@ import {
   TRAINER_VICTORY_SENTENCE_TEXT_ID,
   TRAINER_VS_TYPE_CATEGORIES,
 } from '@modelEntities/trainer';
-import { useSetProjectText, useGetProjectText } from '@utils/ReadingProjectText';
+import { useSetProjectText, useGetProjectText, useCopyProjectText } from '@utils/ReadingProjectText';
 import { createTrainer } from '@utils/entityCreation';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { TooltipWrapper } from '@ds/Tooltip';
@@ -72,10 +72,42 @@ export const TrainerNewEditor = forwardRef<EditorHandlingClose, TrainerNewEditor
   const [baseMoneyError, setBaseMoneyError] = useState<'value' | undefined>(undefined);
   const setText = useSetProjectText();
   const getText = useGetProjectText();
+  const copyText = useCopyProjectText();
   const [selectedTrainer, setSelectedTrainer] = useState('__undef__');
   const [importing, setImporting] = useState(false);
+  const [preserveTextData, setPreserveTextData] = useState(false);
 
   useEditorHandlingClose(ref);
+
+  const classLockedByImport = importing && selectedTrainer !== '__undef__' && preserveTextData;
+
+  const prefillFromTrainer = (dbSymbol: string) => {
+    if (dbSymbol === '__undef__') return;
+    const sourceTrainer = trainers[dbSymbol];
+    // Keep whatever the user already typed as the name; the class is always synced since it's locked while preserving
+    if (!name) setName(getText(TRAINER_NAME_TEXT_ID, sourceTrainer.id));
+    setTrainerClass(getText(TRAINER_CLASS_TEXT_ID, sourceTrainer.id));
+  };
+
+  const onTrainerToImportChange = (dbSymbol: string) => {
+    setSelectedTrainer(dbSymbol);
+    if (preserveTextData) prefillFromTrainer(dbSymbol);
+  };
+
+  const onPreserveTextDataChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.currentTarget.checked;
+    setPreserveTextData(checked);
+    if (checked) prefillFromTrainer(selectedTrainer);
+  };
+
+  // Copies a text across every project language from an existing entity's row to the new trainer's row, then
+  // re-applies currentLanguageValue on top so the current language always reflects what's shown in the dialog
+  // (setText is called first to guarantee the destination row exists before copyText writes into it)
+  const preserveText = (fileId: number, srcId: number, destId: number, currentLanguageValue: string) => {
+    setText(fileId, destId, currentLanguageValue);
+    copyText({ fileId, textId: srcId + 1 }, { fileId, textId: destId + 1 });
+    setText(fileId, destId, currentLanguageValue);
+  };
 
   const onClickNew = () => {
     if (!baseMoneyRef.current || !battleIdRef.current) return;
@@ -83,17 +115,26 @@ export const TrainerNewEditor = forwardRef<EditorHandlingClose, TrainerNewEditor
     let newTrainer = createTrainer(trainers, ai, vsType, battleIdRef.current.valueAsNumber, baseMoneyRef.current.valueAsNumber);
 
     if (importing && selectedTrainer !== '__undef__') {
-      setText(TRAINER_VICTORY_SENTENCE_TEXT_ID, newTrainer.id, getText(TRAINER_VICTORY_SENTENCE_TEXT_ID, trainers[selectedTrainer].id));
-      setText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, newTrainer.id, getText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, trainers[selectedTrainer].id));
+      const sourceTrainer = trainers[selectedTrainer];
+      if (preserveTextData) {
+        preserveText(TRAINER_VICTORY_SENTENCE_TEXT_ID, sourceTrainer.id, newTrainer.id, getText(TRAINER_VICTORY_SENTENCE_TEXT_ID, sourceTrainer.id));
+        preserveText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, sourceTrainer.id, newTrainer.id, getText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, sourceTrainer.id));
+        preserveText(TRAINER_CLASS_TEXT_ID, sourceTrainer.id, newTrainer.id, trainerClass);
+        preserveText(TRAINER_NAME_TEXT_ID, sourceTrainer.id, newTrainer.id, name);
+      } else {
+        setText(TRAINER_VICTORY_SENTENCE_TEXT_ID, newTrainer.id, getText(TRAINER_VICTORY_SENTENCE_TEXT_ID, sourceTrainer.id));
+        setText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, newTrainer.id, getText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, sourceTrainer.id));
+        setText(TRAINER_CLASS_TEXT_ID, newTrainer.id, trainerClass);
+        setText(TRAINER_NAME_TEXT_ID, newTrainer.id, name);
+      }
 
-      newTrainer = importTrainerData(newTrainer, trainers[selectedTrainer]);
+      newTrainer = importTrainerData(newTrainer, sourceTrainer);
     } else {
       setText(TRAINER_VICTORY_SENTENCE_TEXT_ID, newTrainer.id, '');
       setText(TRAINER_DEFEAT_SENTENCE_TEXT_ID, newTrainer.id, '');
+      setText(TRAINER_CLASS_TEXT_ID, newTrainer.id, trainerClass);
+      setText(TRAINER_NAME_TEXT_ID, newTrainer.id, name);
     }
-
-    setText(TRAINER_CLASS_TEXT_ID, newTrainer.id, trainerClass);
-    setText(TRAINER_NAME_TEXT_ID, newTrainer.id, name);
 
     setTrainer({ [newTrainer.dbSymbol]: newTrainer }, { trainer: newTrainer.dbSymbol });
     closeDialog();
@@ -131,7 +172,13 @@ export const TrainerNewEditor = forwardRef<EditorHandlingClose, TrainerNewEditor
           <Label htmlFor="trainer-name" required>
             {t('trainer_name')}
           </Label>
-          <Input type="text" name="name" value={name} onChange={(event) => setName(event.target.value)} placeholder={t('example_trainer_name')} />
+          <Input
+            type="text"
+            name="name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={t('example_trainer_name')}
+          />
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
           <Label htmlFor="trainer-class" required>
@@ -143,6 +190,7 @@ export const TrainerNewEditor = forwardRef<EditorHandlingClose, TrainerNewEditor
             value={trainerClass}
             onChange={(event) => setTrainerClass(event.target.value)}
             placeholder={t('example_trainer_class')}
+            disabled={classLockedByImport}
           />
         </InputWithTopLabelContainer>
         <InputWithTopLabelContainer>
@@ -185,13 +233,17 @@ export const TrainerNewEditor = forwardRef<EditorHandlingClose, TrainerNewEditor
           </ImportInfoContainer>
           <InputWithTopLabelContainer>
             <Label htmlFor="select-trainer-to-import">{t('import_data_from')}</Label>
-            <SelectTrainer
-              dbSymbol={selectedTrainer}
-              onChange={(dbSymbol) => setSelectedTrainer(dbSymbol)}
-              noLabel
-              undefValueOption={t('none_option')}
-            />
+            <SelectTrainer dbSymbol={selectedTrainer} onChange={onTrainerToImportChange} noLabel undefValueOption={t('none_option')} />
           </InputWithTopLabelContainer>
+          {selectedTrainer !== '__undef__' && (
+            <ImportInfoContainer>
+              <InputWithLeftLabelContainer>
+                <Label htmlFor="preserve-text-data">{t('preserve_text_data')}</Label>
+                <Toggle name="preserve-text-data" checked={preserveTextData} onChange={onPreserveTextDataChange} />
+              </InputWithLeftLabelContainer>
+              <ImportInfo>{t('preserve_text_data_info')}</ImportInfo>
+            </ImportInfoContainer>
+          )}
         </InputGroupCollapse>
         <ButtonContainer>
           <TooltipWrapper data-tooltip={checkDisabled() ? t('fields_asterisk_required') : undefined}>


### PR DESCRIPTION
## Description

Add a "Copy texts" toggle to the New Trainer dialog's import section, shown only when an existing trainer is selected as the import source.

When enabled, the trainer's Name, Trainer Class, and Victory/Defeat sentences are copied across every project language (via `useCopyProjectText`) instead of only the current UI language, avoiding the loss of existing translations when duplicating trainers.

- Trainer Class is locked to the source value while the toggle is on.
- Name stays editable and keeps whatever the user already typed before toggling; it's only pre-filled from the source when still empty.
- Each copied field's row is created via `setText` before `copyText` runs, and the current language is re-applied afterward, since `useCopyProjectText` indexes rows without the header offset and only ever wrote into existing rows in its other call sites.

Adds the `preserve_text_data` / `preserve_text_data_info` i18n keys (en, fr).

## Note before testing

The `preserve_text_data` / `preserve_text_data_info` keys are currently only translated for English and French; other locales will fall back to the default language until translated.

## Tests to perform

- Open the database, go to Trainers, click "New Trainer".
- Expand "Other data" and select an existing trainer in "Import data from" — the "Copy texts" toggle should appear.
- With the toggle **off**: creating the trainer should behave exactly as before (manual Name/Class entry, Victory/Defeat sentences copied only in the current UI language).
- With the toggle **on**:
  - Trainer Class field becomes disabled and pre-filled with the source trainer's class.
  - Name field stays editable; if you type a name before enabling the toggle, it must NOT be overwritten. If left empty, it pre-fills from the source.
  - Create the trainer, then switch the project's UI language and confirm Name, Trainer Class, Victory Sentence, and Defeat Sentence all match the source trainer in every language.
- Confirm no duplicate/incorrect CSV rows are created (i.e. the new trainer's texts don't clobber the source trainer's texts, and each field lands on the correct row).

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Add optional Text preservation when creating a Trainer from an existing one
<!-- changelog:end -->