### PR TITLE
Delete obsolete rmxp data files on map deletion

### DIFF
--- a/src/backendTasks/saveProjectData.ts
+++ b/src/backendTasks/saveProjectData.ts
@@ -1,11 +1,22 @@
+import { padStr } from '@utils/PadStr';
+import { SavingData } from '@utils/SavingUtils';
 import log from 'electron-log';
 import fs from 'fs';
-import { SavingData } from '@utils/SavingUtils';
 import path from 'path';
 import { defineBackendServiceFunction } from './defineBackendServiceFunction';
 import { processSavedMaps } from './studioMapToRMXPConversionFacilitator';
 
 export type SaveProjectDataInput = { path: string; data: SavingData };
+
+const getMapFilesToDelete = (projectPath: string, savingPath: string) => {
+  const match = /^maps\/map([0-9]\d*)$/.exec(savingPath);
+  if (!match) return [];
+
+  const mapId = Number(match[1]);
+  const rxdataFile = path.join(projectPath, 'Data', `Map${padStr(mapId, 3)}.rxdata`);
+  const ymlFile = `${rxdataFile}.yml`;
+  return [rxdataFile, ymlFile];
+};
 
 const saveProjectData = async (payload: SaveProjectDataInput) => {
   log.info('save-project-data', { ...payload, data: payload.data.map(({ savingPath, savingAction }) => ({ savingPath, savingAction })) });
@@ -26,6 +37,11 @@ const saveProjectData = async (payload: SaveProjectDataInput) => {
       const filePath = path.join(projectDataPath, sd.savingPath + '.json');
       if (sd.savingAction === 'DELETE' && fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
+        if (sd.savingPath.startsWith('maps/')) {
+          getMapFilesToDelete(payload.path, sd.savingPath).forEach((mapFilePath) => {
+            if (fs.existsSync(mapFilePath)) fs.unlinkSync(mapFilePath);
+          });
+        }
       } else if (sd.data !== undefined) {
         fs.writeFileSync(filePath, sd.data);
       }


### PR DESCRIPTION
## Description

 This PR adds a step during the save process of a project to remove the `.rxdata` and `.rxdata.yml` files linked to a map that was deleted. Previously orphaned files stay untouched.

closes #817 

## Tests to perform

- [x] Delete a map and trigger a save, verify that the `.rxdata` and `.rxdata.yml` files linked to that map are deleted.
- [x] Repeat the previous test but delete multiple maps at once, all their related files are deleted.
- [x] Recreate a map and verify in RMXP that no events are present from the previously deleted map.

## Changelog entry

<!--
Write one short sentence in English US for makers and players between the changelog entries.
Describe the functional change, not its implementation.
Leave empty only when using the changelog:skip label.
-->

<!-- changelog:start -->
Delete obsolete RMXP map Data when removing a map
<!-- changelog:end -->