### PR TITLE
Update home documentation links to the new PW doc

### DIFF
--- a/src/views/components/home/Footer.tsx
+++ b/src/views/components/home/Footer.tsx
@@ -1,7 +1,7 @@
+import { Link } from '@components/Link';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import { Link } from '@components/Link';
 
 const FooterContainer = styled.div`
   display: flex;
@@ -21,8 +21,8 @@ const Footer = () => {
   return (
     <FooterContainer>
       <LinkContainer>
-        <Link external href="https://psdk.pokemonworkshop.com/yard/" text={t('documentation')} />
-        <Link external href="https://psdk.pokemonworkshop.fr/wiki/en/index.html" text={t('getting_started')} />
+        <Link external href="https://docs.pokemonworkshop.com/pokemon-studio" text={t('documentation')} />
+        <Link external href="https://docs.pokemonworkshop.com/getting-started" text={t('getting_started')} />
         <Link external href="https://discord.gg/0noB0gBDd91B8pMk" text={t('discord')} />
         <Link external href="https://twitter.com/pokemonworkshop" text={t('twitter')} />
       </LinkContainer>


### PR DESCRIPTION
## Description

This PR updates the two documentation links in the Home page footer.
Fixes: #816

## Tests to perform

- "Documentation" and "Getting started" should now open the new website.
- The other links should not be affected.

## Note

I also noticed that `src/main/menu.ts` at line 175 contains "Documentation" and "Getting started". These two links will still point to the old website. This PR does not change them.

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Update Documentation Links on the Home Page
<!-- changelog:end -->