### PR TITLE
Fix splicing the wrong condition when you add a group to a zone

### DIFF
--- a/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneAddGroupEditor.tsx
@@ -1,26 +1,26 @@
 import React, { forwardRef, useState } from 'react';
-import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
+import { DarkButton, PrimaryButton, SecondaryButton } from '@components/buttons';
 import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
 import { InputContainer, InputWithTopLabelContainer, Label } from '@components/inputs';
 import { SelectGroup } from '@components/selects';
-import { DarkButton, PrimaryButton, SecondaryButton } from '@components/buttons';
 import { TagWithSelection } from '@components/Tag';
 import { TooltipWrapper } from '@ds/Tooltip';
 
 import { useZonePage } from '@src/hooks/usePage';
 
+import { DbSymbol } from '@modelEntities/dbSymbol';
 import { StudioGroup } from '@modelEntities/group';
 import { StudioZone } from '@modelEntities/zone';
-import { DbSymbol } from '@modelEntities/dbSymbol';
 
-import { padStr } from '@utils/PadStr';
+import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
 import { cloneEntity } from '@utils/cloneEntity';
 import { defineRelationCustomCondition } from '@utils/GroupUtils';
+import { padStr } from '@utils/PadStr';
 import { useUpdateZone } from './useUpdateZone';
-import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
 
 const GroupContainer = styled.div`
   display: flex;
@@ -43,7 +43,7 @@ const ButtonContainer = styled.div`
 `;
 
 const mapIdIndexInGroup = (mapId: number, group: StudioGroup) =>
-  group.customConditions.filter((condition) => condition.type === 'mapId').findIndex((condition) => condition.value === mapId);
+  group.customConditions.findIndex((condition) => condition.type === 'mapId' && condition.value === mapId);
 
 const setAllTagsMapsOnByDefault = (group: StudioGroup, zone: StudioZone) => {
   zone.maps.forEach((mapId) => {

--- a/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
+++ b/src/views/components/database/zone/editors/ZoneEditGroupEditor.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useState } from 'react';
-import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import { Editor } from '@components/editor';
 import { EditorHandlingClose, useEditorHandlingClose } from '@components/editor/useHandleCloseEditor';
@@ -10,14 +10,14 @@ import { TagWithSelection } from '@components/Tag';
 
 import { useZonePage } from '@src/hooks/usePage';
 
-import { StudioGroup } from '@modelEntities/group';
 import { DbSymbol } from '@modelEntities/dbSymbol';
+import { StudioGroup } from '@modelEntities/group';
 
-import { padStr } from '@utils/PadStr';
-import { cloneEntity } from '@utils/cloneEntity';
-import { useUpdateZone } from './useUpdateZone';
 import { useUpdateGroup } from '@components/database/group/editors/useUpdateGroup';
+import { cloneEntity } from '@utils/cloneEntity';
 import { defineRelationCustomCondition } from '@utils/GroupUtils';
+import { padStr } from '@utils/PadStr';
+import { useUpdateZone } from './useUpdateZone';
 
 const MapsListContainer = styled.div`
   display: flex;
@@ -27,7 +27,7 @@ const MapsListContainer = styled.div`
 `;
 
 const mapIdIndexInGroup = (mapId: number, group: StudioGroup) =>
-  group.customConditions.filter((condition) => condition.type === 'mapId').findIndex((condition) => condition.value === mapId);
+  group.customConditions.findIndex((condition) => condition.type === 'mapId' && condition.value === mapId);
 
 const rejectedGroup = (wildGroups: string[], group: StudioGroup) => {
   const wildGroupsCopy = Object.assign([], wildGroups);


### PR DESCRIPTION
## Description

This PR fixes the issue by searching for the index directly in the original `customConditions` array, while checking both the condition type and value.

Hi, I want to help, but I'm not very confident with my skills, so please take a close look.

I think the bug happened because `ZoneEditGroupEditor.tsx` and `ZoneAddGroupEditor.tsx` used this logic:

```ts
group.customConditions
  .filter((condition) => condition.type === 'mapId')
  .findIndex((condition) => condition.value === mapId);
```

The index returned here comes from the filtered `mapId` conditions array, not from the original `customConditions` array.

Later, the code uses that index on the original copied array:

```ts
customConditions.splice(index, 1);
```

This can remove the wrong condition.

Example:

```ts
const original = [
  { type: 'should not be deleted', value: 1 },
  { type: 'mapId', value: 2 },
  { type: 'mapId', value: 3 },
];
```

After filtering by `mapId`, the array becomes:

```ts
[
  { type: 'mapId', value: 2 },
  { type: 'mapId', value: 3 },
]
```

If the user removes map `2`, the index is `0` in the filtered array.

But then the code calls:

```ts
customConditions.splice(0, 1);
```

on the original copied array, so it removes:

```ts
{ type: 'should not be deleted', value: 1 }
```

After that, when `getActivationValue` in `GroupUtils.ts` reads the group, the `should not be deleted` condition is gone, so the activation falls back to `'always'`.

Fixes #783


## Tests to perform

The bug should be fixed, and other functions should not be affected.

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Fix splicing the wrong condition when you add a group to a zone
<!-- changelog:end -->