### PR TITLE
Added Shortcut Page to Settings

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Cartes Tiled assignées avec succès",
   "assigning_tiled_maps_error": "Erreur lors de l'assignation des cartes Tiled",
   "max_trainer_party_size": "Nombre maximum de créatures dans l'équipe d'un dresseur",
-  "add_trainer_party_max_size_to_settings": "Ajout de la taille maximale de l'équipe d'un dresseur aux paramètres du projet"
+  "add_trainer_party_max_size_to_settings": "Ajout de la taille maximale de l'équipe d'un dresseur aux paramètres du projet",
+  "keyboard_shortcuts": "Raccourcis clavier",
+  "shortcut_category_default": "Raccourcis par défaut",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Divers",
+  "shortcut_save_project": "Sauvegarder les modifications apportées au projet",
+  "shortcut_create_entry": "Créer un nouvel élément dans la base de données",
+  "shortcut_copy_id": "Copier l'identifiant d'une entrée de la base de données",
+  "shortcut_start_debug": "Démarrer le jeu en mode debug",
+  "shortcut_navigate_list": "Naviguer entre les éléments d'une liste",
+  "shortcut_navigate_secondary_list": "Naviguer entre les éléments d'une liste secondaire",
+  "shortcut_toggle_fullscreen": "Afficher en plein écran",
+  "shortcut_minimize_window": "Réduire la fenêtre",
+  "shortcut_open_devtools": "Afficher les Developer Tools",
+  "app_settings": "Parametres de L'appli"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/zh_Hans.json
+++ b/assets/i18n/zh_Hans.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/assets/i18n/zh_Hant.json
+++ b/assets/i18n/zh_Hant.json
@@ -1918,5 +1918,19 @@
   "assigning_tiled_maps_success": "Tiled maps successfully assigned",
   "assigning_tiled_maps_error": "Error while assigning Tiled maps",
   "max_trainer_party_size": "Max trainer party size",
-  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings"
+  "add_trainer_party_max_size_to_settings": "Add trainer party max size to settings",
+  "keyboard_shortcuts": "Keyboard Shortcuts",
+  "shortcut_category_default": "Default shortcuts",
+  "shortcut_category_navigation": "Navigation",
+  "shortcut_category_miscellaneous": "Miscellaneous",
+  "shortcut_save_project": "Save Project Changes",
+  "shortcut_create_entry": "Create a new database entry",
+  "shortcut_copy_id": "Copy the selected database entry ID",
+  "shortcut_start_debug": "Start the game in debug mode",
+  "shortcut_navigate_list": "Navigate between items in a list",
+  "shortcut_navigate_secondary_list": "Navigate between items in a secondary list",
+  "shortcut_toggle_fullscreen": "Toggle Fullscreen",
+  "shortcut_minimize_window": "Minimize Window",
+  "shortcut_open_devtools": "Open Developer Tools",
+  "app_settings": "App Settings"
 }

--- a/src/views/components/database/dataBlocks/DataFieldsetField.tsx
+++ b/src/views/components/database/dataBlocks/DataFieldsetField.tsx
@@ -2,7 +2,7 @@ import { IClickable } from '@hooks/useShortcutNavigation';
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
-/* eslint-disable react/require-default-props */
+// eslint-disable react/require-default-props
 type FieldSize = 's' | 'm';
 
 type FieldsetProps = {
@@ -65,7 +65,7 @@ export const FieldData = styled.span<FieldDataProps>`
   }
 `;
 
-const FieldCode = styled.span`
+export const FieldCode = styled.span`
   border-radius: 4px;
   padding: 4px 8px;
   ${(props) => props.theme.fonts.codeRegular};

--- a/src/views/components/settings/SettingsNavigation.tsx
+++ b/src/views/components/settings/SettingsNavigation.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { NavigationDatabaseStyle } from '@components/database/navigation/NavigationDatabase/NavigationDatabaseStyle';
 import { NavigationDatabaseGroup } from '@components/database/navigation/NavigationDatabaseGroup';
 import { NavigationDatabaseItem } from '@components/database/navigation/NavigationDatabaseItem';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const SettingsNavigation = () => {
@@ -10,6 +10,9 @@ export const SettingsNavigation = () => {
     <NavigationDatabaseStyle>
       <NavigationDatabaseGroup title={t('user_settings')}>
         <NavigationDatabaseItem path="/settings/language" label={t('language')} />
+      </NavigationDatabaseGroup>
+      <NavigationDatabaseGroup title={t('app_settings')}>
+        <NavigationDatabaseItem path="/settings/shortcuts" label={t('keyboard_shortcuts')} />
       </NavigationDatabaseGroup>
       <NavigationDatabaseGroup title={t('integrations')}>
         <NavigationDatabaseItem path="/settings/maps" label={t('map_management')} />

--- a/src/views/pages/settings/Settings.Router.page.tsx
+++ b/src/views/pages/settings/Settings.Router.page.tsx
@@ -1,9 +1,10 @@
+import { PageWithMenu, PageWithMenuProps } from '@components/pages';
+import { SettingsNavigation } from '@components/settings';
 import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
-import { SettingsNavigation } from '@components/settings';
-import { SettingsMapsPage } from './Settings.maps.page';
 import { SettingsLanguagePage } from './Settings.language.page';
-import { PageWithMenu, PageWithMenuProps } from '@components/pages';
+import { SettingsMapsPage } from './Settings.maps.page';
+import { SettingsShortcutsPage } from './Settings.shortcuts.page';
 
 const SettingsPageWithMenu = ({ children }: Omit<PageWithMenuProps, 'navigation'>) => (
   <PageWithMenu navigation={<SettingsNavigation />}>{children}</PageWithMenu>
@@ -26,6 +27,14 @@ const SettingsRouterComponent = () => {
         element={
           <SettingsPageWithMenu>
             <SettingsMapsPage />
+          </SettingsPageWithMenu>
+        }
+      />
+      <Route
+        path="shortcuts"
+        element={
+          <SettingsPageWithMenu>
+            <SettingsShortcutsPage />
           </SettingsPageWithMenu>
         }
       />

--- a/src/views/pages/settings/Settings.shortcuts.page.tsx
+++ b/src/views/pages/settings/Settings.shortcuts.page.tsx
@@ -1,0 +1,102 @@
+import { FieldCode } from '@components/database/dataBlocks/DataFieldsetField';
+import { InputWithLeftLabelContainer, Label } from '@components/inputs';
+import { PageEditor, PageTemplate } from '@components/pages';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+interface ShortcutGroup {
+  categoryKey: string;
+  shortcuts: { labelKey: string; mac: string; other: string }[];
+}
+
+const isMac = window.api.platform === 'darwin';
+
+const formatKey = (key: string): string => {
+  if (isMac) {
+    if (key === 'Option') return '⌥ Opt';
+    if (key === 'Cmd') return '⌘ Cmd';
+    if (key === 'Ctrl') return '⌃ Ctrl';
+    if (key === 'Shift') return '⇧ Shift';
+  }
+  return key;
+};
+
+const parseCombinations = (shortcutStr: string): string[][] => {
+  return shortcutStr.split(' / ').map((combo) => combo.split(' + ').map((key) => key.trim()));
+};
+
+const SHORTCUTS_DATA: ShortcutGroup[] = [
+  {
+    categoryKey: 'shortcut_category_default',
+    shortcuts: [
+      { labelKey: 'shortcut_save_project', mac: 'Cmd + S', other: 'Ctrl + S' },
+      { labelKey: 'shortcut_create_entry', mac: 'Cmd + N', other: 'Ctrl + N' },
+      { labelKey: 'shortcut_copy_id', mac: 'Option + Shift + C', other: 'Ctrl + Shift + C' },
+      { labelKey: 'shortcut_start_debug', mac: 'Cmd + P', other: 'Ctrl + P' },
+    ],
+  },
+  {
+    categoryKey: 'shortcut_category_navigation',
+    shortcuts: [
+      { labelKey: 'shortcut_navigate_list', mac: 'Option + \u2190 / Option + \u2192', other: 'Ctrl + \u2190 / Ctrl + \u2192' },
+      {
+        labelKey: 'shortcut_navigate_secondary_list',
+        mac: 'Option + Shift + \u2190 / Option + Shift + \u2192',
+        other: 'Ctrl + Alt + \u2190 / Ctrl + Alt + \u2192',
+      },
+    ],
+  },
+  {
+    categoryKey: 'shortcut_category_miscellaneous',
+    shortcuts: [
+      { labelKey: 'shortcut_toggle_fullscreen', mac: 'Ctrl + Cmd + F', other: 'F11' },
+      { labelKey: 'shortcut_minimize_window', mac: 'Cmd + H', other: 'Ctrl + H' },
+      { labelKey: 'shortcut_open_devtools', mac: 'Cmd + Option + I', other: 'Ctrl + Alt + I' },
+    ],
+  },
+];
+
+const ShortcutRow = styled.div`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const ShortcutStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+`;
+
+export const SettingsShortcutsPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <PageTemplate title={t('keyboard_shortcuts')} size="default">
+      {SHORTCUTS_DATA.map((group) => (
+        <PageEditor key={group.categoryKey} editorTitle={t('keyboard_shortcuts')} title={t(group.categoryKey)}>
+          {group.shortcuts.map((shortcut) => {
+            const combinations = parseCombinations(isMac ? shortcut.mac : shortcut.other);
+            return (
+              <InputWithLeftLabelContainer key={shortcut.labelKey}>
+                <Label>{t(shortcut.labelKey)}</Label>
+                <ShortcutStack>
+                  {combinations.map((keys, rowIdx) => (
+                    <ShortcutRow key={rowIdx}>
+                      {keys.map((key, keyIdx) => (
+                        <FieldCode key={keyIdx}>{formatKey(key)}</FieldCode>
+                      ))}
+                    </ShortcutRow>
+                  ))}
+                </ShortcutStack>
+              </InputWithLeftLabelContainer>
+            );
+          })}
+        </PageEditor>
+      ))}
+    </PageTemplate>
+  );
+};


### PR DESCRIPTION
Thank you for your contribution to the **Pokémon Studio** repo.

Before submitting this PR into the develop branch, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are following the [Code guidelines](../CodeGuidelines.md)
- [x] You tested your code to make sure it does what it is supposed to do

## Description

<!-- Explain what does your code here. -->
### Github issue https://github.com/PokemonWorkshop/PokemonStudio/issues/433
- Adds a shortcut page that lists all the app shortcuts (Is placed in settings, under its own category of "App Settings")
- A French translation was provided to the page as well

## Tests to perform

<!-- Explain all the scenario the tester has to test. -->
- Test if the page will switch to Mac inputs when using a Mac

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Add a Shortcut Page to App Settings
<!-- changelog:end -->