### PR TITLE
Add dependabot weekly version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly" # We can add a cron if needed - We'll fix the interval depending on our releases


### PR DESCRIPTION
## Description

Add a `dependabot.yml` file to clarify the dependabot update interval. We'll start with a weekly interval then adjust it depending on our releases.

## Note before testing

Dependabot will be useful to handle product obsolescence.

## Tests to perform

- [x] Check the `dependabot.yml` file to see if that fit our needs

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->

<!-- changelog:end -->
