### PR TITLE
Update GitHub actions versions and add permissions

### DIFF
--- a/.github/actions/package_studio/action.yml
+++ b/.github/actions/package_studio/action.yml
@@ -8,5 +8,3 @@ runs:
       shell: bash
       run: |
         npm run make
-      env:
-        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/package_studio/action.yml
+++ b/.github/actions/package_studio/action.yml
@@ -8,3 +8,5 @@ runs:
       shell: bash
       run: |
         npm run make
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/publish_studio/action.yml
+++ b/.github/actions/publish_studio/action.yml
@@ -19,7 +19,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Save to Github Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: studio_${{ env.BRANCH_NAME }}_${{ runner.os }}
         path: ./out/make

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version-file: '.nvmrc'
 
@@ -20,7 +20,7 @@ runs:
 
     - name: Prepare cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: node_modules
         key: ${{ runner.os }}-cache-${{ github.ref_name }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -12,6 +12,9 @@ on:
         default: true
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Studio
@@ -23,7 +26,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Environment
         uses: ./.github/actions/setup_environment
         with:

--- a/.github/workflows/pr_linux.yml
+++ b/.github/workflows/pr_linux.yml
@@ -14,6 +14,9 @@ on:
         default: false
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Studio
@@ -25,16 +28,11 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Environment
         uses: ./.github/actions/setup_environment
         with:
           force_build_node_module: ${{ inputs.force_build_node_module || false }}
-
-      # # No linting because the team never actually agreed with any of those rules and eslint is 1000% of the time counter productive
-      # - name: Run linting
-      #   shell: bash
-      #   run: npm run lint
 
       - name: Package Studio
         uses: ./.github/actions/package_studio

--- a/.github/workflows/pr_macos.yml.disabled
+++ b/.github/workflows/pr_macos.yml.disabled
@@ -14,6 +14,9 @@ on:
         default: false
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Studio
@@ -25,7 +28,7 @@ jobs:
         os: [macos-latest-xlarge]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Environment
         uses: ./.github/actions/setup_environment
         with:

--- a/.github/workflows/pr_windows.yml
+++ b/.github/workflows/pr_windows.yml
@@ -14,6 +14,9 @@ on:
         default: false
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Studio
@@ -25,16 +28,11 @@ jobs:
         os: [windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Environment
         uses: ./.github/actions/setup_environment
         with:
           force_build_node_module: ${{ inputs.force_build_node_module || false }}
-
-      # # No linting because the team never actually agreed with any of those rules and eslint is 1000% of the time counter productive
-      # - name: Run linting
-      #   shell: bash
-      #   run: npm run lint
 
       - name: Package Studio
         uses: ./.github/actions/package_studio

--- a/.github/workflows/production_ci.yml
+++ b/.github/workflows/production_ci.yml
@@ -14,22 +14,21 @@ jobs:
     name: Build Studio
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
+    permissions:
+      contents: write
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Environment
         uses: ./.github/actions/setup_environment
         with:
           force_build_node_module: ${{ inputs.force_build_node_module || false }}
-
-      # # No linting because the team never actually agreed with any of those rules and eslint is 1000% of the time counter productive
-      # - name: Run linting
-      #   shell: bash
-      #   run: npm run lint
 
       - name: Publish Studio
         uses: ./.github/actions/publish_studio


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions used by Pokémon Studio and tightens workflow permissions to follow current GitHub recommendations.

### Changes

* Update GitHub Actions to their latest major versions:
  * `actions/checkout` → `v7`
  * `actions/setup-node` → `v7`
  * `actions/cache` → `v6`
  * `actions/upload-artifact` → `v7`
* Explicitly restrict CI workflows to read-only repository access with:
  * `contents: read`
* Grant `contents: write` only to the production build job that needs to publish GitHub releases.

## Why

GitHub Actions have evolved significantly since the versions currently used by the project. Updating them keeps the CI compatible with current runners and supported action runtimes.

Explicit workflow permissions also reduce the privileges granted to CI jobs by default. Regular builds and pull requests only need read access, while write access is limited to the production publishing job.

This keeps the change intentionally small and focused on CI maintenance and repository security without changing the existing build or release workflow.

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->

<!-- changelog:end -->